### PR TITLE
Simplify nav, add onboarding wizard, and workout focus mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,19 +169,18 @@
       align-items: stretch;
       z-index: 1000;
       box-shadow: 0 -4px 24px rgba(0,0,0,0.45);
-      overflow-x: auto;
-      overflow-y: hidden;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: none;
-      scroll-snap-type: x proximity;
+      overflow: hidden;
+      transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     }
-    #bottomNav::-webkit-scrollbar {
-      display: none;
+
+    /* Hide nav during active workout */
+    .workout-active #bottomNav {
+      transform: translateY(100%);
+      pointer-events: none;
     }
 
     .bn-item {
-      flex: 0 0 auto;
-      min-width: 72px;
+      flex: 1;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -193,12 +192,11 @@
       font-size: 11px;
       font-family: 'Poppins', sans-serif;
       cursor: pointer;
-      padding: 0 10px;
+      padding: 0 6px;
       margin: 0;
       box-shadow: none;
       transition: color 0.2s ease;
       -webkit-tap-highlight-color: transparent;
-      scroll-snap-align: start;
     }
     .bn-item:hover {
       background: none;
@@ -221,12 +219,236 @@
       letter-spacing: 0.02em;
       white-space: nowrap;
     }
-    .bn-item.bn-logout {
-      color: #c05060;
+    .bn-item.bn-more.active {
+      color: var(--secondary-text);
     }
-    .bn-item.bn-logout:hover {
-      color: #e06070;
+
+    /* ── More drawer ────────────────────────────────── */
+    .more-drawer {
+      position: fixed;
+      inset: 0;
+      z-index: 1200;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
     }
+    .more-drawer[hidden] { display: none; }
+    .more-drawer-scrim {
+      flex: 1;
+      background: rgba(0,0,0,0.5);
+      backdrop-filter: blur(2px);
+      cursor: pointer;
+    }
+    .more-drawer-panel {
+      background: var(--card-bg, #0f1510);
+      border-top: 1px solid var(--border-color);
+      border-radius: 20px 20px 0 0;
+      padding: 8px 16px 80px;
+      transform: translateY(100%);
+      transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
+    }
+    .more-drawer.open .more-drawer-panel {
+      transform: translateY(0);
+    }
+    .more-drawer-handle {
+      width: 36px;
+      height: 4px;
+      background: var(--border-color);
+      border-radius: 2px;
+      margin: 0 auto 16px;
+    }
+    .more-drawer-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 8px;
+    }
+    .more-drawer-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 12px 8px;
+      border: none;
+      background: var(--surface-bg, #141e17);
+      border-radius: 12px;
+      color: var(--text-color);
+      font-size: 12px;
+      cursor: pointer;
+      transition: background 0.15s, transform 0.1s;
+      font-family: 'Poppins', sans-serif;
+    }
+    .more-drawer-item:active {
+      transform: scale(0.95);
+      background: var(--border-color);
+    }
+    .more-drawer-icon { font-size: 22px; }
+    .more-drawer-logout { color: #c05060; }
+
+    /* ── Workout focus bar (shown when nav is hidden) ─ */
+    #workoutFocusBar {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 64px;
+      background: rgba(10, 15, 12, 0.97);
+      border-top: 1px solid var(--primary, #5fa87e);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 20px;
+      z-index: 1001;
+      transform: translateY(100%);
+      transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    .workout-active #workoutFocusBar {
+      transform: translateY(0);
+    }
+    .wfb-timer {
+      font-family: 'Courier New', monospace;
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: var(--primary, #5fa87e);
+    }
+    .wfb-label {
+      font-size: 0.8rem;
+      color: var(--secondary-text);
+    }
+    .wfb-end-btn {
+      padding: 8px 18px;
+      border-radius: 10px;
+      background: #c05060;
+      color: #fff;
+      border: none;
+      font-weight: 700;
+      font-size: 0.85rem;
+      cursor: pointer;
+      font-family: 'Poppins', sans-serif;
+    }
+
+    /* ── Onboarding overlay ─────────────────────────── */
+    .onboarding-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 2000;
+      background: var(--bg, #0a0f0c);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      overflow-y: auto;
+    }
+    .onboarding-overlay[hidden] { display: none; }
+    .onboarding-card {
+      width: 100%;
+      max-width: 420px;
+    }
+    .onboarding-progress {
+      display: flex;
+      gap: 6px;
+      margin-bottom: 32px;
+    }
+    .ob-step {
+      height: 4px;
+      flex: 1;
+      border-radius: 2px;
+      background: var(--border-color);
+      transition: background 0.3s;
+    }
+    .ob-step.ob-active, .ob-step.ob-done {
+      background: var(--primary, #5fa87e);
+    }
+    .ob-screen { display: none; }
+    .ob-screen.active { display: block; }
+    .ob-screen h2 { font-size: 1.5rem; margin-bottom: 6px; text-align: left; color: var(--text-color); }
+    .ob-subtitle { color: var(--secondary-text); margin-bottom: 24px; font-size: 0.95rem; }
+    .ob-archetype-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+    .ob-archetype-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      padding: 20px 12px;
+      border: 2px solid var(--border-color);
+      border-radius: 14px;
+      background: var(--surface-bg, #141e17);
+      color: var(--text-color);
+      cursor: pointer;
+      transition: border-color 0.2s, background 0.2s;
+      font-family: 'Poppins', sans-serif;
+    }
+    .ob-archetype-card.selected {
+      border-color: var(--primary, #5fa87e);
+      background: rgba(95,168,126,0.12);
+    }
+    .ob-archetype-card strong { font-size: 0.95rem; }
+    .ob-archetype-card small { font-size: 0.78rem; color: var(--secondary-text); }
+    .ob-arch-icon { font-size: 2rem; }
+    .ob-option-list { display: flex; flex-direction: column; gap: 10px; margin-bottom: 24px; }
+    .ob-option {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 16px;
+      border: 2px solid var(--border-color);
+      border-radius: 12px;
+      cursor: pointer;
+      background: var(--surface-bg, #141e17);
+      transition: border-color 0.2s;
+    }
+    .ob-option:has(input:checked) { border-color: var(--primary, #5fa87e); }
+    .ob-option input[type="radio"] { display: none; }
+    .ob-option-label { font-weight: 600; flex: 1; color: var(--text-color); }
+    .ob-option-hint { color: var(--secondary-text); font-size: 0.8rem; }
+    .ob-next-btn {
+      width: 100%;
+      padding: 14px;
+      border-radius: 12px;
+      background: var(--primary, #5fa87e);
+      color: #fff;
+      font-weight: 700;
+      font-size: 1rem;
+      border: none;
+      cursor: pointer;
+      transition: opacity 0.2s;
+      margin-bottom: 10px;
+      font-family: 'Poppins', sans-serif;
+    }
+    .ob-next-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+    .ob-back-btn {
+      width: 100%;
+      padding: 10px;
+      border: none;
+      background: none;
+      color: var(--secondary-text);
+      cursor: pointer;
+      font-size: 0.9rem;
+      font-family: 'Poppins', sans-serif;
+    }
+    .ob-prefs { display: flex; flex-direction: column; gap: 18px; margin-bottom: 24px; }
+    .ob-pref-row { display: flex; justify-content: space-between; align-items: center; color: var(--text-color); font-weight: 600; }
+    .ob-toggle-group {
+      display: flex;
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .ob-toggle-btn {
+      padding: 8px 18px;
+      border: none;
+      background: transparent;
+      color: var(--secondary-text);
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: background 0.15s, color 0.15s;
+      font-family: 'Poppins', sans-serif;
+    }
+    .ob-toggle-btn.ob-active { background: var(--primary, #5fa87e); color: #fff; }
 
 
     /* Tab content */
@@ -1283,6 +1505,96 @@
   <button id="loginButton" class="loading-btn" onclick="startLogin()"><span>Login</span><span class="spinner"></span></button>
   <button id="signupButton" class="loading-btn" onclick="startSignup()"><span>Sign Up</span><span class="spinner"></span></button>
 </div>
+<!-- ── Onboarding Wizard (shown after first signup) ─────────────────── -->
+<div id="onboardingOverlay" class="onboarding-overlay" hidden>
+  <div class="onboarding-card">
+    <!-- Progress dots -->
+    <div class="onboarding-progress">
+      <span class="ob-step ob-active" data-step="1"></span>
+      <span class="ob-step" data-step="2"></span>
+      <span class="ob-step" data-step="3"></span>
+    </div>
+
+    <!-- Step 1: Training style -->
+    <div class="ob-screen active" id="obStep1">
+      <h2>What's your training focus?</h2>
+      <p class="ob-subtitle">We'll personalise the app for you</p>
+      <div class="ob-archetype-grid">
+        <button class="ob-archetype-card" data-archetype="bodybuilder">
+          <span class="ob-arch-icon">💪</span>
+          <strong>Bodybuilder</strong>
+          <small>Physique &amp; hypertrophy</small>
+        </button>
+        <button class="ob-archetype-card" data-archetype="powerlifter">
+          <span class="ob-arch-icon">🏋️</span>
+          <strong>Powerlifter</strong>
+          <small>Squat, bench &amp; deadlift</small>
+        </button>
+        <button class="ob-archetype-card" data-archetype="hybrid">
+          <span class="ob-arch-icon">⚡</span>
+          <strong>Hybrid</strong>
+          <small>Strength &amp; conditioning</small>
+        </button>
+        <button class="ob-archetype-card" data-archetype="recreational">
+          <span class="ob-arch-icon">🌱</span>
+          <strong>Recreational</strong>
+          <small>General fitness</small>
+        </button>
+      </div>
+      <button class="ob-next-btn" id="obNext1" disabled>Continue</button>
+    </div>
+
+    <!-- Step 2: Experience level -->
+    <div class="ob-screen" id="obStep2">
+      <h2>Your experience level</h2>
+      <p class="ob-subtitle">Helps us set smart starting defaults</p>
+      <div class="ob-option-list" role="radiogroup">
+        <label class="ob-option">
+          <input type="radio" name="obExperience" value="beginner">
+          <span class="ob-option-label">Beginner</span>
+          <span class="ob-option-hint">Under 1 year</span>
+        </label>
+        <label class="ob-option">
+          <input type="radio" name="obExperience" value="intermediate">
+          <span class="ob-option-label">Intermediate</span>
+          <span class="ob-option-hint">1–3 years</span>
+        </label>
+        <label class="ob-option">
+          <input type="radio" name="obExperience" value="advanced">
+          <span class="ob-option-label">Advanced</span>
+          <span class="ob-option-hint">3+ years</span>
+        </label>
+      </div>
+      <button class="ob-next-btn" id="obNext2" disabled>Continue</button>
+      <button class="ob-back-btn" id="obBack2">Back</button>
+    </div>
+
+    <!-- Step 3: Quick preferences -->
+    <div class="ob-screen" id="obStep3">
+      <h2>A few quick preferences</h2>
+      <p class="ob-subtitle">You can change these any time in Settings</p>
+      <div class="ob-prefs">
+        <div class="ob-pref-row">
+          <span>Weight unit</span>
+          <div class="ob-toggle-group" id="obUnitToggle">
+            <button class="ob-toggle-btn ob-active" data-unit="kg">kg</button>
+            <button class="ob-toggle-btn" data-unit="lbs">lbs</button>
+          </div>
+        </div>
+        <div class="ob-pref-row">
+          <span>Theme</span>
+          <div class="ob-toggle-group" id="obThemeToggle">
+            <button class="ob-toggle-btn ob-active" data-theme="dark">Dark</button>
+            <button class="ob-toggle-btn" data-theme="light">Light</button>
+          </div>
+        </div>
+      </div>
+      <button class="ob-next-btn" id="obFinish">Let's go!</button>
+      <button class="ob-back-btn" id="obBack3">Back</button>
+    </div>
+  </div>
+</div>
+
 <div id="dashboardContainer" class="section" style="display:none; text-align:center;">
   <h2>Welcome to Pocket Coach</h2>
   <button onclick="openSection('pocketFit')">PocketFit</button>
@@ -1292,7 +1604,7 @@
 
 <div id="pocketFitContainer" class="section" style="display:none;">
   
-  <!-- Unified Navigation Bar (single scrollable bar with all tabs) -->
+  <!-- Simplified Navigation Bar: 5 core tabs + archetype specialty + More -->
   <nav id="bottomNav" aria-label="Main navigation">
     <button class="bn-item active" data-tab="homeTab" aria-label="Home">
       <span class="bn-icon">🏠</span>
@@ -1306,22 +1618,11 @@
       <span class="bn-icon">📈</span>
       <span class="bn-label">Progress</span>
     </button>
-    <button class="bn-item" data-tab="macroTab" aria-label="Macros">
-      <span class="bn-icon">🍽️</span>
-      <span class="bn-label">Macros</span>
+    <button class="bn-item" data-tab="programTab" aria-label="Programs">
+      <span class="bn-icon">🗓️</span>
+      <span class="bn-label">Programs</span>
     </button>
-    <button class="bn-item" data-tab="checkInTab" aria-label="Check-In">
-      <span class="bn-icon">🧾</span>
-      <span class="bn-label">Check-In</span>
-    </button>
-    <button class="bn-item" data-tab="weightTab" aria-label="Weight">
-      <span class="bn-icon">⚖️</span>
-      <span class="bn-label">Weight</span>
-    </button>
-    <button class="bn-item" data-tab="cardioTab" aria-label="Cardio">
-      <span class="bn-icon">🏃</span>
-      <span class="bn-label">Cardio</span>
-    </button>
+    <!-- Archetype-specific specialty tab (only one is visible at a time via mode classes) -->
     <button class="bn-item bb-only" data-tab="posingTab" aria-label="Posing">
       <span class="bn-icon">🎭</span>
       <span class="bn-label">Posing</span>
@@ -1330,39 +1631,75 @@
       <span class="bn-icon">🏋️</span>
       <span class="bn-label">Lifting</span>
     </button>
-    <button class="bn-item" data-tab="programTab" aria-label="Programs">
-      <span class="bn-icon">🗓️</span>
-      <span class="bn-label">Programs</span>
-    </button>
     <button class="bn-item athlete-only" data-tab="crossfitTab" aria-label="CrossFit">
       <span class="bn-icon">💪</span>
       <span class="bn-label">CrossFit</span>
     </button>
-    <button class="bn-item" data-tab="communityTab" aria-label="Community">
-      <span class="bn-icon">👥</span>
-      <span class="bn-label">Community</span>
-    </button>
-    <button class="bn-item" data-tab="leaderboardTab" aria-label="Leaderboard">
-      <span class="bn-icon">🏅</span>
-      <span class="bn-label">Leaderboard</span>
-    </button>
-    <button class="bn-item" data-tab="logHistoryTab" aria-label="History">
-      <span class="bn-icon">📜</span>
-      <span class="bn-label">History</span>
-    </button>
-    <button class="bn-item coach-only" data-tab="coachingTab" aria-label="Coach">
-      <span class="bn-icon">🧭</span>
-      <span class="bn-label">Coach</span>
-    </button>
-    <button class="bn-item" data-tab="settingsTab" aria-label="Settings">
-      <span class="bn-icon">⚙️</span>
-      <span class="bn-label">Settings</span>
-    </button>
-    <button class="bn-item bn-logout" onclick="logout()" aria-label="Logout">
-      <span class="bn-icon">🚪</span>
-      <span class="bn-label">Logout</span>
+    <!-- More button opens the secondary-tabs drawer -->
+    <button class="bn-item bn-more" id="moreNavBtn" aria-label="More" aria-expanded="false" aria-controls="moreDrawer">
+      <span class="bn-icon">⋯</span>
+      <span class="bn-label">More</span>
     </button>
   </nav>
+
+  <!-- More drawer: secondary tabs accessible via the More button -->
+  <div id="moreDrawer" class="more-drawer" role="dialog" aria-modal="true" aria-label="More options" hidden>
+    <div class="more-drawer-scrim" id="moreDrawerScrim"></div>
+    <div class="more-drawer-panel">
+      <div class="more-drawer-handle"></div>
+      <div class="more-drawer-grid">
+        <button class="more-drawer-item" data-tab="macroTab">
+          <span class="more-drawer-icon">🍽️</span>
+          <span>Macros</span>
+        </button>
+        <button class="more-drawer-item" data-tab="checkInTab">
+          <span class="more-drawer-icon">🧾</span>
+          <span>Check-In</span>
+        </button>
+        <button class="more-drawer-item" data-tab="weightTab">
+          <span class="more-drawer-icon">⚖️</span>
+          <span>Weight</span>
+        </button>
+        <button class="more-drawer-item" data-tab="cardioTab">
+          <span class="more-drawer-icon">🏃</span>
+          <span>Cardio</span>
+        </button>
+        <button class="more-drawer-item" data-tab="communityTab">
+          <span class="more-drawer-icon">👥</span>
+          <span>Community</span>
+        </button>
+        <button class="more-drawer-item" data-tab="leaderboardTab">
+          <span class="more-drawer-icon">🏅</span>
+          <span>Leaderboard</span>
+        </button>
+        <button class="more-drawer-item" data-tab="logHistoryTab">
+          <span class="more-drawer-icon">📜</span>
+          <span>History</span>
+        </button>
+        <button class="more-drawer-item coach-only" data-tab="coachingTab">
+          <span class="more-drawer-icon">🧭</span>
+          <span>Coach</span>
+        </button>
+        <button class="more-drawer-item" data-tab="settingsTab">
+          <span class="more-drawer-icon">⚙️</span>
+          <span>Settings</span>
+        </button>
+        <button class="more-drawer-item more-drawer-logout" id="moreDrawerLogoutBtn">
+          <span class="more-drawer-icon">🚪</span>
+          <span>Logout</span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Workout focus bar: replaces the nav during an active workout -->
+  <div id="workoutFocusBar" aria-live="polite">
+    <div>
+      <div class="wfb-label">Workout in progress</div>
+      <div class="wfb-timer" id="wfbElapsed">00:00:00</div>
+    </div>
+    <button class="wfb-end-btn" id="wfbEndBtn">End Workout</button>
+  </div>
 
   <div id="appContainer" class="main-content">
 <div id="progressReminder"></div>
@@ -2959,7 +3296,22 @@ async function startSignup() {
     const result = await response.json();
 
     if (result.success) {
-      alert("Account created successfully! You can now log in.");
+      // Auto-login after signup so onboarding can persist settings to the right user
+      const loginResponse = await fetch(`${window.SERVER_URL}/login`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const loginResult = await loginResponse.json();
+      if (loginResult.success || loginResult.token) {
+        if (loginResult.token) localStorage.setItem('token', loginResult.token);
+        setCurrentUser(username);
+        document.getElementById('loginContainer').style.display = 'none';
+        showOnboarding();
+      } else {
+        alert("Account created! Please log in to continue.");
+      }
     } else {
       alert(result.message || "Signup failed.");
     }
@@ -3174,6 +3526,7 @@ function addLogEntry() {
   if (typeof startWorkoutTimer === 'function') {
     try {
       startWorkoutTimer();
+      if (typeof enterWorkoutFocusMode === 'function') enterWorkoutFocusMode();
     } catch (err) {
       console.warn('Unable to start workout timer', err);
     }
@@ -11013,6 +11366,7 @@ function showHistoryMiniTab(type) {
             console.warn('Unable to stop workout timer via button', err);
           }
         }
+        if (typeof exitWorkoutFocusMode === 'function') exitWorkoutFocusMode();
         finishAndClearCurrentLog();
       });
     }
@@ -11570,6 +11924,231 @@ function applyTrainingModeClasses(mode) {
 
 window.setTrainingMode = setTrainingMode;
 window.getTrainingMode = getTrainingMode;
+
+// ─────────────────────────────────────────────
+// MORE DRAWER
+// ─────────────────────────────────────────────
+
+function openMoreDrawer() {
+  const drawer = document.getElementById('moreDrawer');
+  const btn = document.getElementById('moreNavBtn');
+  if (!drawer) return;
+  drawer.removeAttribute('hidden');
+  requestAnimationFrame(() => drawer.classList.add('open'));
+  if (btn) btn.setAttribute('aria-expanded', 'true');
+  document.addEventListener('keydown', _onDrawerKeydown);
+}
+
+function closeMoreDrawer() {
+  const drawer = document.getElementById('moreDrawer');
+  const btn = document.getElementById('moreNavBtn');
+  if (!drawer) return;
+  drawer.classList.remove('open');
+  const panel = drawer.querySelector('.more-drawer-panel');
+  if (panel) {
+    panel.addEventListener('transitionend', () => {
+      drawer.setAttribute('hidden', '');
+      if (btn) btn.setAttribute('aria-expanded', 'false');
+    }, { once: true });
+  } else {
+    drawer.setAttribute('hidden', '');
+    if (btn) btn.setAttribute('aria-expanded', 'false');
+  }
+  document.removeEventListener('keydown', _onDrawerKeydown);
+}
+
+function _onDrawerKeydown(e) {
+  if (e.key === 'Escape') closeMoreDrawer();
+}
+
+window.openMoreDrawer = openMoreDrawer;
+window.closeMoreDrawer = closeMoreDrawer;
+
+// Wire up More drawer after DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+  const moreBtn = document.getElementById('moreNavBtn');
+  if (moreBtn) moreBtn.addEventListener('click', openMoreDrawer);
+
+  const scrim = document.getElementById('moreDrawerScrim');
+  if (scrim) scrim.addEventListener('click', closeMoreDrawer);
+
+  const logoutBtn = document.getElementById('moreDrawerLogoutBtn');
+  if (logoutBtn) logoutBtn.addEventListener('click', () => { closeMoreDrawer(); logout(); });
+
+  document.querySelectorAll('#moreDrawer .more-drawer-item[data-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tabName = btn.dataset.tab;
+      closeMoreDrawer();
+      // Wait for drawer close animation before switching tab
+      setTimeout(() => showTab(tabName), 200);
+    });
+  });
+
+  // Apply coach-only visibility inside the drawer too
+  applyAppModeToNavigation();
+});
+
+// ─────────────────────────────────────────────
+// WORKOUT FOCUS MODE
+// ─────────────────────────────────────────────
+
+function enterWorkoutFocusMode() {
+  document.body.classList.add('workout-active');
+  // Mirror the elapsed time to the focus bar
+  const wfbElapsed = document.getElementById('wfbElapsed');
+  if (wfbElapsed) {
+    const mainElapsed = document.getElementById('workoutElapsed');
+    if (mainElapsed) wfbElapsed.textContent = mainElapsed.textContent;
+    // Keep the focus bar timer in sync
+    window._wfbInterval = setInterval(() => {
+      const src = document.getElementById('workoutElapsed');
+      if (src) wfbElapsed.textContent = src.textContent;
+    }, 1000);
+  }
+}
+
+function exitWorkoutFocusMode() {
+  document.body.classList.remove('workout-active');
+  if (window._wfbInterval) {
+    clearInterval(window._wfbInterval);
+    window._wfbInterval = null;
+  }
+}
+
+window.enterWorkoutFocusMode = enterWorkoutFocusMode;
+window.exitWorkoutFocusMode = exitWorkoutFocusMode;
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Focus bar "End Workout" mirrors the main End Workout button behaviour
+  const wfbEndBtn = document.getElementById('wfbEndBtn');
+  if (wfbEndBtn) {
+    wfbEndBtn.addEventListener('click', () => {
+      const mainEndBtn = document.getElementById('endWorkoutBtn');
+      if (mainEndBtn) mainEndBtn.click();
+      exitWorkoutFocusMode();
+    });
+  }
+
+  // If a workout timer is already running on page load, enter focus mode
+  const timerKey = 'tl_workout_timer_v1';
+  try {
+    const stored = localStorage.getItem(timerKey);
+    if (stored && JSON.parse(stored)?.startTimeMs) {
+      enterWorkoutFocusMode();
+    }
+  } catch (_) {}
+});
+
+// ─────────────────────────────────────────────
+// ONBOARDING WIZARD
+// ─────────────────────────────────────────────
+
+const _ob = { archetype: null, experience: null, unit: 'kg', theme: 'dark' };
+
+function showOnboarding() {
+  const overlay = document.getElementById('onboardingOverlay');
+  if (overlay) {
+    overlay.removeAttribute('hidden');
+    _obGoToStep(1);
+  }
+}
+
+function _obGoToStep(step) {
+  document.querySelectorAll('.ob-screen').forEach((el, i) => {
+    el.classList.toggle('active', i + 1 === step);
+  });
+  document.querySelectorAll('.ob-step').forEach((dot, i) => {
+    dot.classList.toggle('ob-active', i + 1 === step);
+    dot.classList.toggle('ob-done', i + 1 < step);
+  });
+}
+
+function _initOnboarding() {
+  // Step 1: archetype card selection
+  document.querySelectorAll('.ob-archetype-card').forEach(card => {
+    card.addEventListener('click', () => {
+      document.querySelectorAll('.ob-archetype-card').forEach(c => c.classList.remove('selected'));
+      card.classList.add('selected');
+      _ob.archetype = card.dataset.archetype;
+      const btn = document.getElementById('obNext1');
+      if (btn) btn.disabled = false;
+    });
+  });
+
+  document.getElementById('obNext1')?.addEventListener('click', () => _obGoToStep(2));
+  document.getElementById('obBack2')?.addEventListener('click', () => _obGoToStep(1));
+
+  // Step 2: experience radio
+  document.querySelectorAll('[name="obExperience"]').forEach(radio => {
+    radio.addEventListener('change', () => {
+      _ob.experience = radio.value;
+      const btn = document.getElementById('obNext2');
+      if (btn) btn.disabled = false;
+    });
+  });
+
+  document.getElementById('obNext2')?.addEventListener('click', () => _obGoToStep(3));
+  document.getElementById('obBack3')?.addEventListener('click', () => _obGoToStep(2));
+
+  // Step 3: unit toggle
+  document.querySelectorAll('#obUnitToggle .ob-toggle-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#obUnitToggle .ob-toggle-btn').forEach(b => b.classList.remove('ob-active'));
+      btn.classList.add('ob-active');
+      _ob.unit = btn.dataset.unit;
+    });
+  });
+
+  // Step 3: theme toggle
+  document.querySelectorAll('#obThemeToggle .ob-toggle-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#obThemeToggle .ob-toggle-btn').forEach(b => b.classList.remove('ob-active'));
+      btn.classList.add('ob-active');
+      _ob.theme = btn.dataset.theme;
+    });
+  });
+
+  document.getElementById('obFinish')?.addEventListener('click', _finishOnboarding);
+}
+
+function _finishOnboarding() {
+  const user = window.currentUser || localStorage.getItem('fitnessAppUser');
+
+  if (user && _ob.archetype) {
+    // Map archetype → training mode
+    const archetypeToMode = {
+      bodybuilder: 'bodybuilding',
+      powerlifter: 'powerlifting',
+      hybrid: 'bodybuilding',
+      recreational: 'bodybuilding',
+      athlete: 'athlete'
+    };
+    setTrainingMode(archetypeToMode[_ob.archetype] || 'bodybuilding');
+
+    // Persist to settings
+    const key = `settings_${user}`;
+    const settings = (() => { try { return JSON.parse(localStorage.getItem(key) || '{}'); } catch { return {}; } })();
+    settings.unit = _ob.unit;
+    settings.theme = _ob.theme;
+    settings.profile = settings.profile || {};
+    settings.profile.athleteArchetype = _ob.archetype;
+    settings.profile.experienceLevel = _ob.experience;
+    localStorage.setItem(key, JSON.stringify(settings));
+
+    // Apply unit preference
+    localStorage.setItem('weightUnit', _ob.unit);
+
+    // Apply theme if handler exists
+    if (typeof window.applyTheme === 'function') window.applyTheme(_ob.theme);
+  }
+
+  document.getElementById('onboardingOverlay').setAttribute('hidden', '');
+  openSection('pocketFit');
+}
+
+document.addEventListener('DOMContentLoaded', _initOnboarding);
+
+window.showOnboarding = showOnboarding;
 
 // ─────────────────────────────────────────────
 // POWERLIFTING TAB


### PR DESCRIPTION
- Replace 16-tab scrollable nav with 5 core tabs (Home, Log, Progress, Programs + archetype specialty) and a More drawer for secondary items (Macros, Check-In, Weight, Cardio, Community, Leaderboard, History, Settings, Logout) — eliminates cognitive overload of the old bar
- Add 3-step onboarding overlay shown after signup: training style (archetype cards), experience level, and unit/theme preferences; auto-logs the user in and persists choices to settings on completion
- Add workout focus mode: entering a log set adds body.workout-active, slides the nav out of view, and raises a minimal focus bar showing the live elapsed timer and an End Workout button; exits cleanly when the workout is stopped