### PR TITLE
feat(mobile): horizontal layout for resistance inputs

### DIFF
--- a/ProgramTab.css
+++ b/ProgramTab.css
@@ -1,4 +1,21 @@
 .frequency-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: .5rem; }
-.inputs-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 1rem; }
+.inputs-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .inputs-grid {
+    display: flex;
+    overflow-x: auto;
+    gap: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  .inputs-grid input,
+  .inputs-grid select {
+    flex: 0 0 140px;
+  }
+}
 fieldset { border: 1px solid #ccc; padding: 1rem; margin-bottom: 1.5rem; border-radius: 4px; }
 legend { font-weight: bold; }

--- a/index.html
+++ b/index.html
@@ -533,6 +533,20 @@
   width:100%;
   max-width:100%;
 }
+
+@media (max-width: 600px){
+  #resistance-inputs{
+    flex-direction:row;
+    overflow-x:auto;
+    gap:8px;
+    padding-bottom:8px;
+    align-items:flex-start;
+  }
+  #resistance-inputs input,
+  #resistance-inputs select{
+    flex:0 0 140px;
+  }
+}
 #training-calendar{
   width:100%;
   max-width:500px;


### PR DESCRIPTION
## Summary
- make training log input grid responsive for mobile
- allow mobile scrolling for resistance input fields

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bb50acc1c832396450999c00bfc80