### PR TITLE
Fix offline PocketLifestyle scripts

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -4,6 +4,23 @@ const ASSETS = [
   'index.html',
   'style.css',
   'manifest.webmanifest',
+  // Cache all local scripts so the app works offline
+  'archiveOldWorkouts.js',
+  'progressiveOverload.js',
+  'community.js',
+  'config.js',
+  'progressUtils.js',
+  'progressMilestones.js',
+  'progressAnalytics.js',
+  'progressGoals.js',
+  'progressAI.js',
+  'gamification.js',
+  'offline.js',
+  'autoProgression.js',
+  'periodization.js',
+  'macrosFeatures.js',
+  'lifestyle.js',
+  'ProgramTab.js',
   'icons/icon-192.png',
   'icons/icon-512.png'
 ];


### PR DESCRIPTION
## Summary
- include all local JS files in service worker cache so sections like PocketLifestyle load while offline

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d7c3f41488323b87f80ac5db188a9