### PR TITLE
Add competition section to Community tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,6 +681,10 @@
 </div>
 
 <div id="communityTab" class="tab-content">
+  <nav class="community-nav">
+    <button onclick="showCommunitySection('groups')">Groups</button>
+    <button onclick="showCommunitySection('competition')">Competition</button>
+  </nav>
   <div id="groupsPanel" class="panel active">
   <h2>Community</h2>
   <div class="community-search">
@@ -714,6 +718,10 @@
     <button class="action-btn" onclick="loadGroups()">Refresh Groups</button>
   </div>
   <div id="groupDetail" style="display:none;"></div>
+  </div>
+  <div id="competitionPanel" class="panel" style="display:none;">
+    <h2>Leaderboards</h2>
+    <div id="competitionContent"></div>
   </div>
   <div id="postsPanel" class="panel"></div>
 </div>
@@ -1261,7 +1269,7 @@ function showTab(tabName) {
       loadProgramDropdown();
       break;
     case 'communityTab':
-      if (window.loadGroups) loadGroups();
+      if (window.showCommunitySection) showCommunitySection('groups');
       break;
     case 'progressTab':
       showWorkoutProgress();

--- a/style.css
+++ b/style.css
@@ -175,3 +175,28 @@ header, .dark-bg, .coach-only {
   align-self: flex-end;
   margin-top: auto;
 }
+
+/* community competition */
+.community-nav {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.community-nav button {
+  flex: 1;
+}
+.leaderboard {
+  margin-top: 10px;
+}
+.leader-entry {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+.leader-details {
+  margin-top: 10px;
+  padding: 10px;
+  background: var(--card-bg);
+  box-shadow: var(--shadow);
+}


### PR DESCRIPTION
## Summary
- create new competition panel under Community
- add leaderboard rendering with Chart.js
- switch Community panels via `showCommunitySection`
- style leaderboard and navigation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fc1e0876c83239e3a02081507179e