### PR TITLE
Add CORS origins option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ npm test
 
 ## Server Configuration
 
-`server.js` exposes a `/config` endpoint that provides the Airtable credentials. Create a `.env` file with the following variables before starting the server:
+`server.js` exposes a `/config` endpoint that provides the Airtable credentials. Create a `.env` file with the following variables before starting the server. `CORS_ORIGINS` may list allowed origins separated by commas:
 
 ```bash
 AIRTABLE_TOKEN=yourTokenHere
 AIRTABLE_BASE_ID=yourBaseIdHere
+CORS_ORIGINS=https://your-site.github.io,https://your-pwa-origin
 ```
 
 Run the server with:

--- a/server.js
+++ b/server.js
@@ -7,7 +7,14 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-app.use(cors());
+
+const allowedOrigins = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',').map(o => o.trim())
+  : [];
+const corsOptions = allowedOrigins.length
+  ? { origin: allowedOrigins, credentials: true }
+  : { origin: true, credentials: true };
+app.use(cors(corsOptions));
 app.use(express.json());
 app.use(express.static(__dirname));
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
## Summary
- allow configuration of allowed CORS origins via `CORS_ORIGINS`
- document the new environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687af6977f108323867f3de3f3a9b2f3