### PR TITLE
Improve mobile resistance log layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,16 +535,27 @@
 }
 
 @media (max-width: 600px){
-  #resistance-inputs{
-    flex-direction:row;
-    overflow-x:auto;
+  #resistance-section{display:block;}
+  #resistance-section .inputs-grid{
+    display:flex;
+    flex-direction:column;
     gap:8px;
-    padding-bottom:8px;
-    align-items:flex-start;
+  }
+  #resistance-inputs{
+    flex-direction:column;
+    align-items:stretch;
+    overflow:visible;
+    gap:8px;
+    padding-bottom:0;
   }
   #resistance-inputs input,
   #resistance-inputs select{
-    flex:0 0 140px;
+    flex:none;
+    width:100%;
+  }
+  #restTimerSection{
+    display:flex;
+    gap:8px;
   }
 }
 #training-calendar{
@@ -632,8 +643,9 @@
 
 <div id="progressReminder"></div>
 
-<div id="logTab" class="tab-content">
+  <div id="logTab" class="tab-content">
   <div id="logPanel" class="panel active">
+  <div id="training-calendar" class="slide-up"></div>
   <h2>Resistance Exercise Log</h2>
 
 <div id="resistance-section">
@@ -705,9 +717,6 @@
   </div>
     <!-- Logs will render below this -->
     <div id="workoutsContainer" style="margin-top: 20px;"></div>
-    </div>
-    <div id="calendarPanel" class="panel">
-      <div id="training-calendar" class="slide-up"></div>
     </div>
 
 


### PR DESCRIPTION
## Summary
- adjust calendar placement to the top of the resistance log
- add mobile styles for ladder style stacking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bb940c9648323a416cbd8ad7252cd