### PR TITLE
Add sorting and tag filters to Community tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,9 +689,22 @@
     <label for="goalFilter">Goal</label>
     <input id="goalFilter" placeholder="Goal">
     <label for="tagFilter">Tag</label>
-    <input id="tagFilter" placeholder="Tag">
+    <input id="tagFilter" list="tagOptions" placeholder="Tag">
+    <datalist id="tagOptions">
+      <option value="strength"></option>
+      <option value="hypertrophy"></option>
+      <option value="conditioning"></option>
+      <option value="crossfit"></option>
+    </datalist>
+    <label for="sortFilter">Sort By</label>
+    <select id="sortFilter" onchange="doGroupSearch()">
+      <option value="">--</option>
+      <option value="members">Most Members</option>
+      <option value="active">Recently Active</option>
+      <option value="alpha">Alphabetical (A-Z)</option>
+    </select>
     <div class="search-buttons">
-      <button class="action-btn" onclick="doGroupSearch()">Search</button>
+      <button id="groupSearchBtn" class="action-btn loading-btn" onclick="doGroupSearch()"><span>Search</span><span class="spinner"></span></button>
       <button class="action-btn" onclick="clearGroupFilters()">Clear Filters</button>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -122,6 +122,9 @@ header, .dark-bg, .coach-only {
 .community-search input {
   margin: 0;
 }
+.community-search select {
+  margin: 0;
+}
 .search-buttons {
   display: flex;
   gap: 10px;

--- a/tests/groupSearch.test.js
+++ b/tests/groupSearch.test.js
@@ -13,4 +13,17 @@ describe('filterGroups', () => {
     expect(names).toContain('A');
     expect(names).toContain('C');
   });
+
+  test('filters by search across name, goal and tags', () => {
+    const groups = [
+      { name: 'Strength Stars', goal: 'Build muscle', tags: ['hypertrophy'] },
+      { name: 'Endurance Club', goal: 'Improve cardio', tags: ['running'] },
+      { name: 'Powerlifters', goal: 'Powerlifting', tags: ['strength'] }
+    ];
+    const res = filterGroups(groups, { search: 'strength' });
+    expect(res.length).toBe(2);
+    const names = res.map(g => g.name);
+    expect(names).toContain('Strength Stars');
+    expect(names).toContain('Powerlifters');
+  });
 });

--- a/tests/sortGroups.test.js
+++ b/tests/sortGroups.test.js
@@ -1,0 +1,24 @@
+const { sortGroups } = require('../community');
+
+describe('sortGroups', () => {
+  const groups = [
+    { name: 'B', members: [1,2], posts: [{ date: '2022-01-01' }] },
+    { name: 'A', members: [1], posts: [{ date: '2022-01-02' }] },
+    { name: 'C', members: [1,2,3], posts: [] }
+  ];
+
+  test('sorts alphabetically', () => {
+    const res = sortGroups(groups, 'alpha');
+    expect(res.map(g => g.name)).toEqual(['A','B','C']);
+  });
+
+  test('sorts by most members', () => {
+    const res = sortGroups(groups, 'members');
+    expect(res[0].name).toBe('C');
+  });
+
+  test('sorts by recent activity', () => {
+    const res = sortGroups(groups, 'active');
+    expect(res[0].name).toBe('A');
+  });
+});


### PR DESCRIPTION
## Summary
- enhance client-side filtering for community groups
- allow sorting by members, activity or name
- add tag suggestions and new sorting dropdown
- show loading spinner on search
- update tests and add new sortGroups tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fbf7238c88323befe400c23cf0a5e