### PR TITLE
Add lifestyle section with schedule, study, todos, habits and goals

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,9 +924,54 @@
   </div> <!-- #settingsTab -->
   </div> <!-- #appContainer -->
 </div> <!-- #pocketFitContainer -->
-<div id="pocketLifestyleContainer" class="section" style="display:none; text-align:center;">
+<div id="pocketLifestyleContainer" class="section" style="display:none;">
   <h2>PocketLifestyle</h2>
-  <p>Coming Soon</p>
+  <nav class="lifestyle-nav">
+    <button data-ltab="dailyTab">Daily Schedule</button>
+    <button data-ltab="studyTab">Study Sessions</button>
+    <button data-ltab="todoTab">To-Do List</button>
+    <button data-ltab="habitsTab">Habits</button>
+    <button data-ltab="goalsTab">Goals</button>
+  </nav>
+  <div id="dailyTab" class="lifestyle-tab">
+    <input type="date" id="scheduleDate" />
+    <ul id="scheduleList"></ul>
+    <button class="fab" onclick="openScheduleForm()">+</button>
+  </div>
+  <div id="studyTab" class="lifestyle-tab" style="display:none;">
+    <div class="quick-add">
+      <select id="subjectFilter"></select>
+      <button class="icon-btn" onclick="addSubject()">+</button>
+    </div>
+    <div id="studyTimerDisplay"></div>
+    <button onclick="startStudySession()" id="studyTimerBtn">Start Study Session</button>
+    <ul id="studyList"></ul>
+    <button class="fab" onclick="openStudyForm()">+</button>
+  </div>
+  <div id="todoTab" class="lifestyle-tab" style="display:none;">
+    <div class="quick-add">
+      <select id="todoCategoryFilter"></select>
+      <button class="icon-btn" onclick="addTodoCategory()">+</button>
+    </div>
+    <ul id="todoList"></ul>
+    <button class="fab" onclick="openTodoForm()">+</button>
+  </div>
+  <div id="habitsTab" class="lifestyle-tab" style="display:none;">
+    <div class="quick-add">
+      <select id="habitCategoryFilter"></select>
+      <button class="icon-btn" onclick="addHabit()">+</button>
+    </div>
+    <ul id="habitsList"></ul>
+    <button class="fab" onclick="openHabitForm()">+</button>
+  </div>
+  <div id="goalsTab" class="lifestyle-tab" style="display:none;">
+    <div class="quick-add">
+      <select id="goalCategoryFilter"></select>
+      <button class="icon-btn" onclick="addGoalCategory()">+</button>
+    </div>
+    <ul id="goalsList"></ul>
+    <button class="fab" onclick="openGoalForm()">+</button>
+  </div>
   <button onclick="openDashboard()">Back to Dashboard</button>
 </div>
 <div id="pocketFinanceContainer" class="section" style="display:none; text-align:center;">
@@ -950,6 +995,7 @@
 <script type="module" src="autoProgression.js"></script>
 <script type="module" src="periodization.js"></script>
 <script type="module" src="macrosFeatures.js"></script>
+<script type="module" src="lifestyle.js"></script>
 <script>
 
 let currentUser = null;
@@ -2831,7 +2877,14 @@ function openSection(section) {
   document.getElementById('dashboardContainer').style.display = 'none';
   const el = document.getElementById(section + 'Container');
   animateSwitch(el);
-  if (section === 'pocketFit') showTab('logTab');
+  if (section === 'pocketFit') {
+    showTab('logTab');
+  } else if (section === 'pocketLifestyle') {
+    if (!window.lifestyleInitialized && window.initLifestyle) {
+      window.initLifestyle();
+      window.lifestyleInitialized = true;
+    }
+  }
 }
 
 function openDashboard() {

--- a/lifestyle.js
+++ b/lifestyle.js
@@ -1,0 +1,232 @@
+const PREFIX = 'lifestyle_';
+function load(key){
+  return JSON.parse(localStorage.getItem(PREFIX+key) || '[]');
+}
+function save(key,data){
+  localStorage.setItem(PREFIX+key,JSON.stringify(data));
+}
+// ----- Tab navigation -----
+function initLifestyle(){
+  const navButtons=document.querySelectorAll('.lifestyle-nav button');
+  navButtons.forEach(btn=>{
+    btn.addEventListener('click',()=>showLifestyleTab(btn.dataset.ltab));
+  });
+  showLifestyleTab('dailyTab');
+  document.getElementById('scheduleDate').value = new Date().toISOString().split('T')[0];
+  renderSchedule();
+  renderStudy();
+  renderTodos();
+  renderHabits();
+  renderGoals();
+}
+function showLifestyleTab(id){
+  document.querySelectorAll('.lifestyle-tab').forEach(t=>t.classList.remove('active'));
+  const tab=document.getElementById(id);
+  if(tab){ tab.classList.add('active'); }
+}
+// ----- Daily Schedule -----
+function renderSchedule(){
+  const list=document.getElementById('scheduleList');
+  if(!list) return;
+  const date=document.getElementById('scheduleDate').value;
+  const items=load('schedule').filter(i=>i.date===date);
+  list.innerHTML='';
+  items.forEach(item=>{
+    const li=document.createElement('li');
+    li.textContent=item.text;
+    if(item.done) li.style.textDecoration='line-through';
+    li.addEventListener('click',()=>toggleScheduleItem(item.id));
+    list.appendChild(li);
+  });
+}
+function openScheduleForm(){
+  const text=prompt('Schedule item');
+  if(!text) return;
+  const date=document.getElementById('scheduleDate').value;
+  const data=load('schedule');
+  data.push({id:Date.now(),date,text,done:false});
+  save('schedule',data);
+  renderSchedule();
+}
+function toggleScheduleItem(id){
+  const data=load('schedule');
+  const item=data.find(i=>i.id===id);
+  if(item){ item.done=!item.done; save('schedule',data); renderSchedule(); }
+}
+if(document.getElementById('scheduleDate')){
+  document.getElementById('scheduleDate').addEventListener('change',renderSchedule);
+}
+// ----- Study Sessions -----
+let studyTimer=null,studyStart=0;
+function renderStudy(){
+  const list=document.getElementById('studyList');
+  const filter=document.getElementById('subjectFilter');
+  if(!list||!filter) return;
+  const sessions=load('study');
+  const subjects=[...new Set(sessions.map(s=>s.subject))];
+  filter.innerHTML='<option value="">All Subjects</option>'+subjects.map(s=>`<option>${s}</option>`).join('');
+  const sel=filter.value;
+  list.innerHTML='';
+  sessions.filter(s=>!sel||s.subject===sel).forEach(s=>{
+    const li=document.createElement('li');
+    li.textContent=`${s.date} - ${s.subject} - ${s.duration}m`;
+    li.addEventListener('click',()=>deleteStudy(s.id));
+    list.appendChild(li);
+  });
+}
+function addSubject(){
+  const sub=prompt('New subject');
+  if(!sub) return;
+  const opt=document.createElement('option');
+  opt.textContent=sub; opt.value=sub;
+  document.getElementById('subjectFilter').appendChild(opt);
+  document.getElementById('subjectFilter').value=sub;
+}
+function startStudySession(){
+  const btn=document.getElementById('studyTimerBtn');
+  const display=document.getElementById('studyTimerDisplay');
+  if(studyTimer){
+    clearInterval(studyTimer); studyTimer=null;
+    const mins=Math.round((Date.now()-studyStart)/60000);
+    const subject=document.getElementById('subjectFilter').value || 'General';
+    const date=new Date().toISOString().split('T')[0];
+    const data=load('study');
+    data.push({id:Date.now(),date,subject,duration:mins});
+    save('study',data);
+    display.textContent='';
+    btn.textContent='Start Study Session';
+    renderStudy();
+  }else{
+    studyStart=Date.now();
+    display.textContent='0m';
+    studyTimer=setInterval(()=>{
+      const m=Math.floor((Date.now()-studyStart)/60000);
+      display.textContent=`${m}m`;
+    },60000);
+    btn.textContent='Stop Session';
+  }
+}
+function deleteStudy(id){
+  if(!confirm('Delete session?')) return;
+  let data=load('study');
+  data=data.filter(s=>s.id!==id); save('study',data); renderStudy();
+}
+function openStudyForm(){
+  const subject=prompt('Subject');
+  const duration=parseInt(prompt('Duration (minutes)'),10);
+  if(!subject||!duration) return;
+  const date=new Date().toISOString().split('T')[0];
+  const data=load('study');
+  data.push({id:Date.now(),date,subject,duration});
+  save('study',data); renderStudy();
+}
+if(document.getElementById('subjectFilter')){
+  document.getElementById('subjectFilter').addEventListener('change',renderStudy);
+}
+// ----- To-do List -----
+function renderTodos(){
+  const list=document.getElementById('todoList');
+  const filter=document.getElementById('todoCategoryFilter');
+  if(!list||!filter) return;
+  const todos=load('todo');
+  const cats=[...new Set(todos.map(t=>t.category))];
+  filter.innerHTML='<option value="">All Categories</option>'+cats.map(c=>`<option>${c}</option>`).join('');
+  const sel=filter.value;
+  list.innerHTML='';
+  todos.filter(t=>!sel||t.category===sel).forEach(t=>{
+    const li=document.createElement('li');
+    const cb=document.createElement('input');
+    cb.type='checkbox'; cb.checked=t.done;
+    cb.onchange=()=>{t.done=cb.checked; save('todo',todos);};
+    li.appendChild(cb);
+    li.appendChild(document.createTextNode(' '+t.text));
+    li.addEventListener('dblclick',()=>deleteTodo(t.id));
+    list.appendChild(li);
+  });
+}
+function addTodoCategory(){
+  const c=prompt('New category');
+  if(!c) return;
+  const opt=document.createElement('option'); opt.textContent=c; opt.value=c;
+  document.getElementById('todoCategoryFilter').appendChild(opt);
+  document.getElementById('todoCategoryFilter').value=c;
+}
+function openTodoForm(){
+  const text=prompt('Task');
+  if(!text) return;
+  const cat=document.getElementById('todoCategoryFilter').value||'General';
+  const todos=load('todo');
+  todos.push({id:Date.now(),text,category:cat,done:false});
+  save('todo',todos); renderTodos();
+}
+function deleteTodo(id){
+  let todos=load('todo');
+  todos=todos.filter(t=>t.id!==id); save('todo',todos); renderTodos();
+}
+if(document.getElementById('todoCategoryFilter')){
+  document.getElementById('todoCategoryFilter').addEventListener('change',renderTodos);
+}
+// ----- Habits -----
+function renderHabits(){
+  const list=document.getElementById('habitsList');
+  if(!list) return;
+  const habits=load('habits');
+  list.innerHTML='';
+  habits.forEach(h=>{
+    const li=document.createElement('li');
+    const chk=document.createElement('input');
+    chk.type='checkbox';
+    const date=new Date().toISOString().split('T')[0];
+    const log=load('habitLog');
+    const entry=log.find(e=>e.habit===h.id&&e.date===date);
+    chk.checked=!!entry;
+    chk.onchange=()=>{
+      let l=load('habitLog');
+      if(chk.checked){l.push({habit:h.id,date});}else{l=l.filter(e=>!(e.habit===h.id&&e.date===date));}
+      save('habitLog',l);
+    };
+    li.appendChild(chk);
+    li.appendChild(document.createTextNode(' '+h.text));
+    list.appendChild(li);
+  });
+}
+function openHabitForm(){
+  const text=prompt('Habit');
+  if(!text) return;
+  const habits=load('habits');
+  habits.push({id:Date.now(),text});
+  save('habits',habits); renderHabits();
+}
+function addHabit(){
+  openHabitForm();
+}
+// ----- Goals -----
+function renderGoals(){
+  const list=document.getElementById('goalsList');
+  if(!list) return;
+  const goals=load('goals');
+  list.innerHTML='';
+  goals.forEach(g=>{
+    const li=document.createElement('li');
+    const progress=document.createElement('progress');
+    progress.max=g.target; progress.value=g.progress||0;
+    progress.style.width='80%';
+    progress.onclick=()=>{const add=+prompt('Add progress',1); if(add){g.progress=Math.min(g.target,(g.progress||0)+add); save('goals',goals); renderGoals();}}
+    li.textContent=g.text+' ';
+    li.appendChild(progress);
+    list.appendChild(li);
+  });
+}
+function openGoalForm(){
+  const text=prompt('Goal description');
+  const target=parseInt(prompt('Target amount'),10);
+  if(!text||!target) return;
+  const goals=load('goals');
+  goals.push({id:Date.now(),text,target,progress:0});
+  save('goals',goals); renderGoals();
+}
+function addGoalCategory(){
+  openGoalForm();
+}
+// init on page load
+window.initLifestyle = initLifestyle;

--- a/style.css
+++ b/style.css
@@ -91,3 +91,20 @@ header, .dark-bg, .coach-only {
 .dark-mode * {
   color: #fff;
 }
+
+/* Lifestyle section */
+.lifestyle-nav {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 10px;
+  overflow-x: auto;
+}
+.lifestyle-nav button {
+  flex: 1;
+}
+.lifestyle-tab {
+  display: none;
+}
+.lifestyle-tab.active {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- implement PocketLifestyle section with 5 tabs (Daily Schedule, Study Sessions, To-Do List, Habits and Goals)
- add styles for lifestyle navigation
- create `lifestyle.js` with localStorage backed helpers
- load the lifestyle module in `index.html`
- only initialize Lifestyle logic when its dashboard section is opened

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d76fadadc83238b28960f2a2e7543