### PR TITLE
Modernize global input styles for cleaner dark-theme look

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,18 +77,22 @@
       line-height: 1.4;
     }
     input, select, textarea {
-      padding: 10px;
+      padding: 10px 14px;
       margin: 12px 0;
       width: 100%;
       box-sizing: border-box;
-      border-radius: 6px;
+      border-radius: 10px;
+      background: var(--surface-bg);
       border: 1px solid var(--border-color);
+      color: var(--text-color);
       font-size: 16px;
-      box-shadow: inset 0 1px 3px rgba(0,0,0,0.1);
+      font-family: inherit;
+      box-shadow: inset 0 1px 4px rgba(0,0,0,0.18);
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
     }
     input::placeholder,
     textarea::placeholder {
-      color: var(--secondary-text);
+      color: var(--text-muted);
     }
     .suggested-input::placeholder {
       font-style: italic;
@@ -96,7 +100,7 @@
     input:focus, select:focus, textarea:focus {
       outline: none;
       border-color: var(--primary);
-      box-shadow: 0 0 0 2px rgba(0,123,255,0.3);
+      box-shadow: 0 0 0 3px rgba(45, 125, 91, 0.22), inset 0 1px 4px rgba(0,0,0,0.12);
     }
 
     button {

--- a/style.css
+++ b/style.css
@@ -900,7 +900,7 @@ body.theme-dark .set-row {
 .modal-content input,
 .modal-content select {
   width: 100%;
-  padding: 8px;
+  margin: 6px 0;
 }
 
 .modal-actions {
@@ -1069,9 +1069,7 @@ body.theme-dark .set-row {
 }
 .adv-row input {
   width: 100%;
-  padding: 6px 8px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
+  margin: 0;
 }
 .adv-btn {
   padding: 6px 10px;
@@ -1128,9 +1126,7 @@ body.theme-dark .set-row {
 }
 .tag-input input {
   width: 100%;
-  padding: 6px 8px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
+  margin: 0;
 }
 .set-state {
   display: flex;


### PR DESCRIPTION
- Bump border-radius from 6px to 10px for a softer feel
- Add explicit background (--surface-bg) so inputs appear recessed rather than flashing browser-default white
- Add color and font-family: inherit to respect dark theme and Poppins font
- Fix focus ring from hardcoded blue (rgba(0,123,255,0.3)) to green primary (rgba(45,125,91,0.22)) with 3px spread
- Shift placeholder color to --text-muted for better contrast hierarchy
- Add smooth transition on border-color and box-shadow
- Remove hardcoded #ccc borders in .adv-row input and .tag-input input that were bypassing the dark theme
- Tidy .modal-content input margin override