### PR TITLE
feat: full app upgrade — program builder, all priority features, bug fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -9118,6 +9118,47 @@ function getWorkoutTopSetEntries(workouts, matcher) {
   return entries.sort((a, b) => String(a.date).localeCompare(String(b.date)));
 }
 
+/**
+ * getCurrentProfile / getUserProfile
+ * Returns a profile object with athleteInfo (divisionClass, height, currentWeight)
+ * sourced from the prepMode phase state + localStorage settings.
+ * Both names are aliased because different parts of the codebase use either.
+ */
+function getCurrentProfile(userId) {
+  const uid = userId ||
+    (typeof currentUser !== 'undefined' ? currentUser : null) ||
+    localStorage.getItem('currentUser') ||
+    localStorage.getItem('fitnessAppUser') ||
+    localStorage.getItem('username') || '';
+
+  // Try prepMode phase state first (has athleteInfo.divisionClass etc.)
+  const phaseState = window.prepModeApi?.getCurrentPhaseState?.(uid) || {};
+  const athleteInfo = phaseState.athleteInfo || {};
+
+  // Fallback: read individual settings keys saved by the settings tab
+  const divisionClass = athleteInfo.divisionClass ||
+    localStorage.getItem(`userDivision_${uid}`) ||
+    localStorage.getItem('userDivision') || '';
+
+  const height = athleteInfo.height ||
+    localStorage.getItem(`userHeight_${uid}`) ||
+    localStorage.getItem('userHeight') || '';
+
+  const currentWeight = athleteInfo.currentWeight ||
+    parseFloat(localStorage.getItem(`currentBodyweight_${uid}`)) ||
+    parseFloat(localStorage.getItem('currentBodyweight')) || null;
+
+  return {
+    athleteInfo: { divisionClass, height, currentWeight, ...athleteInfo },
+    division:    divisionClass,
+    archetype:   localStorage.getItem('athleteArchetype') || '',
+    uid,
+  };
+}
+// Alias — some call getUserProfile, others call getCurrentProfile
+window.getCurrentProfile = getCurrentProfile;
+window.getUserProfile    = getCurrentProfile;
+
 function renderProgressArchetypeSpotlight(context = {}) {
   const panel = document.getElementById('progressArchetypeSpotlight');
   if (!panel) return;
@@ -11556,7 +11597,30 @@ window.renderMeetPrep = renderMeetPrep;
     });
   </script>
   <script>
-    // ── Service Worker registration ──────────────────────────
+    // ── showProgramView safety fallback ─────────────────────
+  // ProgramTabV2.js sets window.showProgramView inside its IIFE.
+  // If that file fails to load or throws before reaching line 941,
+  // the nav buttons would throw ReferenceError. This guard ensures
+  // the function always exists with basic view-switching logic.
+  if (typeof window.showProgramView !== 'function') {
+    window.showProgramView = function (view) {
+      var bc   = document.getElementById('programBuilderContainer');
+      var lv   = document.getElementById('progListView');
+      var btns = document.querySelectorAll('#progTopNav .prog-top-btn');
+      if (view === 'list') {
+        if (bc) bc.style.display = 'none';
+        if (lv) lv.style.display = '';
+        btns.forEach(function(b, i) { b.classList.toggle('active', i === 1); });
+      } else {
+        if (bc) bc.style.display = '';
+        if (lv) lv.style.display = 'none';
+        btns.forEach(function(b, i) { b.classList.toggle('active', i === 0); });
+        if (typeof window.initProgramBuilder === 'function') window.initProgramBuilder();
+      }
+    };
+  }
+
+  // ── Service Worker registration ──────────────────────────
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function () {
         navigator.serviceWorker.register('/sw.js').then(function (reg) {

--- a/prepMode.js
+++ b/prepMode.js
@@ -259,11 +259,17 @@
   }
 
   function syncPhaseStateToBackend(userId, state) {
-    const payload = sanitizeState(state);
-    const resolvedUser = resolveUserId(userId);
+    // localStorage is the source of truth. The network sync is only attempted
+    // when a real Express backend is running (localhost / custom domain).
+    // On GitHub Pages (static host) there is no API, so we skip silently.
     try {
-      // Future backend endpoint: PUT /api/bodybuilding/phase-state/:userId
-      // Keep local storage as the source of truth even when this sync fails.
+      const host = (typeof location !== 'undefined' && location.hostname) || '';
+      const isStaticHost = host.includes('github.io') || host.includes('netlify.app') ||
+                           host.includes('vercel.app') || host === '' || host === 'localhost' && !_hasApiBackend();
+      if (isStaticHost) return false;
+
+      const payload = sanitizeState(state);
+      const resolvedUser = resolveUserId(userId);
       if (typeof globalScope.fetch !== 'function') return false;
       return globalScope.fetch(`/api/bodybuilding/phase-state/${encodeURIComponent(resolvedUser)}`, {
         method: 'PUT',
@@ -273,6 +279,15 @@
     } catch (_error) {
       return false;
     }
+  }
+
+  // Lightweight check: has a /api route responded recently?
+  let _apiBackendConfirmed = false;
+  function _hasApiBackend() { return _apiBackendConfirmed; }
+  if (typeof globalScope.fetch === 'function') {
+    globalScope.fetch('/api/ping', { method: 'HEAD' })
+      .then(r => { if (r.ok) _apiBackendConfirmed = true; })
+      .catch(() => {});
   }
 
   function getDaysUntilShow(showDate) {


### PR DESCRIPTION
## Summary

13 commits covering every priority tier plus 3 bug fixes.

### 🏗️ Foundation
- Modularised inline CSS into css/ directory
- Simplified nav, onboarding wizard, workout focus mode
- Coaching mode enhancements (6 features)
- Archetype features + More drawer fixes
- 4-week workout log archiver to Airtable

### 🎨 UI Declutter
- Log tab split into 5 sub-tabs: Log / Rest / History / Templates / Streaks
- Macro sparklines & heatmap wrapped in collapsible accordions
- Hydration/digestion moved to Personal Details

### 🔨 Program Builder Redesign
- 5-step guided wizard: Goal → Split → Exercises → Schedule → Save
- Searchable exercise library (60+ exercises, 7 categories)
- My Programs list with load/delete

### 🔴 High-Priority Features
- PR Tracker — auto-detects weight, e1RM & volume PRs with bounce celebration modal
- Progressive Overload Hints — debounced chip showing last session + +2.5 kg suggestion
- Workout History Search — full-text search with set chips and e1RM display
- Water Tracker — daily ring gauge, quick-add buttons, persistent target

### 🟡 Medium-Priority Features
- Body Measurements — 7-site logging, history table, Chart.js trend line
- Daily Readiness Check-in — morning modal, real-time score, home dashboard card
- Data Export — workouts/weight/measurements/readiness CSV + full JSON backup
- Rest Timer Notifications — Web Notification when timer hits 00:00

### 🟢 Low-Priority Features
- Food Database — USDA FoodData Central search, per-serving macro calculator, food diary
- Weekly Summary Card — home dashboard with calendar dots, volume, PRs, streak, readiness
- Monthly Challenges & Badges — 7 challenges with progress bars + 12 permanent milestone badges
- Service Worker / PWA — offline-first cache + manifest.json for install-to-home-screen
- Client Check-in System — Coach Dashboard tab for per-athlete session notes & ratings
- Progress Report (PDF) — print-ready window with 30-day stats, PRs, weight, measurements

### 🐛 Bug Fixes
- prepMode.js — skip PUT /api/bodybuilding/phase-state on static hosts (GitHub Pages 405 error)
- getCurrentProfile / getUserProfile — defined missing functions, fixing crash in progress spotlight
- showProgramView — added safety fallback so nav buttons never throw ReferenceError

## Test plan
- [ ] All 5 Log sub-tabs switch correctly
- [ ] Log a workout → PR celebration fires if a record is broken
- [ ] Overload hint appears when typing a known exercise
- [ ] History search returns cards with set chips
- [ ] Water tracker ring/% updates; resets; custom target persists
- [ ] Body measurements log, chart, and history table render
- [ ] Readiness modal appears on fresh day; home card reflects score
- [ ] All 5 export buttons download correct files
- [ ] Food search returns results; serving calculator updates; Add credits macros
- [ ] Weekly summary card shows correct week data and calendar dots
- [ ] Challenges progress bars update; badge unlocks with celebration
- [ ] Coach Dashboard → Check-ins tab logs and displays entries
- [ ] Progress Report opens print window with populated 30-day stats
- [ ] DevTools → Application → Service Workers: SW registered and active
- [ ] No console errors on program tab load or nav button click
- [ ] Settings save no longer logs 405 errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)