### PR TITLE
Add leaderboard stats pages

### DIFF
--- a/community.js
+++ b/community.js
@@ -466,7 +466,13 @@ function renderCompetition(metric = 'workouts') {
     </div>`;
 
   container.querySelectorAll('.leader-entry').forEach(el => {
-    el.addEventListener('click', () => showLeaderDetail(el.dataset.id));
+    el.addEventListener('click', () => {
+      if (window.showGroupStats) {
+        window.showGroupStats(el.dataset.id);
+      } else {
+        showLeaderDetail(el.dataset.id);
+      }
+    });
   });
 
   renderCompetitionChart(data.slice(0,5), metric);

--- a/index.html
+++ b/index.html
@@ -746,6 +746,14 @@
   </div>
 </div>
 
+<div id="userStatsTab" class="tab-content">
+  <div id="userStatsContent"></div>
+</div>
+
+<div id="groupStatsTab" class="tab-content">
+  <div id="groupStatsContent"></div>
+</div>
+
   <div id="cardioTab" class="tab-content">
     <div id="cardioFormPanel" class="panel active">
     <h2>Cardio Tracker</h2>
@@ -1052,6 +1060,7 @@
 <script src="progressiveOverload.js"></script>
 <script src="community.js"></script>
 <script src="leaderboard.js"></script>
+<script src="stats.js"></script>
 <!-- Optional runtime configuration -->
 <script src="config.js"></script>
 <script type="module" src="progressUtils.js"></script>
@@ -1294,6 +1303,10 @@ function showTab(tabName) {
       break;
     case 'leaderboardTab':
       if (window.initLeaderboard) initLeaderboard();
+      break;
+    case 'userStatsTab':
+      break;
+    case 'groupStatsTab':
       break;
     case 'progressTab':
       showWorkoutProgress();

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -34,6 +34,11 @@ function renderLeaderboard(sortKey = 'workoutsLogged') {
     `<div class="leader-entry" data-name="${d.name}"><span>#${i + 1}</span><span><strong>${d.name}</strong></span><span>${d[sortKey]}</span></div>`
   ).join('');
   container.innerHTML = `<div class="leaderboard">${rows}</div>`;
+  container.querySelectorAll('.leader-entry').forEach(el => {
+    el.addEventListener('click', () => {
+      if (window.showUserStats) window.showUserStats(el.dataset.name);
+    });
+  });
   renderCharts(data);
 }
 

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,136 @@
+const sampleUserStats = {
+  Alice: {
+    profile: { name: 'Alice', goal: 'Build strength' },
+    workouts: [
+      { date: '2023-09-10', exercise: 'Squat', sets: 5, reps: 5, weight: 100 },
+      { date: '2023-09-08', exercise: 'Bench Press', sets: 5, reps: 5, weight: 70 },
+      { date: '2023-09-06', exercise: 'Deadlift', sets: 5, reps: 5, weight: 120 }
+    ],
+    volumeByExercise: {
+      Squat: 2500,
+      'Bench Press': 1750,
+      Deadlift: 3000
+    },
+    weeklyVolume: [5000, 5200, 5300, 5500]
+  },
+  Bob: {
+    profile: { name: 'Bob', goal: 'Hypertrophy focus' },
+    workouts: [
+      { date: '2023-09-11', exercise: 'Squat', sets: 4, reps: 8, weight: 90 },
+      { date: '2023-09-09', exercise: 'Bench Press', sets: 4, reps: 8, weight: 65 },
+      { date: '2023-09-07', exercise: 'Deadlift', sets: 4, reps: 8, weight: 110 }
+    ],
+    volumeByExercise: {
+      Squat: 2880,
+      'Bench Press': 2080,
+      Deadlift: 3520
+    },
+    weeklyVolume: [4800, 5000, 4950, 5100]
+  }
+};
+
+const sampleGroupStats = {
+  1: {
+    name: 'Alpha Team',
+    description: 'Strength training group',
+    activities: ['Alice posted a new workout', 'Bob shared a tip'],
+    topContributors: [{ user: 'Alice', posts: 12 }, { user: 'Bob', posts: 8 }],
+    exerciseVolume: { Squat: 12000, 'Bench Press': 9000, Deadlift: 15000 },
+    weeklyVolume: [8000, 8500, 8700, 9200]
+  },
+  2: {
+    name: 'Bravo Squad',
+    description: 'General fitness enthusiasts',
+    activities: ['Cara joined the group'],
+    topContributors: [{ user: 'Cara', posts: 4 }],
+    exerciseVolume: { Squat: 9000, 'Bench Press': 7000, Deadlift: 11000 },
+    weeklyVolume: [6000, 6400, 6300, 6500]
+  }
+};
+
+let userVolumeChart;
+let groupVolumeChart;
+
+function showUserStats(name) {
+  const stats = sampleUserStats[name];
+  if (!stats) return;
+  const container = document.getElementById('userStatsContent');
+  if (!container) return;
+  const workouts = (stats.workouts || [])
+    .map(w => `<tr><td>${w.date}</td><td>${w.exercise}</td><td>${w.sets}</td><td>${w.reps}</td><td>${w.weight}</td></tr>`)
+    .join('');
+  const volumes = Object.entries(stats.volumeByExercise || {})
+    .map(([ex,v]) => `<tr><td>${ex}</td><td>${v}</td></tr>`).join('');
+  container.innerHTML = `
+    <h3>${stats.profile.name}</h3>
+    <p>${stats.profile.goal}</p>
+    <h4>Recent Workouts</h4>
+    <table><tr><th>Date</th><th>Exercise</th><th>Sets</th><th>Reps</th><th>Weight</th></tr>${workouts}</table>
+    <h4>Exercise Summary</h4>
+    <table><tr><th>Exercise</th><th>Total Volume</th></tr>${volumes}</table>
+    <canvas id="userVolumeChart"></canvas>
+    <div style="margin-top:10px;"><button onclick="showTab('leaderboardTab')">Back to Leaderboard</button></div>
+  `;
+  showTab('userStatsTab');
+  if (typeof Chart !== 'undefined') {
+    const ctx = document.getElementById('userVolumeChart');
+    if (ctx) {
+      if (userVolumeChart) userVolumeChart.destroy();
+      userVolumeChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: stats.weeklyVolume.map((_,i)=>`W${i+1}`),
+          datasets: [{ label: 'Weekly Volume', data: stats.weeklyVolume, fill:false, tension:0.4 }]
+        },
+        options: { responsive:true, plugins:{ legend:{ display:false } } }
+      });
+    }
+  }
+}
+
+function showGroupStats(id) {
+  const stats = sampleGroupStats[id];
+  if (!stats) return;
+  const container = document.getElementById('groupStatsContent');
+  if (!container) return;
+  const activities = (stats.activities || []).map(a=>`<li>${a}</li>`).join('');
+  const contributors = (stats.topContributors || [])
+    .map(c=>`<li>${c.user} (${c.posts})</li>`).join('');
+  const volumes = Object.entries(stats.exerciseVolume || {})
+    .map(([ex,v])=>`<tr><td>${ex}</td><td>${v}</td></tr>`).join('');
+  container.innerHTML = `
+    <h3>${stats.name}</h3>
+    <p>${stats.description}</p>
+    <h4>Recent Activity</h4>
+    <ul>${activities}</ul>
+    <h4>Top Contributors</h4>
+    <ul>${contributors}</ul>
+    <h4>Exercise Totals</h4>
+    <table><tr><th>Exercise</th><th>Total Volume</th></tr>${volumes}</table>
+    <canvas id="groupVolumeChart"></canvas>
+    <div style="margin-top:10px;"><button onclick="showTab('communityTab'); if(window.showCommunitySection) showCommunitySection('competition');">Back to Leaderboard</button></div>
+  `;
+  showTab('groupStatsTab');
+  if (typeof Chart !== 'undefined') {
+    const ctx = document.getElementById('groupVolumeChart');
+    if (ctx) {
+      if (groupVolumeChart) groupVolumeChart.destroy();
+      groupVolumeChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: stats.weeklyVolume.map((_,i)=>`W${i+1}`),
+          datasets: [{ label: 'Weekly Volume', data: stats.weeklyVolume, fill:false, tension:0.4 }]
+        },
+        options: { responsive:true, plugins:{ legend:{ display:false } } }
+      });
+    }
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.showUserStats = showUserStats;
+  window.showGroupStats = showGroupStats;
+}
+if (typeof module !== 'undefined') {
+  module.exports = { showUserStats, showGroupStats };
+}


### PR DESCRIPTION
## Summary
- add user and group stats tabs with placeholder data
- show stats on leaderboard clicks
- wire up new stats module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68801a4560a48323b347fde892f65c0c