### PR TITLE
Add leaderboard tab with sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,6 +556,7 @@
       <li><a href="#" data-target="crossfitTab">💪 CrossFit</a></li>
       <li><a href="#" data-target="programTab">🗓️ Programs</a></li>
       <li><a href="#" data-target="communityTab">👥 Community</a></li>
+      <li><a href="#" data-target="leaderboardTab">🏅 Leaderboard</a></li>
       <li><a href="#" data-target="progressTab">📈 Progress</a></li>
       <li><a href="#" data-target="logHistoryTab">📜 Log History</a></li>
       <li class="coach-only"><a href="#" data-target="coachingTab">🏆 Coaching</a></li>
@@ -724,6 +725,21 @@
     <div id="competitionContent"></div>
   </div>
   <div id="postsPanel" class="panel"></div>
+</div>
+
+<div id="leaderboardTab" class="tab-content">
+  <h2>Leaderboard</h2>
+  <div class="leaderboard-screen">
+    <div class="leaderboard-controls">
+      <label for="leaderSortStatic">Sort By</label>
+      <select id="leaderSortStatic">
+        <option value="workoutsLogged">Workouts Logged</option>
+        <option value="studyHours">Study Hours</option>
+        <option value="groupActivity">Group Activity</option>
+      </select>
+    </div>
+    <div id="leaderboardContainer"></div>
+  </div>
 </div>
 
   <div id="cardioTab" class="tab-content">
@@ -1031,6 +1047,7 @@
 <script src="archiveOldWorkouts.js"></script>
 <script src="progressiveOverload.js"></script>
 <script src="community.js"></script>
+<script src="leaderboard.js"></script>
 <!-- Optional runtime configuration -->
 <script src="config.js"></script>
 <script type="module" src="progressUtils.js"></script>
@@ -1270,6 +1287,9 @@ function showTab(tabName) {
       break;
     case 'communityTab':
       if (window.showCommunitySection) showCommunitySection('groups');
+      break;
+    case 'leaderboardTab':
+      if (window.initLeaderboard) initLeaderboard();
       break;
     case 'progressTab':
       showWorkoutProgress();

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,30 @@
+const sampleLeaders = [
+  { name: 'User A', workoutsLogged: 25, studyHours: 40, groupActivity: 300 },
+  { name: 'User B', workoutsLogged: 30, studyHours: 35, groupActivity: 280 },
+  { name: 'User C', workoutsLogged: 20, studyHours: 50, groupActivity: 320 }
+];
+
+function renderLeaderboard(sortKey = 'workoutsLogged') {
+  const container = document.getElementById('leaderboardContainer');
+  if (!container) return;
+  const data = [...sampleLeaders].sort((a,b) => (b[sortKey]||0) - (a[sortKey]||0));
+  const rows = data.map((d,i) =>
+    `<div class="leader-entry" data-name="${d.name}"><span>#${i+1}</span><span><strong>${d.name}</strong></span><span>${d[sortKey]}</span></div>`
+  ).join('');
+  container.innerHTML = `<div class="leaderboard">${rows}</div>`;
+  container.querySelectorAll('.leader-entry').forEach(el => {
+    el.addEventListener('click', () => alert(`Clicked ${el.dataset.name}`));
+  });
+}
+
+function initLeaderboard() {
+  const select = document.getElementById('leaderSortStatic');
+  if (!select) return;
+  select.onchange = () => renderLeaderboard(select.value);
+  renderLeaderboard(select.value);
+}
+
+if (typeof window !== 'undefined') {
+  window.initLeaderboard = initLeaderboard;
+}
+

--- a/style.css
+++ b/style.css
@@ -210,3 +210,17 @@ header, .dark-bg, .coach-only {
 .exercise-compare select {
   margin-right: 6px;
 }
+
+.leaderboard-screen {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0 10px;
+}
+.leaderboard-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.leaderboard-controls select {
+  flex: 1;
+}


### PR DESCRIPTION
## Summary
- introduce a new Leaderboard screen
- support sorting by workouts, study hours or group activity
- add static leaderboard sample data and click placeholder
- style leaderboard for mobile layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68800f5995648323be43c7ed5405fc4b