### PR TITLE
Improve community group cards

### DIFF
--- a/community.js
+++ b/community.js
@@ -232,12 +232,48 @@ function renderGroups(list) {
   if (!container) return;
   container.innerHTML = '';
   list.forEach(g => {
-    const div = document.createElement('div');
-    div.textContent = g.name;
-    div.className = 'group-item';
-    div.onclick = () => openGroup(g.id);
-    container.appendChild(div);
+    const card = document.createElement('div');
+    card.className = 'group-card card group-item';
+
+    const title = document.createElement('div');
+    title.className = 'group-title';
+    title.textContent = g.name;
+    card.appendChild(title);
+
+    const descText = g.goal && g.goal.trim() ? g.goal : 'No description';
+    const desc = document.createElement('div');
+    desc.className = 'group-desc';
+    desc.textContent = descText;
+    card.appendChild(desc);
+
+    const count = Array.isArray(g.members) ? g.members.length : 0;
+    const members = document.createElement('div');
+    members.className = 'group-members';
+    members.textContent = `${count} member${count === 1 ? '' : 's'}`;
+    card.appendChild(members);
+
+    const isMember = window.currentUser && Array.isArray(g.members) && g.members.includes(window.currentUser);
+    const btn = document.createElement('button');
+    btn.className = 'action-btn';
+    btn.textContent = isMember ? 'View Group' : 'Join';
+    btn.onclick = () => {
+      if (isMember) openGroup(g.id); else joinGroup(g.id);
+    };
+    card.appendChild(btn);
+
+    container.appendChild(card);
   });
+}
+
+function joinGroup(id) {
+  const g = groups.find(gr => gr.id === id);
+  if (!g || !window.currentUser) return;
+  if (!Array.isArray(g.members)) g.members = [];
+  if (!g.members.includes(window.currentUser)) {
+    g.members.push(window.currentUser);
+    saveGroups();
+  }
+  openGroup(id);
 }
 
 async function openGroup(id) {
@@ -320,6 +356,7 @@ if (typeof window !== 'undefined') {
   window.shareProgramToGroup = shareProgramToGroup;
   window.doGroupSearch = doGroupSearch;
   window.clearGroupFilters = clearGroupFilters;
+  window.joinGroup = joinGroup;
 }
 
 // allow tests to import functions

--- a/index.html
+++ b/index.html
@@ -695,7 +695,7 @@
       <button class="action-btn" onclick="clearGroupFilters()">Clear Filters</button>
     </div>
   </div>
-  <div id="groupList"></div>
+  <div id="groupList" class="group-list"></div>
   <div class="community-actions">
     <button class="action-btn" onclick="showCreateGroup()">Create Group</button>
     <button class="action-btn" onclick="loadGroups()">Refresh Groups</button>

--- a/style.css
+++ b/style.css
@@ -142,3 +142,33 @@ header, .dark-bg, .coach-only {
   border-radius: 8px;
   margin: 0;
 }
+
+/* group card layout */
+.group-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+}
+.group-card {
+  flex: 1 1 250px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.group-title {
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.group-desc {
+  font-size: 0.9rem;
+  margin-bottom: 6px;
+}
+.group-members {
+  font-size: 0.8rem;
+  color: var(--secondary-text);
+  margin-bottom: 8px;
+}
+.group-card button {
+  align-self: flex-end;
+  margin-top: auto;
+}


### PR DESCRIPTION
## Summary
- style community groups list with card layout
- show group description and member count
- add simple Join/View button on each card
- implement local joinGroup helper

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fba84afc48323bf984d0d37a8d14d