### PR TITLE
Configure backend URL via env files

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL=http://localhost:3000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL=https://traininglog-backend.onrender.com

--- a/README.md
+++ b/README.md
@@ -75,16 +75,19 @@ cp config.example.js config.js
 The file exports two constants:
 
 ```javascript
-window.SERVER_URL = 'http://localhost:3000';
+window.SERVER_URL = 'https://traininglog-backend.onrender.com';
 window.airtableConfig = {
   airtableToken: 'yourToken',
   airtableBaseId: 'yourBase'
 };
 ```
 
-Optionally, set `SERVER_URL` to point at the Express backend that exposes the
-`/config` route. When no backend is reachable, the page falls back to the
-values provided in `config.js`.
-During development you can override `window.SERVER_URL` to use a local backend
-like `http://localhost:3000`.
+You can override the backend URL by setting the `REACT_APP_BACKEND_URL`
+environment variable. When no backend is reachable, the page falls back to the
+values provided in `config.js`. During development you may want to point it at a
+local server by creating an `.env.development` file containing
+
+```ini
+REACT_APP_BACKEND_URL=http://localhost:3000
+```
 

--- a/config.js
+++ b/config.js
@@ -3,7 +3,13 @@
 // Optionally set SERVER_URL if your backend exposes a /config endpoint.
 
 
-window.SERVER_URL = window.SERVER_URL || 'http://localhost:3000';
+const backendBaseUrl =
+  (typeof process !== 'undefined' &&
+    process.env &&
+    process.env.REACT_APP_BACKEND_URL) ||
+  'https://traininglog-backend.onrender.com';
+
+window.SERVER_URL = window.SERVER_URL || backendBaseUrl;
 window.airtableConfig = {
   airtableToken: 'patHs7yemB2TYuOOc.6ed847f094d08b1d30710f9f5763d909d1841a2e7dc63fbdac208133a39ae577',
   airtableBaseId: 'appmjr4IgnEH72K1b'


### PR DESCRIPTION
## Summary
- use environment variable for SERVER_URL fallback
- document backend URL config in README
- add `.env.production` and `.env.development` examples

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688261075aa88323ab2ce59b298cdad5