### PR TITLE
feat: full-session improvements — leaderboard, community, features, coaching fixes

### DIFF
--- a/community.js
+++ b/community.js
@@ -489,16 +489,31 @@ let competitionChart;
 function showCommunitySection(section) {
   currentCommunitySection = section;
   const panels = {
-    groups: document.getElementById('groupsPanel'),
+    groups:      document.getElementById('groupsPanel'),
     competition: document.getElementById('competitionPanel'),
-    posts: document.getElementById('postsPanel')
+    posts:       document.getElementById('postsPanel'),
+    feed:        document.getElementById('feedPanel'),
   };
   Object.values(panels).forEach(p => { if (p) p.style.display = 'none'; });
   if (panels[section]) panels[section].style.display = 'block';
+
+  // Update nav active class
+  const navMap = {
+    groups:      'commNavGroups',
+    feed:        'commNavFeed',
+    competition: 'commNavCompetition',
+  };
+  document.querySelectorAll('.comm-nav-btn').forEach(b => b.classList.remove('active'));
+  const activeBtn = document.getElementById(navMap[section]);
+  if (activeBtn) activeBtn.classList.add('active');
+
   if (section === 'groups') {
     loadGroups();
+    if (window.renderWeeklyChallenge) renderWeeklyChallenge();
   } else if (section === 'competition') {
     renderCompetition();
+  } else if (section === 'feed') {
+    if (window.renderActivityFeed) renderActivityFeed();
   }
 }
 

--- a/css/coaching.css
+++ b/css/coaching.css
@@ -825,3 +825,14 @@
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
+
+/* Lazy-load placeholder for sub-panels not yet rendered */
+.coach-subtab-placeholder {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--secondary-text, #7a8f7d);
+  font-size: 0.85rem;
+  border: 1px dashed var(--border-color, #2a3a2e);
+  border-radius: 12px;
+  margin: 8px 0;
+}

--- a/css/features.css
+++ b/css/features.css
@@ -2421,3 +2421,405 @@
 @media (max-width: 360px) {
   .lb-ps-grid { grid-template-columns: repeat(2, 1fr); }
 }
+
+/* =============================================================
+   COMMUNITY IMPROVEMENTS  ⑥⑦⑨⑩⑪
+   Activity feed · Filter pills · Exercise LB · Challenge · Posts
+   ============================================================= */
+
+/* ── Community nav ─────────────────────────────────────────── */
+
+.community-nav {
+  display: flex;
+  gap: 6px;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--border, #2a3a2e);
+  margin-bottom: 14px;
+}
+
+.comm-nav-btn {
+  flex: 1;
+  padding: 8px 6px;
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  color: var(--text-muted, #7a8f7d);
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.18s, color 0.18s, border-color 0.18s;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.comm-nav-btn.active,
+.comm-nav-btn:hover {
+  background: var(--primary, #5fa87e);
+  border-color: var(--primary, #5fa87e);
+  color: #fff;
+}
+
+/* ── ⑦ Filter pills ─────────────────────────────────────────── */
+
+.comm-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.comm-search-input {
+  flex: 1;
+  background: var(--bg, #0b130d);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 8px;
+  padding: 8px 12px;
+  color: var(--text, #e8f5e9);
+  font-size: 0.85rem;
+  font-family: 'Poppins', sans-serif;
+  outline: none;
+  transition: border-color 0.18s;
+}
+.comm-search-input:focus { border-color: var(--primary, #5fa87e); }
+
+.comm-clear-btn {
+  background: transparent;
+  border: 1px solid var(--border, #2a3a2e);
+  color: var(--text-muted, #7a8f7d);
+  border-radius: 6px;
+  padding: 7px 10px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: color 0.18s, border-color 0.18s;
+}
+.comm-clear-btn:hover { color: var(--text, #e8f5e9); border-color: var(--text-muted, #7a8f7d); }
+
+.comm-tag-pills {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.comm-pill {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  color: var(--text-muted, #7a8f7d);
+  border-radius: 20px;
+  padding: 4px 12px;
+  font-size: 0.77rem;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: background 0.18s, color 0.18s, border-color 0.18s;
+}
+.comm-pill.active,
+.comm-pill:hover {
+  background: var(--primary, #5fa87e);
+  border-color: var(--primary, #5fa87e);
+  color: #fff;
+}
+
+.comm-sort-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.comm-sort-label {
+  font-size: 0.7rem;
+  color: var(--text-muted, #7a8f7d);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+#commSortPills {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.comm-sort-pill {
+  background: transparent;
+  border: 1px solid var(--border, #2a3a2e);
+  color: var(--text-muted, #7a8f7d);
+  border-radius: 6px;
+  padding: 3px 10px;
+  font-size: 0.75rem;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.comm-sort-pill.active,
+.comm-sort-pill:hover {
+  background: rgba(95,168,126,0.15);
+  border-color: var(--primary, #5fa87e);
+  color: var(--primary, #5fa87e);
+}
+
+/* ── ⑩ Weekly challenge card ─────────────────────────────────── */
+
+.comm-challenge-card {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 12px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+  transition: border-color 0.2s;
+}
+.comm-challenge-card.done {
+  border-color: var(--primary, #5fa87e);
+  background: rgba(95,168,126,0.06);
+}
+
+.comm-challenge-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.comm-challenge-icon { font-size: 1.3rem; flex-shrink: 0; }
+
+.comm-challenge-info { flex: 1; }
+
+.comm-challenge-title {
+  font-size: 0.65rem;
+  color: var(--text-muted, #7a8f7d);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.comm-challenge-label {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text, #e8f5e9);
+}
+
+.comm-challenge-count {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--primary, #5fa87e);
+  white-space: nowrap;
+}
+
+.comm-challenge-bar-wrap {
+  height: 5px;
+  background: var(--border, #2a3a2e);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.comm-challenge-bar {
+  height: 100%;
+  background: var(--primary, #5fa87e);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+.comm-challenge-card.done .comm-challenge-bar { background: #81c784; }
+
+.comm-challenge-badge {
+  margin-top: 6px;
+  font-size: 0.78rem;
+  color: var(--primary, #5fa87e);
+  font-weight: 600;
+}
+
+/* ── ⑥⑪ Activity feed + post composer ───────────────────────── */
+
+.feed-composer {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 12px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+}
+
+.feed-composer-top {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.feed-avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--primary, #5fa87e);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.feed-textarea {
+  flex: 1;
+  background: var(--bg, #0b130d);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: var(--text, #e8f5e9);
+  font-size: 0.85rem;
+  font-family: 'Poppins', sans-serif;
+  resize: none;
+  outline: none;
+  transition: border-color 0.18s;
+}
+.feed-textarea:focus { border-color: var(--primary, #5fa87e); }
+
+.feed-composer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.feed-tag-group { display: flex; gap: 5px; flex-wrap: wrap; }
+
+.feed-tag-btn {
+  background: transparent;
+  border: 1px solid var(--border, #2a3a2e);
+  color: var(--text-muted, #7a8f7d);
+  border-radius: 20px;
+  padding: 3px 10px;
+  font-size: 0.75rem;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.feed-tag-btn.active,
+.feed-tag-btn:hover {
+  background: rgba(95,168,126,0.15);
+  border-color: var(--primary, #5fa87e);
+  color: var(--primary, #5fa87e);
+}
+
+.feed-post-btn {
+  background: var(--primary, #5fa87e);
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  font-family: 'Poppins', sans-serif;
+  padding: 7px 18px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.feed-post-btn:hover { opacity: 0.85; }
+
+/* Feed card */
+
+.activity-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.feed-card {
+  display: flex;
+  gap: 10px;
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 12px;
+  padding: 10px 12px;
+  transition: border-color 0.18s;
+}
+.feed-card:hover { border-color: var(--primary, #5fa87e); }
+
+.feed-card-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--border, #2a3a2e);
+  color: var(--text, #e8f5e9);
+  font-weight: 700;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.feed-card-body { flex: 1; min-width: 0; }
+
+.feed-card-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 3px;
+  flex-wrap: wrap;
+}
+
+.feed-card-name { color: var(--text, #e8f5e9); font-size: 0.85rem; }
+.feed-card-type { font-size: 0.9rem; }
+.feed-card-time { margin-left: auto; font-size: 0.7rem; color: var(--text-muted, #7a8f7d); }
+
+.feed-card-text {
+  font-size: 0.82rem;
+  color: var(--text-muted, #7a8f7d);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.feed-empty {
+  text-align: center;
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.85rem;
+  padding: 24px 16px;
+}
+
+/* ── ⑨ Inline exercise leaderboard ──────────────────────────── */
+
+.lb-exercise-section { margin-top: 2px; }
+
+.lb-exercise-inner { padding: 10px 14px 14px; }
+
+.lb-exercise-ctrl {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.lb-exercise-select {
+  flex: 1;
+  background: var(--bg, #0b130d);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 8px;
+  padding: 7px 10px;
+  color: var(--text, #e8f5e9);
+  font-size: 0.83rem;
+  font-family: 'Poppins', sans-serif;
+  outline: none;
+}
+
+.lb-time-pills {
+  display: flex;
+  gap: 5px;
+}
+
+.lb-time-pill {
+  background: transparent;
+  border: 1px solid var(--border, #2a3a2e);
+  color: var(--text-muted, #7a8f7d);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.lb-time-pill.active,
+.lb-time-pill:hover {
+  background: rgba(95,168,126,0.15);
+  border-color: var(--primary, #5fa87e);
+  color: var(--primary, #5fa87e);
+}

--- a/css/features.css
+++ b/css/features.css
@@ -2021,3 +2021,403 @@
 }
 .wt-estimate-table tbody tr:last-child td { border-bottom: none; }
 .wt-estimate-table tbody td:last-child { font-weight: 700; color: var(--primary, #5fa87e); }
+
+/* =============================================================
+   LEADERBOARD IMPROVEMENTS
+   ① Personal stats card  ② Medal rank cards  ③ Your-rank banner
+   ============================================================= */
+
+/* Page wrapper */
+.lb-page {
+  padding: 12px 0 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── ① Personal stats card ─────────────────────────────────── */
+
+.lb-personal-stats {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--primary, #5fa87e);
+  border-radius: 14px;
+  padding: 14px 16px;
+  box-shadow: 0 0 12px rgba(95,168,126,0.12);
+}
+
+.lb-ps-note {
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 8px 0;
+}
+
+.lb-ps-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.lb-ps-avatar {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: var(--primary, #5fa87e);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.lb-ps-name {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.lb-ps-name strong {
+  color: var(--text, #e8f5e9);
+  font-size: 0.95rem;
+}
+
+.lb-ps-sub {
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.72rem;
+}
+
+.lb-ps-streak {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffb74d;
+  white-space: nowrap;
+}
+
+.lb-ps-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.lb-ps-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--bg, #0b130d);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 8px;
+  padding: 8px 4px;
+  text-align: center;
+}
+
+.lb-ps-val {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--primary, #5fa87e);
+}
+
+.lb-ps-lbl {
+  font-size: 0.65rem;
+  color: var(--text-muted, #7a8f7d);
+  margin-top: 2px;
+}
+
+.lb-ps-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.lb-ps-badge.green  { background: rgba(95,168,126,0.2); color: #5fa87e; }
+.lb-ps-badge.amber  { background: rgba(255,183,77,0.15); color: #ffb74d; }
+.lb-ps-badge.red    { background: rgba(239,83,80,0.15);  color: #ef5350; }
+
+.lb-ps-pr, .lb-ps-weight {
+  font-size: 0.78rem;
+  color: var(--text-muted, #7a8f7d);
+  margin-top: 4px;
+}
+.lb-ps-pr strong, .lb-ps-weight strong { color: var(--text, #e8f5e9); }
+
+/* ── Controls ────────────────────────────────────────────────── */
+
+.lb-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.lb-controls-label {
+  font-size: 0.75rem;
+  color: var(--text-muted, #7a8f7d);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.lb-sort-pills {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.lb-sort-pill {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  color: var(--text-muted, #7a8f7d);
+  border-radius: 20px;
+  padding: 5px 14px;
+  font-size: 0.8rem;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: background 0.18s, color 0.18s, border-color 0.18s;
+}
+
+.lb-sort-pill.active,
+.lb-sort-pill:hover {
+  background: var(--primary, #5fa87e);
+  border-color: var(--primary, #5fa87e);
+  color: #fff;
+}
+
+/* ── ② Medal rank cards ─────────────────────────────────────── */
+
+.lb-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lb-card {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 12px;
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  transition: border-color 0.18s, transform 0.15s;
+}
+
+.lb-card:hover { border-color: var(--primary, #5fa87e); transform: translateX(3px); }
+
+.lb-card--gold   { border-color: #FFD700; background: rgba(255,215,0,0.05); }
+.lb-card--silver { border-color: #C0C0C0; background: rgba(192,192,192,0.05); }
+.lb-card--bronze { border-color: #CD7F32; background: rgba(205,127,50,0.05); }
+.lb-card--me     { border-color: var(--primary, #5fa87e) !important; box-shadow: 0 0 10px rgba(95,168,126,0.25); }
+
+.lb-card-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.lb-card-medal {
+  font-size: 1.3rem;
+  width: 28px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.lb-rank-num {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-muted, #7a8f7d);
+}
+
+.lb-card-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--border, #2a3a2e);
+  color: var(--text, #e8f5e9);
+  font-weight: 700;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.lb-card--gold   .lb-card-avatar { background: rgba(255,215,0,0.2);  color: #FFD700; }
+.lb-card--silver .lb-card-avatar { background: rgba(192,192,192,0.2); color: #C0C0C0; }
+.lb-card--bronze .lb-card-avatar { background: rgba(205,127,50,0.2);  color: #CD7F32; }
+
+.lb-card-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.lb-card-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text, #e8f5e9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.lb-you-tag {
+  display: inline-block;
+  margin-left: 5px;
+  padding: 0 5px;
+  background: var(--primary, #5fa87e);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  vertical-align: middle;
+}
+
+.lb-card-bar-wrap {
+  height: 4px;
+  background: var(--border, #2a3a2e);
+  border-radius: 2px;
+  margin-top: 5px;
+  overflow: hidden;
+}
+
+.lb-card-bar {
+  height: 100%;
+  background: var(--primary, #5fa87e);
+  border-radius: 2px;
+  transition: width 0.4s ease;
+}
+
+.lb-card--gold   .lb-card-bar { background: #FFD700; }
+.lb-card--silver .lb-card-bar { background: #C0C0C0; }
+.lb-card--bronze .lb-card-bar { background: #CD7F32; }
+
+.lb-card-value {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--primary, #5fa87e);
+  min-width: 36px;
+  text-align: right;
+}
+
+/* ── ③ Your-rank banner ─────────────────────────────────────── */
+
+.lb-rank-banner {
+  background: linear-gradient(135deg, rgba(95,168,126,0.15), rgba(95,168,126,0.05));
+  border: 1px solid var(--primary, #5fa87e);
+  border-radius: 12px;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.lb-rank-banner-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.lb-rank-banner-medal { font-size: 1.5rem; }
+
+.lb-rank-banner-title {
+  font-size: 0.9rem;
+  color: var(--text, #e8f5e9);
+}
+.lb-rank-banner-title strong { color: var(--primary, #5fa87e); }
+
+.lb-rank-banner-sub {
+  font-size: 0.75rem;
+  color: var(--text-muted, #7a8f7d);
+  margin-top: 2px;
+}
+
+.lb-gap     { color: #ffb74d; }
+.lb-gap-top { color: var(--primary, #5fa87e); }
+
+/* ── Loading / empty states ─────────────────────────────────── */
+
+.lb-loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 20px;
+  justify-content: center;
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.85rem;
+}
+
+.lb-spinner {
+  width: 22px;
+  height: 22px;
+  border: 3px solid var(--border, #2a3a2e);
+  border-top-color: var(--primary, #5fa87e);
+  border-radius: 50%;
+  animation: lb-spin 0.7s linear infinite;
+}
+
+@keyframes lb-spin { to { transform: rotate(360deg); } }
+
+.lb-empty {
+  text-align: center;
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.85rem;
+  padding: 20px;
+}
+
+/* ── Charts section ─────────────────────────────────────────── */
+
+.lb-charts-section {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.lb-charts-summary {
+  padding: 12px 16px;
+  cursor: pointer;
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.85rem;
+  font-weight: 600;
+  user-select: none;
+  list-style: none;
+}
+
+.lb-charts-section[open] .lb-charts-summary {
+  border-bottom: 1px solid var(--border, #2a3a2e);
+  color: var(--text, #e8f5e9);
+}
+
+.lb-charts-section canvas { padding: 12px 16px; }
+
+/* ── Exercise leaderboard button ─────────────────────────────── */
+
+.lb-exercise-btn {
+  width: 100%;
+  padding: 12px;
+  background: var(--card-bg, #0f1510);
+  border: 1px dashed var(--border, #2a3a2e);
+  border-radius: 10px;
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.85rem;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+  text-align: center;
+}
+.lb-exercise-btn:hover {
+  border-color: var(--primary, #5fa87e);
+  color: var(--primary, #5fa87e);
+}
+
+/* Responsive: stack personal stats grid on tiny screens */
+@media (max-width: 360px) {
+  .lb-ps-grid { grid-template-columns: repeat(2, 1fr); }
+}

--- a/index.html
+++ b/index.html
@@ -1544,7 +1544,7 @@
         <button class="coach-bulk-btn" id="coachBulkMacros">🍽️ Update Macros</button>
         <button class="coach-bulk-btn" id="coachBulkCSV">📄 Export CSV</button>
         <button class="coach-bulk-btn" id="coachBulkPDF">🖨️ Export PDF</button>
-        <button class="coach-bulk-btn danger" onclick="_bulkSelected.clear();_updateBulkToolbar();document.querySelectorAll('.coach-client-select').forEach(cb=>cb.checked=false)">✕ Clear</button>
+        <button class="coach-bulk-btn danger" onclick="clearBulkSelection()">✕ Clear</button>
       </div>
     </div>
     <!-- Client roster rendered by existing renderCoachDashboard() -->
@@ -1553,26 +1553,26 @@
 
   <!-- ── Program Builder ── -->
   <div id="coachSub_programs" class="coach-subview">
-    <!-- Rendered by renderCoachProgramBuilder() -->
-    <p style="color:var(--secondary-text);font-size:0.85rem;">Loading program builder…</p>
+    <!-- Rendered by renderCoachProgramBuilder() on first click -->
+    <p class="coach-subtab-placeholder">📋 Click to load the program builder</p>
   </div>
 
   <!-- ── Messaging ── -->
   <div id="coachSub_messaging" class="coach-subview">
-    <!-- Rendered by renderCoachMessaging() -->
-    <p style="color:var(--secondary-text);font-size:0.85rem;">Loading messages…</p>
+    <!-- Rendered by renderCoachMessaging() on first click -->
+    <p class="coach-subtab-placeholder">💬 Click to load client messages</p>
   </div>
 
   <!-- ── Analytics ── -->
   <div id="coachSub_analytics" class="coach-subview">
-    <!-- Rendered by renderCoachAnalytics() -->
-    <p style="color:var(--secondary-text);font-size:0.85rem;">Loading insights…</p>
+    <!-- Rendered by renderCoachAnalytics() on first click -->
+    <p class="coach-subtab-placeholder">📊 Click to load insights</p>
   </div>
 
   <!-- ── GDPR / Privacy ── -->
   <div id="coachSub_gdpr" class="coach-subview">
-    <!-- Rendered by renderCoachGdpr() -->
-    <p style="color:var(--secondary-text);font-size:0.85rem;">Loading privacy settings…</p>
+    <!-- Rendered by renderCoachGdpr() on first click -->
+    <p class="coach-subtab-placeholder">🔒 Click to load privacy settings</p>
   </div>
 </div>
 
@@ -7287,6 +7287,9 @@ const coachDashboardState = {
   selectedClientId: null,
   isBound: false
 };
+// Expose on window so coaching-enhanced.js (external script) can read it.
+// `const` at the top level of an inline <script> is NOT a property of window.
+window.coachDashboardState = coachDashboardState;
 
 function getCoachDemoClients() {
   return [

--- a/index.html
+++ b/index.html
@@ -908,24 +908,52 @@
 </div>
 
 <div id="leaderboardTab" class="tab-content">
-  <h2>Leaderboard</h2>
-  <div class="leaderboard-screen">
-    <div class="leaderboard-controls">
-      <label for="leaderSortStatic">Sort By</label>
-      <select id="leaderSortStatic">
+  <div class="lb-page">
+
+    <!-- ① Always-visible personal stats (local data, no backend needed) -->
+    <div id="lbPersonalStats" class="lb-personal-stats">
+      <!-- populated by renderPersonalStats() -->
+    </div>
+
+    <!-- ② Your rank banner (shown after backend fetch) -->
+    <div id="lbYourRank" style="display:none;"></div>
+
+    <!-- ③ Sort controls -->
+    <div class="lb-controls">
+      <span class="lb-controls-label">Sort by</span>
+      <div class="lb-sort-pills" id="lbSortPills">
+        <button class="lb-sort-pill active" data-sort="workoutsLogged">Workouts</button>
+        <button class="lb-sort-pill" data-sort="studyHours">Study hrs</button>
+        <button class="lb-sort-pill" data-sort="groupActivity">Activity</button>
+      </div>
+      <!-- hidden select kept for JS compatibility -->
+      <select id="leaderSortStatic" style="display:none;">
         <option value="workoutsLogged">Workouts Logged</option>
         <option value="studyHours">Study Hours</option>
         <option value="groupActivity">Group Activity</option>
       </select>
     </div>
-    <div id="leaderboardContainer"></div>
-    <div id="leaderboardLoading" class="spinner" style="display:none;"></div>
-    <p id="leaderboardEmpty" style="display:none;text-align:center;">No data available.</p>
-    <canvas id="lbBarChart"></canvas>
-    <canvas id="lbLineChart" style="margin-top:20px;"></canvas>
-    <div style="margin-top:10px;">
-      <button onclick="showTab('exerciseLeaderboardTab')">Exercise Leaderboard</button>
+
+    <!-- ④ Rank list -->
+    <div id="leaderboardContainer" class="lb-list"></div>
+    <div id="leaderboardLoading" class="lb-loading" style="display:none;">
+      <div class="lb-spinner"></div><span>Loading leaderboard…</span>
     </div>
+    <p id="leaderboardEmpty" class="lb-empty" style="display:none;">
+      No community data yet — be the first to show up here!
+    </p>
+
+    <!-- ⑤ Charts (collapsible) -->
+    <details class="lb-charts-section">
+      <summary class="lb-charts-summary">📊 Charts</summary>
+      <canvas id="lbBarChart"></canvas>
+      <canvas id="lbLineChart" style="margin-top:16px;"></canvas>
+    </details>
+
+    <button class="lb-exercise-btn" onclick="showTab('exerciseLeaderboardTab')">
+      🏋️ Exercise Leaderboard →
+    </button>
+
   </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -863,48 +863,89 @@
 
 <div id="communityTab" class="tab-content">
   <nav class="community-nav">
-    <button onclick="showCommunitySection('groups')">Groups</button>
-    <button onclick="showCommunitySection('competition')">Leaderboard</button>
+    <button class="comm-nav-btn" onclick="showCommunitySection('groups')" id="commNavGroups">👥 Groups</button>
+    <button class="comm-nav-btn" onclick="showCommunitySection('feed')"   id="commNavFeed">📣 Feed</button>
+    <button class="comm-nav-btn" onclick="showCommunitySection('competition')" id="commNavCompetition">🏆 Leaderboard</button>
   </nav>
+
+  <!-- ── Groups panel ── -->
   <div id="groupsPanel" class="panel active">
-  <h2>Community</h2>
-  <div class="community-search">
-    <label for="groupSearchInput">Search Groups</label>
-    <input id="groupSearchInput" placeholder="Search groups">
-    <label for="goalFilter">Goal</label>
-    <input id="goalFilter" placeholder="Goal">
-    <label for="tagFilter">Tag</label>
-    <input id="tagFilter" list="tagOptions" placeholder="Tag">
-    <datalist id="tagOptions">
-      <option value="strength"></option>
-      <option value="hypertrophy"></option>
-      <option value="conditioning"></option>
-      <option value="crossfit"></option>
-    </datalist>
-    <label for="sortFilter">Sort By</label>
-    <select id="sortFilter" onchange="doGroupSearch()">
-      <option value="">--</option>
-      <option value="members">Most Members</option>
-      <option value="active">Recently Active</option>
-      <option value="alpha">Alphabetical (A-Z)</option>
-    </select>
-    <div class="search-buttons">
-      <button id="groupSearchBtn" class="action-btn loading-btn" onclick="doGroupSearch()"><span>Search</span><span class="spinner"></span></button>
-      <button class="action-btn" onclick="clearGroupFilters()">Clear Filters</button>
+    <h2>Community</h2>
+
+    <!-- ⑩ Weekly challenge card -->
+    <div id="communityChallenge"></div>
+
+    <!-- ⑦ Filter pills replacing raw inputs -->
+    <div class="comm-filter-row">
+      <input id="groupSearchInput" class="comm-search-input" placeholder="🔍 Search groups…"
+             oninput="doGroupSearch()">
+      <button class="comm-clear-btn" onclick="clearGroupFilters()" title="Clear">✕</button>
+    </div>
+    <div class="comm-tag-pills" id="commTagPills">
+      <button class="comm-pill active" data-tag="">All</button>
+      <button class="comm-pill" data-tag="strength">Strength</button>
+      <button class="comm-pill" data-tag="hypertrophy">Hypertrophy</button>
+      <button class="comm-pill" data-tag="conditioning">Conditioning</button>
+      <button class="comm-pill" data-tag="crossfit">CrossFit</button>
+    </div>
+    <div class="comm-sort-row">
+      <span class="comm-sort-label">Sort:</span>
+      <div id="commSortPills">
+        <button class="comm-sort-pill active" data-sort="">Default</button>
+        <button class="comm-sort-pill" data-sort="members">Members</button>
+        <button class="comm-sort-pill" data-sort="active">Active</button>
+        <button class="comm-sort-pill" data-sort="alpha">A-Z</button>
+      </div>
+    </div>
+
+    <!-- Hidden inputs kept for doGroupSearch() compatibility -->
+    <input id="goalFilter"  style="display:none;" value="">
+    <input id="tagFilter"   style="display:none;" value="">
+    <select id="sortFilter" style="display:none;"><option value=""></option><option value="members">Most Members</option><option value="active">Recently Active</option><option value="alpha">Alphabetical (A-Z)</option></select>
+    <button id="groupSearchBtn" style="display:none;"></button>
+
+    <div id="groupList" class="group-list"></div>
+    <div class="community-actions">
+      <button class="action-btn" onclick="showCreateGroup()">+ Create Group</button>
+      <button class="action-btn" onclick="loadGroups()">Refresh</button>
+    </div>
+    <div id="groupDetail" style="display:none;"></div>
+  </div>
+
+  <!-- ⑥⑪ Feed panel: activity + posts -->
+  <div id="feedPanel" class="panel" style="display:none;">
+
+    <!-- ⑪ Post composer -->
+    <div class="feed-composer">
+      <div class="feed-composer-top">
+        <div class="feed-avatar" id="feedComposerAvatar">Y</div>
+        <textarea id="feedPostText" class="feed-textarea"
+                  placeholder="Share a workout, PR, or update…" rows="2"></textarea>
+      </div>
+      <div class="feed-composer-actions">
+        <div class="feed-tag-group">
+          <button class="feed-tag-btn active" data-tag="workout">💪 Workout</button>
+          <button class="feed-tag-btn" data-tag="pr">🏆 PR</button>
+          <button class="feed-tag-btn" data-tag="update">📝 Update</button>
+        </div>
+        <button class="feed-post-btn" onclick="submitCommunityPost()">Post</button>
+      </div>
+    </div>
+
+    <!-- ⑥ Activity feed -->
+    <div id="activityFeed" class="activity-feed">
+      <!-- populated by renderActivityFeed() -->
     </div>
   </div>
-  <div id="groupList" class="group-list"></div>
-  <div class="community-actions">
-    <button class="action-btn" onclick="showCreateGroup()">Create Group</button>
-    <button class="action-btn" onclick="loadGroups()">Refresh Groups</button>
-  </div>
-  <div id="groupDetail" style="display:none;"></div>
-  </div>
+
+  <!-- Competition panel -->
   <div id="competitionPanel" class="panel" style="display:none;">
     <h2>Community Leaderboard</h2>
     <div id="competitionContent"></div>
   </div>
-  <div id="postsPanel" class="panel"></div>
+
+  <!-- Legacy posts panel (kept for compatibility) -->
+  <div id="postsPanel" class="panel" style="display:none;"></div>
 </div>
 
 <div id="leaderboardTab" class="tab-content">
@@ -950,9 +991,21 @@
       <canvas id="lbLineChart" style="margin-top:16px;"></canvas>
     </details>
 
-    <button class="lb-exercise-btn" onclick="showTab('exerciseLeaderboardTab')">
-      🏋️ Exercise Leaderboard →
-    </button>
+    <!-- ⑨ Exercise leaderboard inline (replaces hidden separate tab) -->
+    <details class="lb-charts-section lb-exercise-section" id="lbExerciseSection">
+      <summary class="lb-charts-summary">🏋️ Exercise Leaderboard</summary>
+      <div class="lb-exercise-inner">
+        <div class="lb-exercise-ctrl">
+          <select id="exerciseLbSelectInline" class="lb-exercise-select"></select>
+          <div class="lb-time-pills">
+            <button class="lb-time-pill active" data-range="weekly">Weekly</button>
+            <button class="lb-time-pill" data-range="monthly">Monthly</button>
+            <button class="lb-time-pill" data-range="all">All-Time</button>
+          </div>
+        </div>
+        <div id="exerciseLeaderboardInline" class="lb-list"></div>
+      </div>
+    </details>
 
   </div>
 </div>
@@ -11712,6 +11765,7 @@ window.renderMeetPrep = renderMeetPrep;
   <script src="src/js/challenges.js"></script>
   <script src="src/js/client-checkins.js"></script>
   <script src="src/js/progress-report.js"></script>
+  <script src="src/js/community-feed.js"></script>
   <script>
     // Render PR board whenever the Streaks sub-tab becomes active
     document.addEventListener('DOMContentLoaded', function() {

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,11 +1,19 @@
+/* =============================================================
+   LEADERBOARD
+   - Improvement ①: Always-visible local personal-stats card
+   - Improvement ②: Styled medal rank cards with progress bars
+   - Improvement ③: "Your position" banner for logged-in user
+   ============================================================= */
+
 let leaderboardData = [];
+let _currentSortKey  = 'workoutsLogged';
 let barChart;
 let lineChart;
 
+/* ── Helpers ─────────────────────────────────────────────────── */
+
 function getAuthHeaders() {
-  if (typeof localStorage === 'undefined') {
-    return {};
-  }
+  if (typeof localStorage === 'undefined') return {};
   const token = localStorage.getItem('token');
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
@@ -14,15 +22,317 @@ function sum(arr) {
   return Array.isArray(arr) ? arr.reduce((t, n) => t + n, 0) : 0;
 }
 
+function _parse(k) {
+  try { return JSON.parse(localStorage.getItem(k)) || null; } catch { return null; }
+}
+
+function _username() {
+  return (window.getActiveUsername && window.getActiveUsername()) ||
+    localStorage.getItem('fitnessAppUser') ||
+    localStorage.getItem('username') || '';
+}
+
+/* ── ① Local personal stats ─────────────────────────────────── */
+
+function buildLocalStats(username) {
+  if (!username) return null;
+
+  const workouts    = _parse(`workouts_${username}`) || [];
+  const prBoard     = _parse(`prBoard_${username}`)  || {};
+  const weightLog   = _parse(`weightLog_${username}`) || _parse('weightEntries') || [];
+  const readiness   = _parse('dailyReadiness_v1') || {};
+
+  // Workout streak
+  const workedDates = new Set(workouts.map(w => w.date).filter(Boolean));
+  let streak = 0;
+  const today = new Date();
+  const check = new Date(today);
+  check.setHours(0, 0, 0, 0);
+  while (workedDates.has(check.toISOString().slice(0, 10))) {
+    streak++;
+    check.setDate(check.getDate() - 1);
+  }
+
+  // Workouts this month
+  const monthStart = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().slice(0, 10);
+  const monthEnd   = today.toISOString().slice(0, 10);
+  const monthWorkouts = workouts.filter(w => w.date >= monthStart && w.date <= monthEnd).length;
+
+  // Total volume (all time)
+  let totalVolume = 0;
+  for (const w of workouts) {
+    for (const e of (w.log || [])) {
+      const wts = e.weightsArray || [];
+      const rps = e.repsArray    || [];
+      for (let i = 0; i < rps.length; i++) totalVolume += (+wts[i] || 0) * (+rps[i] || 0);
+    }
+  }
+
+  // Top PR by e1RM
+  const topPR = Object.entries(prBoard)
+    .map(([ex, pr]) => ({ ex, e1rm: pr.e1rm || 0, unit: pr.unit || 'kg' }))
+    .sort((a, b) => b.e1rm - a.e1rm)[0] || null;
+
+  // Average readiness (last 30 days)
+  const rangeStart = new Date(today);
+  rangeStart.setDate(rangeStart.getDate() - 29);
+  const rsStr = rangeStart.toISOString().slice(0, 10);
+  const rEntries = Object.entries(readiness)
+    .filter(([k, v]) => !v.skipped && k >= rsStr);
+  const avgReadiness = rEntries.length
+    ? Math.round(rEntries.reduce((s, [, v]) => s + v.score, 0) / rEntries.length)
+    : null;
+
+  // Latest weight
+  const lastWeight = weightLog.length ? weightLog[weightLog.length - 1] : null;
+
+  return {
+    username,
+    streak,
+    monthWorkouts,
+    totalWorkouts: workouts.length,
+    totalVolume:   Math.round(totalVolume),
+    topPR,
+    avgReadiness,
+    lastWeight,
+  };
+}
+
+function renderPersonalStats() {
+  const el = document.getElementById('lbPersonalStats');
+  if (!el) return;
+  const username = _username();
+  if (!username) {
+    el.innerHTML = `<p class="lb-ps-note">Log in to see your personal stats.</p>`;
+    return;
+  }
+  const s = buildLocalStats(username);
+  if (!s) { el.innerHTML = ''; return; }
+
+  const volStr = s.totalVolume >= 1000
+    ? (s.totalVolume / 1000).toFixed(1) + 'k kg'
+    : s.totalVolume + ' kg';
+
+  const readStr = s.avgReadiness !== null
+    ? `<span class="lb-ps-badge ${s.avgReadiness >= 67 ? 'green' : s.avgReadiness >= 40 ? 'amber' : 'red'}">${s.avgReadiness}%</span>`
+    : '—';
+
+  el.innerHTML = `
+    <div class="lb-ps-header">
+      <div class="lb-ps-avatar">${s.username.slice(0, 1).toUpperCase()}</div>
+      <div class="lb-ps-name">
+        <strong>${s.username}</strong>
+        <span class="lb-ps-sub">Your stats (local)</span>
+      </div>
+      ${s.streak > 0 ? `<div class="lb-ps-streak">🔥 ${s.streak}</div>` : ''}
+    </div>
+    <div class="lb-ps-grid">
+      <div class="lb-ps-stat">
+        <span class="lb-ps-val">${s.monthWorkouts}</span>
+        <span class="lb-ps-lbl">This month</span>
+      </div>
+      <div class="lb-ps-stat">
+        <span class="lb-ps-val">${s.totalWorkouts}</span>
+        <span class="lb-ps-lbl">All-time</span>
+      </div>
+      <div class="lb-ps-stat">
+        <span class="lb-ps-val">${volStr}</span>
+        <span class="lb-ps-lbl">Total volume</span>
+      </div>
+      <div class="lb-ps-stat">
+        <span class="lb-ps-val">${readStr}</span>
+        <span class="lb-ps-lbl">Avg readiness</span>
+      </div>
+    </div>
+    ${s.topPR ? `<div class="lb-ps-pr">🏆 Top PR: <strong>${s.topPR.ex}</strong> — ${s.topPR.e1rm} ${s.topPR.unit} e1RM</div>` : ''}
+    ${s.lastWeight ? `<div class="lb-ps-weight">⚖️ Last weight: <strong>${s.lastWeight.weight || s.lastWeight.kg || '—'} kg</strong> on ${s.lastWeight.date}</div>` : ''}
+  `;
+}
+
+/* ── ② Medal rank cards ──────────────────────────────────────── */
+
+function _medalIcon(rank) {
+  if (rank === 1) return '🥇';
+  if (rank === 2) return '🥈';
+  if (rank === 3) return '🥉';
+  return `<span class="lb-rank-num">#${rank}</span>`;
+}
+
+function _medalClass(rank) {
+  if (rank === 1) return 'lb-card--gold';
+  if (rank === 2) return 'lb-card--silver';
+  if (rank === 3) return 'lb-card--bronze';
+  return '';
+}
+
+function renderLeaderboard(sortKey = _currentSortKey) {
+  _currentSortKey = sortKey;
+
+  // Sync hidden select for JS compatibility
+  const sel = document.getElementById('leaderSortStatic');
+  if (sel) sel.value = sortKey;
+
+  // Update pill active state
+  document.querySelectorAll('.lb-sort-pill').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.sort === sortKey);
+  });
+
+  const container = document.getElementById('leaderboardContainer');
+  if (!container) return;
+  if (!leaderboardData.length) { container.innerHTML = ''; return; }
+
+  const sorted   = [...leaderboardData].sort((a, b) => (b[sortKey] || 0) - (a[sortKey] || 0));
+  const topValue = sorted[0]?.[sortKey] || 1;
+  const username = _username();
+
+  const cards = sorted.map((d, i) => {
+    const rank    = i + 1;
+    const value   = d[sortKey] || 0;
+    const pct     = Math.round((value / topValue) * 100);
+    const isMe    = username && d.name.toLowerCase() === username.toLowerCase();
+    const initial = (d.name || '?').slice(0, 1).toUpperCase();
+
+    return `
+      <div class="lb-card ${_medalClass(rank)} ${isMe ? 'lb-card--me' : ''}"
+           data-name="${d.name}"
+           role="button" tabindex="0">
+        <div class="lb-card-left">
+          <div class="lb-card-medal">${_medalIcon(rank)}</div>
+          <div class="lb-card-avatar">${initial}</div>
+          <div class="lb-card-info">
+            <span class="lb-card-name">${d.name}${isMe ? ' <span class="lb-you-tag">You</span>' : ''}</span>
+            <div class="lb-card-bar-wrap">
+              <div class="lb-card-bar" style="width:${pct}%"></div>
+            </div>
+          </div>
+        </div>
+        <div class="lb-card-value">${value}</div>
+      </div>`;
+  }).join('');
+
+  container.innerHTML = cards;
+
+  container.querySelectorAll('.lb-card').forEach(el => {
+    el.addEventListener('click', () => {
+      if (window.showUserStats) window.showUserStats(el.dataset.name);
+    });
+  });
+
+  renderYourRankBanner(sorted, sortKey, username);
+  renderCharts(sorted);
+}
+
+/* ── ③ Your position banner ──────────────────────────────────── */
+
+function renderYourRankBanner(sorted, sortKey, username) {
+  const el = document.getElementById('lbYourRank');
+  if (!el) return;
+  if (!username) { el.style.display = 'none'; return; }
+
+  const idx = sorted.findIndex(d => d.name.toLowerCase() === username.toLowerCase());
+  if (idx === -1) { el.style.display = 'none'; return; }
+
+  const rank   = idx + 1;
+  const d      = sorted[idx];
+  const value  = d[sortKey] || 0;
+  const total  = sorted.length;
+  const above  = rank > 1 ? sorted[rank - 2] : null;
+  const gap    = above ? (above[sortKey] || 0) - value : 0;
+
+  const labelMap = { workoutsLogged: 'workouts', studyHours: 'study hrs', groupActivity: 'activities' };
+  const unit = labelMap[sortKey] || sortKey;
+
+  el.style.display = 'block';
+  el.innerHTML = `
+    <div class="lb-rank-banner">
+      <div class="lb-rank-banner-left">
+        <span class="lb-rank-banner-medal">${_medalIcon(rank)}</span>
+        <div>
+          <div class="lb-rank-banner-title">Your rank: <strong>#${rank}</strong> of ${total}</div>
+          <div class="lb-rank-banner-sub">${value} ${unit}${gap > 0 ? ` &nbsp;·&nbsp; <span class="lb-gap">Need ${gap} more to reach #${rank - 1}</span>` : ' &nbsp;·&nbsp; <span class="lb-gap-top">You\'re #1! 🎉</span>'}</div>
+        </div>
+      </div>
+    </div>`;
+}
+
+/* ── Charts ─────────────────────────────────────────────────── */
+
+function renderCharts(data) {
+  if (typeof Chart === 'undefined') return;
+  const barCtx  = document.getElementById('lbBarChart');
+  const lineCtx = document.getElementById('lbLineChart');
+  if (!barCtx || !lineCtx) return;
+
+  const labels  = data.map(d => d.name);
+  const barData = data.map(d => sum(d.weeklyVolume));
+
+  const chartDefaults = {
+    color: '#b2dfdb',
+    grid:  'rgba(255,255,255,0.06)',
+    tick:  '#7a8f7d',
+  };
+
+  if (barChart) barChart.destroy();
+  barChart = new Chart(barCtx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Weekly Volume',
+        data: barData,
+        backgroundColor: 'rgba(95,168,126,0.75)',
+        borderColor:     '#5fa87e',
+        borderWidth: 1,
+        borderRadius: 4,
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false }, tooltip: { enabled: true } },
+      scales: {
+        x: { grid: { color: chartDefaults.grid }, ticks: { color: chartDefaults.tick } },
+        y: { grid: { color: chartDefaults.grid }, ticks: { color: chartDefaults.tick } },
+      }
+    }
+  });
+
+  const maxLen   = Math.max(...data.map(d => (d.progress || []).length), 1);
+  const lineLbls = Array.from({ length: maxLen }, (_, i) => `W${i + 1}`);
+  const palette  = ['#5fa87e','#81c784','#a5d6a7','#4db6ac','#80cbc4','#ffb74d','#ff8a65'];
+  const lineSets = data.map((d, i) => ({
+    label:       d.name,
+    data:        d.progress || [],
+    tension:     0.4,
+    fill:        false,
+    borderColor: palette[i % palette.length],
+    pointBackgroundColor: palette[i % palette.length],
+    pointRadius: 3,
+  }));
+
+  if (lineChart) lineChart.destroy();
+  lineChart = new Chart(lineCtx, {
+    type: 'line',
+    data: { labels: lineLbls, datasets: lineSets },
+    options: {
+      responsive: true,
+      plugins: { tooltip: { enabled: true }, legend: { labels: { color: chartDefaults.color } } },
+      scales: {
+        x: { grid: { color: chartDefaults.grid }, ticks: { color: chartDefaults.tick } },
+        y: { grid: { color: chartDefaults.grid }, ticks: { color: chartDefaults.tick } },
+      }
+    }
+  });
+}
+
+/* ── Fetch ───────────────────────────────────────────────────── */
+
 async function fetchLeaderboard() {
   const spinner = document.getElementById('leaderboardLoading');
-  const empty = document.getElementById('leaderboardEmpty');
-  if (spinner) spinner.style.display = 'block';
-  if (empty) empty.style.display = 'none';
+  const empty   = document.getElementById('leaderboardEmpty');
+  if (spinner) spinner.style.display = 'flex';
+  if (empty)   empty.style.display   = 'none';
   try {
-    const res = await fetch(`${window.SERVER_URL}/leaderboard`, {
-      headers: getAuthHeaders()
-    });
+    const res = await fetch(`${window.SERVER_URL}/leaderboard`, { headers: getAuthHeaders() });
     leaderboardData = await res.json();
   } catch (e) {
     console.warn('fetch leaderboard failed', e);
@@ -32,56 +342,23 @@ async function fetchLeaderboard() {
   if (!leaderboardData.length && empty) empty.style.display = 'block';
 }
 
-function renderLeaderboard(sortKey = 'workoutsLogged') {
-  const container = document.getElementById('leaderboardContainer');
-  if (!container) return;
-  if (!leaderboardData.length) {
-    container.innerHTML = '';
-    return;
-  }
-  const data = [...leaderboardData].sort((a, b) => (b[sortKey] || 0) - (a[sortKey] || 0));
-  const rows = data.map((d, i) =>
-    `<div class="leader-entry" data-name="${d.name}"><span>#${i + 1}</span><span><strong>${d.name}</strong></span><span>${d[sortKey]}</span></div>`
-  ).join('');
-  container.innerHTML = `<div class="leaderboard">${rows}</div>`;
-  container.querySelectorAll('.leader-entry').forEach(el => {
-    el.addEventListener('click', () => {
-      if (window.showUserStats) window.showUserStats(el.dataset.name);
-    });
-  });
-  renderCharts(data);
-}
-
-function renderCharts(data) {
-  if (typeof Chart === 'undefined') return;
-  const barCtx = document.getElementById('lbBarChart');
-  const lineCtx = document.getElementById('lbLineChart');
-  if (!barCtx || !lineCtx) return;
-  const labels = data.map(d => d.name);
-  const barData = data.map(d => sum(d.weeklyVolume));
-  if (barChart) barChart.destroy();
-  barChart = new Chart(barCtx, {
-    type: 'bar',
-    data: { labels, datasets: [{ label: 'Weekly Volume', data: barData, backgroundColor: '#2F80ED' }] },
-    options: { responsive: true, plugins: { legend: { display: false }, tooltip: { enabled: true } } }
-  });
-
-  const maxLen = Math.max(...data.map(d => d.progress.length));
-  const lineLabels = Array.from({ length: maxLen }, (_, i) => `W${i + 1}`);
-  const lineSets = data.map(d => ({ label: d.name, data: d.progress, tension: .4, fill: false }));
-  if (lineChart) lineChart.destroy();
-  lineChart = new Chart(lineCtx, {
-    type: 'line',
-    data: { labels: lineLabels, datasets: lineSets },
-    options: { responsive: true, plugins: { tooltip: { enabled: true } } }
-  });
-}
+/* ── Init ───────────────────────────────────────────────────── */
 
 function initLeaderboard() {
-  const select = document.getElementById('leaderSortStatic');
-  if (!select) return;
-  select.onchange = () => renderLeaderboard(select.value);
-  fetchLeaderboard().then(() => renderLeaderboard(select.value));
+  // Always render personal stats first (local, instant)
+  renderPersonalStats();
+
+  // Wire sort pills
+  document.querySelectorAll('.lb-sort-pill').forEach(btn => {
+    btn.addEventListener('click', () => renderLeaderboard(btn.dataset.sort));
+  });
+
+  // Wire hidden select for compatibility
+  const sel = document.getElementById('leaderSortStatic');
+  if (sel) sel.onchange = () => renderLeaderboard(sel.value);
+
+  // Fetch + render board
+  fetchLeaderboard().then(() => renderLeaderboard(_currentSortKey));
 }
 
 if (typeof window !== 'undefined') {

--- a/src/js/coaching-enhanced.js
+++ b/src/js/coaching-enhanced.js
@@ -87,6 +87,15 @@ function renderCoachStatsBar() {
    ══════════════════════════════════════════════════════════════ */
 
 const _bulkSelected = new Set();
+// Expose on window so inline onclick handlers in index.html can reach it
+window._bulkSelected = _bulkSelected;
+
+// Global helper called by the "Clear" bulk toolbar button
+window.clearBulkSelection = function () {
+  _bulkSelected.clear();
+  _updateBulkToolbar();
+  document.querySelectorAll('.coach-client-select').forEach(cb => { cb.checked = false; });
+};
 
 function initBulkActions() {
   // Delegate checkbox changes on the roster grid

--- a/src/js/community-feed.js
+++ b/src/js/community-feed.js
@@ -1,0 +1,345 @@
+/* =============================================================
+   COMMUNITY FEED  (improvements ⑥ ⑦ ⑨ ⑩ ⑪)
+   ⑥  Activity feed — recent workouts from localStorage
+   ⑦  Filter pills for group search
+   ⑨  Exercise leaderboard inline rendering
+   ⑩  Weekly challenge card
+   ⑪  Post composer + local posts feed
+   ============================================================= */
+
+(function initCommunityFeed() {
+  'use strict';
+
+  /* ── Helpers ─────────────────────────────────────────────── */
+
+  function _parse(k) {
+    try { return JSON.parse(localStorage.getItem(k)) || null; } catch { return null; }
+  }
+
+  function _save(k, v) {
+    try { localStorage.setItem(k, JSON.stringify(v)); } catch { /* quota */ }
+  }
+
+  function _user() {
+    return (window.getActiveUsername && window.getActiveUsername()) ||
+      localStorage.getItem('fitnessAppUser') ||
+      localStorage.getItem('username') || '';
+  }
+
+  function _initial(name) {
+    return (name || '?').slice(0, 1).toUpperCase();
+  }
+
+  function _timeAgo(isoStr) {
+    if (!isoStr) return '';
+    const diff = Date.now() - new Date(isoStr).getTime();
+    const m = Math.floor(diff / 60000);
+    if (m < 1)  return 'just now';
+    if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    const d = Math.floor(h / 24);
+    return `${d}d ago`;
+  }
+
+  /* ── ⑥ Activity feed ─────────────────────────────────────── */
+
+  function _buildActivityItems(username) {
+    const workouts = _parse(`workouts_${username}`) || [];
+    const posts    = _parse('communityPosts_v1') || [];
+    const items    = [];
+
+    // Convert last 15 workouts to feed items
+    [...workouts].reverse().slice(0, 15).forEach(w => {
+      const exercises = (w.log || []).map(e => e.name || e.exercise || '').filter(Boolean);
+      const topEx     = exercises.slice(0, 2).join(', ') || 'a workout';
+      const setCount  = (w.log || []).reduce((s, e) => s + (e.repsArray?.length || e.sets || 0), 0);
+      items.push({
+        type:    'workout',
+        user:    username,
+        text:    `logged ${topEx}${setCount ? ` — ${setCount} sets` : ''}`,
+        date:    w.date,
+        ts:      w.timestamp || w.date,
+        emoji:   '💪',
+      });
+    });
+
+    // Merge community posts
+    posts.forEach(p => items.push({
+      type:  p.type || 'update',
+      user:  p.user || username,
+      text:  p.text,
+      ts:    p.ts,
+      date:  p.ts ? p.ts.slice(0, 10) : '',
+      emoji: p.type === 'pr' ? '🏆' : p.type === 'update' ? '📝' : '💪',
+    }));
+
+    // Sort newest-first
+    items.sort((a, b) => (b.ts || b.date || '') > (a.ts || a.date || '') ? 1 : -1);
+    return items.slice(0, 30);
+  }
+
+  function renderActivityFeed() {
+    const container = document.getElementById('activityFeed');
+    if (!container) return;
+    const username = _user();
+
+    // Update composer avatar
+    const av = document.getElementById('feedComposerAvatar');
+    if (av) av.textContent = _initial(username);
+
+    if (!username) {
+      container.innerHTML = `<p class="feed-empty">Log in to see your activity feed.</p>`;
+      return;
+    }
+
+    const items = _buildActivityItems(username);
+    if (!items.length) {
+      container.innerHTML = `<p class="feed-empty">No activity yet — log a workout to get started!</p>`;
+      return;
+    }
+
+    container.innerHTML = items.map(item => `
+      <div class="feed-card">
+        <div class="feed-card-avatar">${_initial(item.user)}</div>
+        <div class="feed-card-body">
+          <div class="feed-card-header">
+            <strong class="feed-card-name">${item.user}</strong>
+            <span class="feed-card-type ${item.type}">${item.emoji}</span>
+            <span class="feed-card-time">${item.date || ''}</span>
+          </div>
+          <p class="feed-card-text">${item.text}</p>
+        </div>
+      </div>`).join('');
+  }
+
+  window.renderActivityFeed = renderActivityFeed;
+
+  /* ── ⑪ Post composer ─────────────────────────────────────── */
+
+  let _selectedPostTag = 'workout';
+
+  // Wire tag buttons
+  document.querySelectorAll('.feed-tag-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.feed-tag-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      _selectedPostTag = btn.dataset.tag;
+    });
+  });
+
+  function submitCommunityPost() {
+    const ta       = document.getElementById('feedPostText');
+    const username = _user();
+    const text     = ta ? ta.value.trim() : '';
+    if (!text) return;
+
+    const posts = _parse('communityPosts_v1') || [];
+    posts.unshift({ user: username, text, type: _selectedPostTag, ts: new Date().toISOString() });
+    // Keep last 200
+    _save('communityPosts_v1', posts.slice(0, 200));
+    if (ta) ta.value = '';
+    renderActivityFeed();
+  }
+
+  window.submitCommunityPost = submitCommunityPost;
+
+  /* ── ⑦ Filter pills for group search ────────────────────── */
+
+  function _initGroupFilterPills() {
+    // Tag pills → sync to hidden #tagFilter input + call doGroupSearch
+    document.querySelectorAll('#commTagPills .comm-pill').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#commTagPills .comm-pill').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const tf = document.getElementById('tagFilter');
+        if (tf) tf.value = btn.dataset.tag;
+        if (window.doGroupSearch) window.doGroupSearch();
+      });
+    });
+
+    // Sort pills → sync to hidden #sortFilter select + call doGroupSearch
+    document.querySelectorAll('#commSortPills .comm-sort-pill').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#commSortPills .comm-sort-pill').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const sf = document.getElementById('sortFilter');
+        if (sf) sf.value = btn.dataset.sort;
+        if (window.doGroupSearch) window.doGroupSearch();
+      });
+    });
+  }
+
+  // Also patch clearGroupFilters to reset pills
+  const _origClear = window.clearGroupFilters;
+  window.clearGroupFilters = function () {
+    if (_origClear) _origClear();
+    document.querySelectorAll('#commTagPills .comm-pill').forEach((b, i) =>
+      b.classList.toggle('active', i === 0));
+    document.querySelectorAll('#commSortPills .comm-sort-pill').forEach((b, i) =>
+      b.classList.toggle('active', i === 0));
+  };
+
+  /* ── ⑩ Weekly challenge card ─────────────────────────────── */
+
+  const WEEKLY_GOALS = [
+    { label: 'Log 4 workouts',           key: 'workouts',  target: 4 },
+    { label: 'Log 3 cardio sessions',    key: 'cardio',    target: 3 },
+    { label: 'Hit your protein target',  key: 'protein',   target: 5 },
+    { label: 'Log every day this week',  key: 'daily',     target: 7 },
+  ];
+
+  function _thisWeekStart() {
+    const d = new Date();
+    const day = d.getDay(); // 0=Sun
+    const diff = (day === 0 ? -6 : 1 - day);
+    d.setDate(d.getDate() + diff);
+    d.setHours(0, 0, 0, 0);
+    return d.toISOString().slice(0, 10);
+  }
+
+  function _weeklyProgress(username) {
+    const weekStart = _thisWeekStart();
+    const today     = new Date().toISOString().slice(0, 10);
+    const workouts  = (_parse(`workouts_${username}`) || [])
+      .filter(w => w.date >= weekStart && w.date <= today);
+
+    // Pick the "challenge of the week" based on ISO week number
+    const wk = Math.ceil(new Date().getDate() / 7);
+    const challenge = WEEKLY_GOALS[wk % WEEKLY_GOALS.length];
+
+    let progress = 0;
+    if (challenge.key === 'workouts') {
+      progress = workouts.length;
+    } else if (challenge.key === 'cardio') {
+      const cardio = _parse(`cardioLog_${username}`) || _parse('cardioLog') || [];
+      progress = cardio.filter(e => e.date >= weekStart).length;
+    } else if (challenge.key === 'daily') {
+      const workedDates = new Set(workouts.map(w => w.date));
+      let d = new Date(weekStart);
+      const end = new Date(today);
+      while (d <= end) {
+        if (workedDates.has(d.toISOString().slice(0, 10))) progress++;
+        d.setDate(d.getDate() + 1);
+      }
+    } else if (challenge.key === 'protein') {
+      const diary = _parse(`foodDiary_${username}`) || [];
+      const targets = _parse(`macroTargets_${username}`) || {};
+      const pTarget = targets.protein || 0;
+      if (pTarget > 0) {
+        progress = diary.filter(e => e.date >= weekStart && (e.protein || 0) >= pTarget).length;
+      }
+    }
+
+    return { challenge, progress, target: challenge.target };
+  }
+
+  function renderWeeklyChallenge() {
+    const el = document.getElementById('communityChallenge');
+    if (!el) return;
+    const username = _user();
+    if (!username) { el.innerHTML = ''; return; }
+
+    const { challenge, progress, target } = _weeklyProgress(username);
+    const pct     = Math.min(100, Math.round((progress / target) * 100));
+    const done    = progress >= target;
+
+    el.innerHTML = `
+      <div class="comm-challenge-card ${done ? 'done' : ''}">
+        <div class="comm-challenge-header">
+          <span class="comm-challenge-icon">${done ? '✅' : '🎯'}</span>
+          <div class="comm-challenge-info">
+            <div class="comm-challenge-title">This week's challenge</div>
+            <div class="comm-challenge-label">${challenge.label}</div>
+          </div>
+          <div class="comm-challenge-count">${progress}/${target}</div>
+        </div>
+        <div class="comm-challenge-bar-wrap">
+          <div class="comm-challenge-bar" style="width:${pct}%"></div>
+        </div>
+        ${done ? '<div class="comm-challenge-badge">🏅 Challenge complete!</div>' : ''}
+      </div>`;
+  }
+
+  window.renderWeeklyChallenge = renderWeeklyChallenge;
+
+  /* ── ⑨ Exercise leaderboard inline ─────────────────────── */
+
+  function _initExerciseLbInline() {
+    const sel = document.getElementById('exerciseLbSelectInline');
+    if (!sel || typeof sampleExerciseLeaderboard === 'undefined') return;
+
+    // Populate exercise select
+    Object.keys(sampleExerciseLeaderboard).forEach(ex => {
+      const opt = document.createElement('option');
+      opt.value = ex; opt.textContent = ex;
+      sel.appendChild(opt);
+    });
+
+    let currentRange = 'weekly';
+
+    function renderInline() {
+      const exercise = sel.value;
+      const data = sampleExerciseLeaderboard[exercise]?.[currentRange] || [];
+      const container = document.getElementById('exerciseLeaderboardInline');
+      if (!container) return;
+
+      const username = _user();
+      const topVal   = data[0]?.volume || 1;
+
+      container.innerHTML = data.map((d, i) => {
+        const rank  = i + 1;
+        const pct   = Math.round((d.volume / topVal) * 100);
+        const medal = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `<span class="lb-rank-num">#${rank}</span>`;
+        const isMe  = username && d.user.toLowerCase() === username.toLowerCase();
+        return `
+          <div class="lb-card ${rank <= 3 ? `lb-card--${['gold','silver','bronze'][rank-1]}` : ''} ${isMe ? 'lb-card--me' : ''}">
+            <div class="lb-card-left">
+              <div class="lb-card-medal">${medal}</div>
+              <div class="lb-card-avatar">${_initial(d.user)}</div>
+              <div class="lb-card-info">
+                <span class="lb-card-name">${d.user}${isMe ? ' <span class="lb-you-tag">You</span>' : ''}</span>
+                <div class="lb-card-bar-wrap">
+                  <div class="lb-card-bar" style="width:${pct}%"></div>
+                </div>
+              </div>
+            </div>
+            <div class="lb-card-value">${(d.volume/1000).toFixed(1)}k</div>
+          </div>`;
+      }).join('');
+    }
+
+    sel.onchange = renderInline;
+
+    document.querySelectorAll('.lb-time-pill').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.lb-time-pill').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        currentRange = btn.dataset.range;
+        renderInline();
+      });
+    });
+
+    // Open → render on first expand
+    const details = document.getElementById('lbExerciseSection');
+    if (details) {
+      details.addEventListener('toggle', () => {
+        if (details.open) renderInline();
+      });
+    }
+  }
+
+  /* ── Init (after DOM ready) ──────────────────────────────── */
+
+  function _init() {
+    _initGroupFilterPills();
+    _initExerciseLbInline();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _init);
+  } else {
+    _init();
+  }
+
+})();


### PR DESCRIPTION
## Summary

This PR bundles all work from the current session across three main areas: new features, community/leaderboard improvements, and a coaching dashboard bug fix.

---

### 🏅 Leaderboard improvements (items 1–3)

- **Personal stats card** (`#lbPersonalStats`) — always-visible, built from localStorage (no backend needed). Shows streak 🔥, workouts this month + all-time, total volume lifted, 30-day avg readiness, top PR by e1RM, and latest weight entry.
- **Medal rank cards** — gold/silver/bronze styling for top 3, avatar initials, inline progress bar scaled to the leader, "You" tag on the logged-in user's card, animated hover.
- **"Your position" banner** (`#lbYourRank`) — pinned after backend fetch. Shows your medal, rank out of total, score, and gap to the next rank above.
- Sort pills replace the hidden `<select>` with active-state pill buttons; chart colours updated to green `#5fa87e`.

---

### 👥 Community improvements (items 6–11)

- **⑥ Activity feed** — last 15 workouts from localStorage rendered as social cards (avatar, exercise summary, date) in the new Feed panel.
- **⑦ Filter pills** — replaces raw `<label>+<input>` group search with tag pills (All · Strength · Hypertrophy · Conditioning · CrossFit) and sort pills (Default · Members · Active · A-Z). Hidden inputs kept for `doGroupSearch()` compatibility.
- **⑧ Dark-theme charts** — already shipped in the leaderboard commit.
- **⑨ Exercise leaderboard inline** — collapsible `<details>` section inside the main leaderboard tab with exercise select + weekly/monthly/all-time pills and medal card styling. No more hidden separate tab.
- **⑩ Weekly challenge card** — rotates 4 challenge types by ISO week, reads progress from localStorage, progress bar + "🏅 Challenge complete!" badge.
- **⑪ Post composer + feed** — textarea with Workout/PR/Update tags, posts saved to `communityPosts_v1`, merged with workout activity into one chronological feed.
- Community nav redesigned as 3 pill buttons (Groups · Feed · Leaderboard) with active state.

---

### 🧭 Coaching dashboard bug fix

Two silent bugs prevented `coaching-enhanced.js` from seeing any client data:

1. **`window.coachDashboardState` was `undefined`** — `coachDashboardState` is declared with `const` in an inline `<script>` block. `const` at the top level of a non-module script is NOT a property of `window`. Every function in `coaching-enhanced.js` read `window.coachDashboardState?.clients` → `undefined` → `|| []`. Result: stats bar showed 0, Messages showed "No clients yet", Analytics showed empty charts, GDPR showed no rows, program builder had no client dropdown options.  
   Fix: `window.coachDashboardState = coachDashboardState;` added immediately after the declaration (same object reference, mutations stay in sync).

2. **`_bulkSelected` ReferenceError on bulk clear** — The "Clear" button `onclick` referenced `_bulkSelected` directly, but it's a `const` in `coaching-enhanced.js` scope, not on `window`. Fixed by exposing `window._bulkSelected = _bulkSelected` and a clean `window.clearBulkSelection()` wrapper.

---

### Additional work in this session

- **Bodyweight tracker redesign** — stat strip, card layout, styled log table, BMI estimator.
- **3 program tab console errors fixed** — 405 API call guarded, `getCurrentProfile` defined, `showProgramView` safety fallback.
- **Lower-priority features** — food database (USDA API), weekly summary card, monthly challenges/badges, service worker/PWA, client check-ins, progress report PDF.
- **Medium-priority features** — body measurements, daily readiness check-in, data export & rest notifications.
- **High-priority features** — PR tracker, progressive overload hints, history search, water tracker.

## Test plan

- [ ] Enable Coach mode in Settings → confirm coaching tab appears in More drawer
- [ ] Open coaching tab → stats bar shows client counts; Roster shows 3 demo cards
- [ ] Click each sub-tab (Programs, Messages, Analytics, GDPR) → panels render with client data
- [ ] Click "Open Client" on a card → detail view opens; "← Back to roster" returns
- [ ] Select clients via checkboxes → bulk toolbar appears; "✕ Clear" deselects without error
- [ ] Leaderboard tab → personal stats card visible immediately; sort pills switch ranking; "Your position" banner appears after load
- [ ] Community → Groups tab shows filter pills and weekly challenge; Feed tab shows activity cards and post composer
- [ ] Leaderboard → expand "🏋️ Exercise Leaderboard" section; select exercise and time range
- [ ] Bodyweight tab → stat strip, log table, and BMI estimator render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)