### PR TITLE
fix: repair broken signup flow and login error messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1852,7 +1852,7 @@ async function startLogin() {
     }
 
     if (result && result.success === false) {
-      const message = result.message || "Invalid username or password.";
+      const message = result.error?.message || result.message || "Invalid username or password.";
       if (errorEl) {
         errorEl.textContent = message;
       } else {
@@ -2227,46 +2227,41 @@ async function startSignup() {
   setLoading(btn, true);
   const username = document.getElementById("username").value.trim();
   const password = document.getElementById("password").value.trim();
+  const errorEl = document.getElementById('loginError');
+
+  if (errorEl) errorEl.textContent = '';
 
   if (!username || !password) {
-    alert("Please fill in both username and password.");
+    if (errorEl) errorEl.textContent = "Please fill in both username and password.";
     setLoading(btn, false);
     return;
   }
 
   try {
-    const response = await fetch(`${window.SERVER_URL}/signup`, {
+    // POST /register — returns token directly, no second login call needed
+    const response = await fetch(`${window.SERVER_URL}/register`, {
       method: 'POST',
-        credentials: "include",
+      credentials: "include",
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
     });
 
     const result = await response.json();
 
-    if (result.success) {
-      // Auto-login after signup so onboarding can persist settings to the right user
-      const loginResponse = await fetch(`${window.SERVER_URL}/login`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
-      });
-      const loginResult = await loginResponse.json();
-      if (loginResult.success || loginResult.token) {
-        if (loginResult.token) localStorage.setItem('token', loginResult.token);
-        setCurrentUser(username);
-        document.getElementById('loginContainer').style.display = 'none';
-        showOnboarding();
-      } else {
-        alert("Account created! Please log in to continue.");
-      }
+    if (result.success && result.token) {
+      persistLoginIdentity(result.username || username, result.token);
+      setCurrentUser(result.username || username);
+      document.getElementById('loginContainer').style.display = 'none';
+      showOnboarding();
     } else {
-      alert(result.message || "Signup failed.");
+      const message = result.error?.message || result.message || "Signup failed. Please try again.";
+      if (errorEl) errorEl.textContent = message;
+      else alert(message);
     }
   } catch (error) {
     console.error('Signup error:', error);
-    alert("Error connecting to server.");
+    if (errorEl) errorEl.textContent = "Error connecting to server. Please try again.";
+    else alert("Error connecting to server.");
   } finally {
     setLoading(btn, false);
   }
@@ -10621,19 +10616,7 @@ async function findUser(username) {
   return data.records[0];
 }
 
-async function createUser(username, password) {
-  const url = `/airtable/${airtableBaseId}/${usersTableName}`;
-  await fetch(url, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${airtableToken}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      fields: { Username: username, Password: password }
-    })
-  });
-}
+// createUser removed — registration now handled via POST /register on the backend
 
 async function fetchDailyLogs(username) {
   const token = getAuthToken();


### PR DESCRIPTION
## Summary

- `startSignup()` was calling `/signup` which doesn't exist on the backend — every sign-up attempt silently 404'd. Changed to `/register`.
- Removed unnecessary second `/login` call after signup — `/register` already returns a token, so it's used directly.
- Login and signup error messages now read `result.error?.message` (correct backend shape) with fallback to `result.message` — errors were previously never displayed to the user.
- Signup errors now shown inline via `#loginError` element instead of `alert()`, consistent with login UX.
- Removed `createUser()` — legacy function that wrote **plaintext passwords** directly to Airtable, bypassing the backend entirely.

## Test plan

- [ ] Sign up with a new username/password — should create account and proceed to onboarding
- [ ] Sign up with an already-taken username — should show inline error message
- [ ] Log in with correct credentials — should succeed
- [ ] Log in with wrong password — should show inline error message (not a blank or generic one)
- [ ] Confirm no `alert()` dialogs appear during signup errors

## Notes for reviewer

The backend (`traininglog-backend`) was updated separately in a direct push to `main` on that repo. The backend now exposes `POST /register` (not `/signup`) and returns `{ success, token, username }`. This PR wires the frontend up to match that contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)