### PR TITLE
fix: resolve 4 console errors (getAuthToken, mission URL, manifest, page-load 401)

### DIFF
--- a/dailyMissionEngine.js
+++ b/dailyMissionEngine.js
@@ -154,7 +154,8 @@
       // Future backend endpoint: PUT /api/bodybuilding/daily-mission/:userId
       // Sync errors are intentionally ignored to keep the app fully usable offline.
       if (typeof globalScope.fetch !== 'function') return false;
-      return globalScope.fetch(`/api/bodybuilding/daily-mission/${encodeURIComponent(resolvedUser)}`, {
+      const _serverBase = (typeof window !== 'undefined' && window.SERVER_URL) || '';
+      return globalScope.fetch(`${_serverBase}/api/bodybuilding/daily-mission/${encodeURIComponent(resolvedUser)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(state || {})

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <link rel="stylesheet" href="css/coaching.css">
   <link rel="stylesheet" href="css/ui-declutter.css">
   <link rel="stylesheet" href="css/features.css">
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="manifest.json">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
 </head>
@@ -5937,7 +5937,6 @@ loadMacroDayContext();
 
 
 async function saveDailyMacroLog(username, date, meals, totals) {
-  const token = getAuthToken();
   let dayContext = null;
   try {
     dayContext = JSON.parse(localStorage.getItem(getMacroDayContextKey()) || 'null');
@@ -5961,7 +5960,7 @@ async function saveDailyMacroLog(username, date, meals, totals) {
     const response = await fetch("/dailylogs", {
       method: "POST",
       headers: {
-        Authorization: "Bearer " + token,
+        ...getAuthHeaders(),
         "Content-Type": "application/json"
       },
       body: JSON.stringify(payload)
@@ -10619,12 +10618,11 @@ async function findUser(username) {
 // createUser removed — registration now handled via POST /register on the backend
 
 async function fetchDailyLogs(username) {
-  const token = getAuthToken();
   const params = new URLSearchParams({ username });
 
   try {
     const response = await fetch(`/dailylogs?${params.toString()}`, {
-      headers: { Authorization: `Bearer ${token}` }
+      headers: getAuthHeaders()
     });
     const data = await response.json();
     if (!response.ok) {
@@ -10641,9 +10639,6 @@ async function fetchDailyLogs(username) {
   const loginEl = document.getElementById("loginContainer");
   const dash = document.getElementById("dashboardContainer");
   const fit = document.getElementById("pocketFitContainer");
-
-  // Force a fresh auth handshake by clearing any persisted JWT on app load.
-  forceFreshLogin();
 
   if (savedUser) {
     setCurrentUser(savedUser);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Pocket Coach",
   "short_name": "PocketCoach",
   "description": "Your personal fitness training log and coach.",
-  "start_url": "/",
+  "start_url": "/TrainingLog-mobile/",
   "display": "standalone",
   "background_color": "#0b130d",
   "theme_color": "#5fa87e",


### PR DESCRIPTION
## Summary

- **`getAuthToken is not defined`** — replaced both `getAuthToken()` calls in `index.html` with `getAuthHeaders()` (from `auth.js`), which returns the correct `Authorization` header object
- **`dailyMissionEngine.js` 405 on PUT** — prefixed the `/api/bodybuilding/daily-mission/:userId` URL with `window.SERVER_URL` so it hits the Render backend instead of GitHub Pages
- **`manifest.json` 404** — changed `<link rel="manifest" href="/manifest.json">` to a relative path (`manifest.json`) and updated `start_url` in the manifest to `/TrainingLog-mobile/` to match the GitHub Pages subpath
- **Login 401 on page load** — removed `forceFreshLogin()` call inside `DOMContentLoaded`; this function was wiping the JWT token on every page load (its comment said "fresh auth handshake"), causing authenticated API calls to fire without credentials

## Test plan

- [ ] Log in, refresh — user should remain logged in (session persists)
- [ ] Save a macro log — no `getAuthToken is not defined` error in console
- [ ] Check Network tab — no PUT to `github.io` for daily mission, should go to `traininglog-backend.onrender.com`
- [ ] Check Application → Manifest in DevTools — manifest loads without 404
- [ ] Check console on page load — no 401 errors before login

🤖 Generated with [Claude Code](https://claude.com/claude-code)