### PR TITLE
Add stats views and exercise leaderboard filters

### DIFF
--- a/exerciseLeaderboard.js
+++ b/exerciseLeaderboard.js
@@ -62,13 +62,14 @@ function populateExerciseLbSelect() {
   sel.innerHTML = options;
 }
 
+let currentRange = 'weekly';
+
 function renderExerciseLeaderboard() {
   const exSel = document.getElementById('exerciseLbSelect');
-  const timeSel = document.getElementById('exerciseLbTime');
   const container = document.getElementById('exerciseLeaderboardContainer');
-  if (!exSel || !timeSel || !container) return;
+  if (!exSel || !container) return;
   const ex = exSel.value;
-  const tf = timeSel.value;
+  const tf = currentRange;
   const data = (sampleExerciseLeaderboard[ex] && sampleExerciseLeaderboard[ex][tf]) || [];
   if (!data.length) {
     container.innerHTML = '<p>No data available.</p>';
@@ -89,10 +90,19 @@ function renderExerciseLeaderboard() {
 function initExerciseLeaderboard() {
   populateExerciseLbSelect();
   const exSel = document.getElementById('exerciseLbSelect');
-  const timeSel = document.getElementById('exerciseLbTime');
-  if (!exSel || !timeSel) return;
+  const buttons = document.querySelectorAll('.timeframe-buttons button');
+  if (!exSel || !buttons.length) return;
   exSel.onchange = renderExerciseLeaderboard;
-  timeSel.onchange = renderExerciseLeaderboard;
+  buttons.forEach(btn => {
+    btn.onclick = () => {
+      currentRange = btn.dataset.range;
+      buttons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      renderExerciseLeaderboard();
+    };
+  });
+  // set default active
+  buttons[0].classList.add('active');
   renderExerciseLeaderboard();
 }
 

--- a/index.html
+++ b/index.html
@@ -750,11 +750,15 @@
 </div>
 
 <div id="userStatsTab" class="tab-content">
-  <div id="userStatsContent"></div>
+  <div class="stats-screen">
+    <div id="userStatsContent"></div>
+  </div>
 </div>
 
 <div id="groupStatsTab" class="tab-content">
-  <div id="groupStatsContent"></div>
+  <div class="stats-screen">
+    <div id="groupStatsContent"></div>
+  </div>
 </div>
 
 <div id="exerciseLeaderboardTab" class="tab-content">
@@ -763,12 +767,11 @@
     <div class="leaderboard-controls">
       <label for="exerciseLbSelect">Exercise</label>
       <select id="exerciseLbSelect"></select>
-      <label for="exerciseLbTime">Timeframe</label>
-      <select id="exerciseLbTime">
-        <option value="weekly">Weekly</option>
-        <option value="monthly">Monthly</option>
-        <option value="all">All-Time</option>
-      </select>
+    </div>
+    <div class="timeframe-buttons">
+      <button data-range="weekly">Weekly</button>
+      <button data-range="monthly">Monthly</button>
+      <button data-range="all">All-Time</button>
     </div>
     <div id="exerciseLeaderboardContainer"></div>
     <div style="margin-top:10px;">

--- a/stats.js
+++ b/stats.js
@@ -35,6 +35,10 @@ const sampleGroupStats = {
     description: 'Strength training group',
     activities: ['Alice posted a new workout', 'Bob shared a tip'],
     topContributors: [{ user: 'Alice', posts: 12 }, { user: 'Bob', posts: 8 }],
+    workouts: [
+      { date: '2023-09-12', exercise: 'Squat', sets: 5, reps: 5, weight: 105 },
+      { date: '2023-09-10', exercise: 'Bench Press', sets: 5, reps: 5, weight: 75 }
+    ],
     exerciseVolume: { Squat: 12000, 'Bench Press': 9000, Deadlift: 15000 },
     weeklyVolume: [8000, 8500, 8700, 9200]
   },
@@ -43,6 +47,9 @@ const sampleGroupStats = {
     description: 'General fitness enthusiasts',
     activities: ['Cara joined the group'],
     topContributors: [{ user: 'Cara', posts: 4 }],
+    workouts: [
+      { date: '2023-09-11', exercise: 'Deadlift', sets: 4, reps: 6, weight: 115 }
+    ],
     exerciseVolume: { Squat: 9000, 'Bench Press': 7000, Deadlift: 11000 },
     weeklyVolume: [6000, 6400, 6300, 6500]
   }
@@ -96,11 +103,16 @@ function showGroupStats(id) {
   const activities = (stats.activities || []).map(a=>`<li>${a}</li>`).join('');
   const contributors = (stats.topContributors || [])
     .map(c=>`<li>${c.user} (${c.posts})</li>`).join('');
+  const workouts = (stats.workouts || [])
+    .map(w=>`<tr><td>${w.date}</td><td>${w.exercise}</td><td>${w.sets}</td><td>${w.reps}</td><td>${w.weight}</td></tr>`)
+    .join('');
   const volumes = Object.entries(stats.exerciseVolume || {})
     .map(([ex,v])=>`<tr><td>${ex}</td><td>${v}</td></tr>`).join('');
   container.innerHTML = `
     <h3>${stats.name}</h3>
     <p>${stats.description}</p>
+    <h4>Recent Workouts</h4>
+    <table><tr><th>Date</th><th>Exercise</th><th>Sets</th><th>Reps</th><th>Weight</th></tr>${workouts}</table>
     <h4>Recent Activity</h4>
     <ul>${activities}</ul>
     <h4>Top Contributors</h4>

--- a/style.css
+++ b/style.css
@@ -225,6 +225,26 @@ header, .dark-bg, .coach-only {
   flex: 1;
 }
 
+.stats-screen {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0 10px;
+}
+
+.timeframe-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin: 10px 0;
+}
+.timeframe-buttons button {
+  flex: 1;
+}
+.timeframe-buttons button.active {
+  background-color: var(--primary-dark);
+  color: #fff;
+}
+
 .spinner {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
## Summary
- enhance user and group stats tabs with wrappers for consistent layout
- add recent workout table to group stats sample data and view
- replace exercise leaderboard timeframe selector with buttons
- style new stats screens and timeframe controls

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68801f8be58883239e4aa76bcb99c15c