### PR TITLE
Implement dynamic leaderboard charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -739,6 +739,10 @@
       </select>
     </div>
     <div id="leaderboardContainer"></div>
+    <div id="leaderboardLoading" class="spinner" style="display:none;"></div>
+    <p id="leaderboardEmpty" style="display:none;text-align:center;">No data available.</p>
+    <canvas id="lbBarChart"></canvas>
+    <canvas id="lbLineChart" style="margin-top:20px;"></canvas>
   </div>
 </div>
 

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,19 +1,64 @@
-const sampleLeaders = [
-  { name: 'User A', workoutsLogged: 25, studyHours: 40, groupActivity: 300 },
-  { name: 'User B', workoutsLogged: 30, studyHours: 35, groupActivity: 280 },
-  { name: 'User C', workoutsLogged: 20, studyHours: 50, groupActivity: 320 }
-];
+let leaderboardData = [];
+let barChart;
+let lineChart;
+
+function sum(arr) {
+  return Array.isArray(arr) ? arr.reduce((t, n) => t + n, 0) : 0;
+}
+
+async function fetchLeaderboard() {
+  const spinner = document.getElementById('leaderboardLoading');
+  const empty = document.getElementById('leaderboardEmpty');
+  if (spinner) spinner.style.display = 'block';
+  if (empty) empty.style.display = 'none';
+  try {
+    const res = await fetch(`${window.SERVER_URL}/leaderboard`);
+    leaderboardData = await res.json();
+  } catch (e) {
+    console.warn('fetch leaderboard failed', e);
+    leaderboardData = [];
+  }
+  if (spinner) spinner.style.display = 'none';
+  if (!leaderboardData.length && empty) empty.style.display = 'block';
+}
 
 function renderLeaderboard(sortKey = 'workoutsLogged') {
   const container = document.getElementById('leaderboardContainer');
   if (!container) return;
-  const data = [...sampleLeaders].sort((a,b) => (b[sortKey]||0) - (a[sortKey]||0));
-  const rows = data.map((d,i) =>
-    `<div class="leader-entry" data-name="${d.name}"><span>#${i+1}</span><span><strong>${d.name}</strong></span><span>${d[sortKey]}</span></div>`
+  if (!leaderboardData.length) {
+    container.innerHTML = '';
+    return;
+  }
+  const data = [...leaderboardData].sort((a, b) => (b[sortKey] || 0) - (a[sortKey] || 0));
+  const rows = data.map((d, i) =>
+    `<div class="leader-entry" data-name="${d.name}"><span>#${i + 1}</span><span><strong>${d.name}</strong></span><span>${d[sortKey]}</span></div>`
   ).join('');
   container.innerHTML = `<div class="leaderboard">${rows}</div>`;
-  container.querySelectorAll('.leader-entry').forEach(el => {
-    el.addEventListener('click', () => alert(`Clicked ${el.dataset.name}`));
+  renderCharts(data);
+}
+
+function renderCharts(data) {
+  if (typeof Chart === 'undefined') return;
+  const barCtx = document.getElementById('lbBarChart');
+  const lineCtx = document.getElementById('lbLineChart');
+  if (!barCtx || !lineCtx) return;
+  const labels = data.map(d => d.name);
+  const barData = data.map(d => sum(d.weeklyVolume));
+  if (barChart) barChart.destroy();
+  barChart = new Chart(barCtx, {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Weekly Volume', data: barData, backgroundColor: '#2F80ED' }] },
+    options: { responsive: true, plugins: { legend: { display: false }, tooltip: { enabled: true } } }
+  });
+
+  const maxLen = Math.max(...data.map(d => d.progress.length));
+  const lineLabels = Array.from({ length: maxLen }, (_, i) => `W${i + 1}`);
+  const lineSets = data.map(d => ({ label: d.name, data: d.progress, tension: .4, fill: false }));
+  if (lineChart) lineChart.destroy();
+  lineChart = new Chart(lineCtx, {
+    type: 'line',
+    data: { labels: lineLabels, datasets: lineSets },
+    options: { responsive: true, plugins: { tooltip: { enabled: true } } }
   });
 }
 
@@ -21,7 +66,7 @@ function initLeaderboard() {
   const select = document.getElementById('leaderSortStatic');
   if (!select) return;
   select.onchange = () => renderLeaderboard(select.value);
-  renderLeaderboard(select.value);
+  fetchLeaderboard().then(() => renderLeaderboard(select.value));
 }
 
 if (typeof window !== 'undefined') {

--- a/server.js
+++ b/server.js
@@ -34,6 +34,37 @@ const groups = [];
 const programs = [];
 const sharedPrograms = [];
 
+// sample leaderboard data
+const leaderboard = [
+  {
+    id: 1,
+    name: 'Alice',
+    workoutsLogged: 45,
+    studyHours: 30,
+    groupActivity: 120,
+    weeklyVolume: [500, 700, 650, 800],
+    progress: [10, 12, 14, 15, 16]
+  },
+  {
+    id: 2,
+    name: 'Bob',
+    workoutsLogged: 30,
+    studyHours: 40,
+    groupActivity: 100,
+    weeklyVolume: [400, 600, 550, 500],
+    progress: [8, 9, 11, 13, 14]
+  },
+  {
+    id: 3,
+    name: 'Cara',
+    workoutsLogged: 35,
+    studyHours: 55,
+    groupActivity: 90,
+    weeklyVolume: [450, 500, 470, 520],
+    progress: [15, 14, 16, 18, 20]
+  }
+];
+
 app.get('/config', (req, res) => {
   res.json({
     airtableToken: process.env.AIRTABLE_TOKEN || 'patHs7yemB2TYuOOc.6ed847f094d08b1d30710f9f5763d909d1841a2e7dc63fbdac208133a39ae577',
@@ -165,6 +196,11 @@ app.get('/community/groups/:groupId/progress', (req, res) => {
   }));
   const lb = calculateLeaderboard(members);
   res.json({ members, leaderboard: lb });
+});
+
+// basic leaderboard endpoint
+app.get('/leaderboard', (req, res) => {
+  res.json(leaderboard);
 });
 
 app.listen(PORT, () => {

--- a/style.css
+++ b/style.css
@@ -224,3 +224,17 @@ header, .dark-bg, .coach-only {
 .leaderboard-controls select {
   flex: 1;
 }
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 3px solid rgba(0,0,0,0.1);
+  border-top-color: var(--text-color);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 20px auto;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- serve `/leaderboard` endpoint with sample data
- fetch leaderboard asynchronously on tab open
- allow client-side sorting and chart rendering
- show loading spinner and empty state
- add bar and line charts with Chart.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688014e71fb48323bba8d50655e798eb