### PR TITLE
Fix log date handling and test

### DIFF
--- a/index.html
+++ b/index.html
@@ -1448,7 +1448,10 @@ function addLogEntry() {
   }
 
   const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
-  if (workouts.length === 0 || !workouts[workouts.length - 1].log) {
+  if (
+    workouts.length === 0 ||
+    workouts[workouts.length - 1].date !== date
+  ) {
     workouts.push({ title: `Workout on ${date}`, date, log: [], restBreaks: [] });
   }
 
@@ -1649,7 +1652,10 @@ function formatRestTime(sec) {
 function logRestBreak(mins) {
   const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
   const date = new Date().toISOString().split('T')[0];
-  if (workouts.length === 0 || !workouts[workouts.length - 1].log) {
+  if (
+    workouts.length === 0 ||
+    workouts[workouts.length - 1].date !== date
+  ) {
     workouts.push({ title: `Workout on ${date}`, date, log: [], restBreaks: [] });
   }
   const workout = workouts[workouts.length - 1];
@@ -1984,6 +1990,7 @@ function completeWorkout() {
   if (!workouts.some(w => w.date === date)) {
     workouts.push({ title: `Workout on ${date}`, date, log: [], restBreaks: [] });
     localStorage.setItem(`workouts_${currentUser}`, JSON.stringify(workouts));
+    trackWorkoutDate(date);
   }
   renderWorkouts();
   renderWorkoutHistory();

--- a/tests/addLogEntry.test.js
+++ b/tests/addLogEntry.test.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+describe('addLogEntry', () => {
+  function loadAddLogEntry(context) {
+    const html = fs.readFileSync('index.html', 'utf8');
+    const start = html.indexOf('function addLogEntry()');
+    const end = html.indexOf('function renderWorkouts', start);
+    const code = html.slice(start, end);
+    vm.runInContext(code, context);
+    return context.addLogEntry;
+  }
+
+  let context;
+  let dom;
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html>
+      <input id="exercise">
+      <input id="sets">
+      <input id="goal">
+      <input id="repGoal">
+      <input id="weightUnit">
+      <input id="entryDate">
+      <div id="setInputsContainer"></div>
+      <input id="reps_0">
+      <input id="weight_0">`);
+
+    context = {
+      document: dom.window.document,
+      localStorage: {
+        store: {},
+        getItem(key) { return this.store[key] || null; },
+        setItem(key, val) { this.store[key] = String(val); },
+        clear() { this.store = {}; }
+      },
+      currentUser: 'u1',
+      calculateWorkoutVolume: () => 0,
+      updatePRs: () => {},
+      updateGoalProgress: () => {},
+      renderPRs: () => {},
+      analyzeProgress: () => [],
+      renderMilestones: () => {},
+      renderGoalBar: () => {},
+      showCoachInsights: () => {},
+      saveUserExercise: () => {},
+      trackWorkoutDate: () => {},
+      renderWorkouts: () => {},
+      updateTrainingCalendar: () => {},
+      showToast: () => {},
+      updateAddButtonState: () => {},
+      alert: () => {},
+      currentSetCount: 0
+    };
+    vm.createContext(context);
+    context.addLogEntry = loadAddLogEntry(context);
+  });
+
+  test('creates new workout when date differs from last', () => {
+    const doc = context.document;
+    doc.getElementById('exercise').value = 'Bench';
+    doc.getElementById('sets').value = '1';
+    doc.getElementById('goal').value = '100';
+    doc.getElementById('repGoal').value = '5';
+    doc.getElementById('weightUnit').value = 'kg';
+    doc.getElementById('reps_0').value = '5';
+    doc.getElementById('weight_0').value = '100';
+
+    doc.getElementById('entryDate').value = '2024-01-01';
+    context.addLogEntry();
+    let workouts = JSON.parse(context.localStorage.getItem('workouts_u1'));
+    expect(workouts.length).toBe(1);
+
+    doc.getElementById('entryDate').value = '2024-01-02';
+    doc.getElementById('exercise').value = 'Bench';
+    doc.getElementById('sets').value = '1';
+    doc.getElementById('reps_0').value = '5';
+    doc.getElementById('weight_0').value = '100';
+    context.addLogEntry();
+    workouts = JSON.parse(context.localStorage.getItem('workouts_u1'));
+    expect(workouts.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure new workout created when log entry uses a new date
- do the same check for logging rest breaks
- track workout date when completing a new workout
- add unit test verifying new workout is created for different dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eb5bd8ba88323a5f57473c830ef0b