### PR TITLE
Fix lifestyle tabs visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,7 @@
     <ul id="scheduleList"></ul>
     <button class="fab" onclick="openScheduleForm()">+</button>
   </div>
-  <div id="studyTab" class="lifestyle-tab" style="display:none;">
+  <div id="studyTab" class="lifestyle-tab">
     <div class="quick-add">
       <select id="subjectFilter"></select>
       <button class="icon-btn" onclick="addSubject()">+</button>
@@ -1057,7 +1057,7 @@
     <ul id="studyList"></ul>
     <button class="fab" onclick="openStudyForm()">+</button>
   </div>
-  <div id="todoTab" class="lifestyle-tab" style="display:none;">
+  <div id="todoTab" class="lifestyle-tab">
     <div class="quick-add">
       <select id="todoCategoryFilter"></select>
       <button class="icon-btn" onclick="addTodoCategory()">+</button>
@@ -1065,7 +1065,7 @@
     <ul id="todoList"></ul>
     <button class="fab" onclick="openTodoForm()">+</button>
   </div>
-  <div id="habitsTab" class="lifestyle-tab" style="display:none;">
+  <div id="habitsTab" class="lifestyle-tab">
     <div class="quick-add">
       <select id="habitCategoryFilter"></select>
       <button class="icon-btn" onclick="addHabit()">+</button>
@@ -1073,7 +1073,7 @@
     <ul id="habitsList"></ul>
     <button class="fab" onclick="openHabitForm()">+</button>
   </div>
-  <div id="goalsTab" class="lifestyle-tab" style="display:none;">
+  <div id="goalsTab" class="lifestyle-tab">
     <div class="quick-add">
       <select id="goalCategoryFilter"></select>
       <button class="icon-btn" onclick="addGoalCategory()">+</button>


### PR DESCRIPTION
## Summary
- remove inline display:none styles from lifestyle tab content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811ce9486083239ad1f8fd06837185