### PR TITLE
UI overhaul: cardio, check-in, community sharing, PL scores + bug fixes

### DIFF
--- a/ProgramTab.css
+++ b/ProgramTab.css
@@ -503,7 +503,7 @@
   border-radius: 6px;
   color: var(--text, #e8f5e9);
   padding: 5px 4px;
-  font-size: 0.82rem;
+  font-size: 1rem; /* ≥16px — prevent iOS auto-zoom */
   text-align: center;
   font-family: 'Poppins', sans-serif;
 }
@@ -565,7 +565,7 @@
   border: 1px solid var(--border, #2a3a2e);
   border-radius: 8px;
   color: var(--text, #e8f5e9);
-  font-size: 0.86rem;
+  font-size: 1rem; /* ≥16px — prevent iOS auto-zoom */
   font-family: 'Poppins', sans-serif;
   margin-bottom: 16px;
 }
@@ -712,7 +712,7 @@
   border-radius: 8px;
   color: var(--text, #e8f5e9);
   padding: 8px 10px;
-  font-size: 0.84rem;
+  font-size: 1rem; /* ≥16px — prevent iOS auto-zoom */
   font-family: 'Poppins', sans-serif;
 }
 

--- a/ProgramTab.css
+++ b/ProgramTab.css
@@ -3,6 +3,52 @@
    Dark theme matching the app's green palette.
    ============================================================= */
 
+/* ── Template loader strip ──────────────────────────────────── */
+
+.pbv2-template-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  background: var(--card-bg, #0f1510);
+  border: 1px dashed var(--border, #2a3a2e);
+  border-radius: 10px;
+}
+
+.pbv2-template-select {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  font-size: 1rem; /* ≥16px — no iOS zoom */
+  background: var(--bg, #0b130d);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 8px;
+  color: var(--text, #e8f5e9);
+  font-family: 'Poppins', sans-serif;
+  margin: 0; /* override global input margin */
+  width: auto;
+}
+
+.pbv2-template-load-btn {
+  flex-shrink: 0;
+  padding: 7px 14px;
+  font-size: 0.88rem;
+  background: var(--primary, #5fa87e);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.pbv2-template-load-btn:hover {
+  background: var(--primary-dark, #3d7a5a);
+  transform: none;
+  box-shadow: none;
+}
+
 /* ── Top nav ─────────────────────────────────────────────────── */
 
 .prog-top-nav {

--- a/ProgramTab.js
+++ b/ProgramTab.js
@@ -350,7 +350,8 @@ function initProgramTabV1(root) {
           credentials: "include",
           method: "POST",
           headers: { "Content-Type": "application/json", ...getAuthHeaders() },
-          body: JSON.stringify(payload)
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(5000)
         });
       } catch (_error) {
         // Local save is still authoritative.
@@ -371,7 +372,8 @@ function initProgramTabV1(root) {
       credentials: "include",
       method: "POST",
       headers: { "Content-Type": "application/json", ...getAuthHeaders() },
-      body: JSON.stringify({ programId: state.shareId, recipientUsername: username })
+      body: JSON.stringify({ programId: state.shareId, recipientUsername: username }),
+      signal: AbortSignal.timeout(5000)
     });
     state.showShare = false;
     render();

--- a/auth.js
+++ b/auth.js
@@ -91,7 +91,8 @@ async function login(username, password, serverUrl) {
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password })
+    body: JSON.stringify({ username, password }),
+    signal: AbortSignal.timeout(5000)
   });
 
   const data = await parseJsonResponse(response);
@@ -110,7 +111,8 @@ async function login(username, password, serverUrl) {
 async function fetchProtected(serverUrl) {
   const url = `${resolveServerUrl(serverUrl)}/protected-route`;
   const response = await fetch(url, {
-    headers: getAuthHeaders()
+    headers: getAuthHeaders(),
+    signal: AbortSignal.timeout(5000)
   });
 
   const data = await parseJsonResponse(response);
@@ -129,7 +131,8 @@ async function fetchProtected(serverUrl) {
 async function loadTemplates(username, serverUrl) {
   const url = `${resolveServerUrl(serverUrl)}/templates?username=${encodeURIComponent(username)}`;
   const response = await fetch(url, {
-    headers: getAuthHeaders()
+    headers: getAuthHeaders(),
+    signal: AbortSignal.timeout(5000)
   });
 
   const data = await parseJsonResponse(response);

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,7 +1,7 @@
 {
   "appId": "com.pocketcoach.app",
   "appName": "Pocket Coach",
-  "webDir": ".",
+  "webDir": "www",
   "server": {
     "androidScheme": "https"
   },

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,0 +1,40 @@
+{
+  "appId": "com.pocketcoach.app",
+  "appName": "Pocket Coach",
+  "webDir": ".",
+  "server": {
+    "androidScheme": "https"
+  },
+  "plugins": {
+    "SplashScreen": {
+      "launchShowDuration": 2000,
+      "launchAutoHide": true,
+      "backgroundColor": "#0b130d",
+      "androidSplashResourceName": "splash",
+      "androidScaleType": "CENTER_CROP",
+      "showSpinner": false,
+      "splashFullScreen": true,
+      "splashImmersive": true
+    },
+    "StatusBar": {
+      "style": "DARK",
+      "backgroundColor": "#0b130d"
+    },
+    "Keyboard": {
+      "resize": "body",
+      "style": "DARK",
+      "resizeOnFullScreen": true
+    }
+  },
+  "ios": {
+    "contentInset": "always",
+    "allowsLinkPreview": false,
+    "scrollEnabled": true,
+    "backgroundColor": "#0b130d"
+  },
+  "android": {
+    "allowMixedContent": false,
+    "captureInput": true,
+    "webContentsDebuggingEnabled": false
+  }
+}

--- a/cardioTab.js
+++ b/cardioTab.js
@@ -1,22 +1,35 @@
 (function (global) {
   const MET_VALUES = {
-    run: 9.8,
-    running: 9.8,
-    jog: 7,
-    jogging: 7,
-    walk: 3.8,
-    walking: 3.8,
-    bike: 7.5,
-    cycling: 7.5,
-    swim: 8,
-    swimming: 8,
-    row: 7,
-    rowing: 7,
+    run: 9.8, running: 9.8,
+    jog: 7, jogging: 7,
+    walk: 3.8, walking: 3.8,
+    bike: 7.5, cycling: 7.5, cycle: 7.5,
+    swim: 8, swimming: 8,
+    row: 7, rowing: 7,
     hiit: 10,
-    stair: 8.8,
+    stair: 8.8, stairs: 8.8,
     elliptical: 5.5,
-    jump: 8.5,
+    jump: 8.5, 'jump rope': 8.5,
+    hike: 5.3, hiking: 5.3,
+    yoga: 2.5,
+    pilates: 3.0,
+    dance: 5.5,
+    other: 6,
     default: 6,
+  };
+
+  /* Activity display config — icon, colour accent, metric type */
+  const ACTIVITY_CONFIG = {
+    run:        { label: 'Run',        icon: '🏃', metric: 'pace',  color: '#e05252' },
+    walk:       { label: 'Walk',       icon: '🚶', metric: 'pace',  color: '#52c078' },
+    cycle:      { label: 'Cycle',      icon: '🚴', metric: 'speed', color: '#5295e0' },
+    swim:       { label: 'Swim',       icon: '🏊', metric: 'pace',  color: '#52c0d8' },
+    row:        { label: 'Row',        icon: '🚣', metric: 'speed', color: '#9070d8' },
+    hiit:       { label: 'HIIT',       icon: '💪', metric: null,    color: '#e0943a' },
+    hike:       { label: 'Hike',       icon: '🥾', metric: 'pace',  color: '#7ab848' },
+    yoga:       { label: 'Yoga',       icon: '🧘', metric: null,    color: '#a07dc0' },
+    elliptical: { label: 'Elliptical', icon: '⚙️', metric: 'speed', color: '#7f9891' },
+    other:      { label: 'Other',      icon: '🏅', metric: null,    color: '#8c9891' },
   };
 
   function normalizeType(type) {
@@ -26,6 +39,36 @@
   function resolveMET(type) {
     const value = MET_VALUES[normalizeType(type)];
     return Number.isFinite(value) ? value : MET_VALUES.default;
+  }
+
+  /**
+   * Compute pace (min/km → "M:SS /km") or speed (km/h → "X.X km/h")
+   * based on the activity type. Returns null when not applicable.
+   */
+  function computePaceOrSpeed({ type, durationMinutes, distanceKm }) {
+    const dur  = Number(durationMinutes);
+    const dist = Number(distanceKm);
+    if (!Number.isFinite(dur) || dur <= 0 || !Number.isFinite(dist) || dist <= 0) return null;
+
+    const norm = normalizeType(type);
+    const cfg  = ACTIVITY_CONFIG[norm] || ACTIVITY_CONFIG.other;
+
+    if (cfg.metric === 'pace') {
+      const totalSec = (dur / dist) * 60;
+      const mins = Math.floor(totalSec / 60);
+      const secs = Math.round(totalSec % 60).toString().padStart(2, '0');
+      return { value: `${mins}:${secs} /km`, label: 'Pace', icon: '⚡' };
+    }
+    if (cfg.metric === 'speed') {
+      const kmh = dist / (dur / 60);
+      return { value: `${kmh.toFixed(1)} km/h`, label: 'Speed', icon: '🚀' };
+    }
+    return null;
+  }
+
+  /** Return the ACTIVITY_CONFIG entry for a type, falling back gracefully */
+  function getActivityConfig(type) {
+    return ACTIVITY_CONFIG[normalizeType(type)] || { label: type || 'Other', icon: '🏅', metric: null, color: '#8c9891' };
   }
 
   function estimateCardioCalories({ type, durationMinutes, weightKg }) {
@@ -74,11 +117,14 @@
 
   const api = {
     MET_VALUES,
+    ACTIVITY_CONFIG,
     normalizeType,
     resolveMET,
     estimateCardioCalories,
     computeDailyCardioExpenditure,
     applyCardioMacroAdjustment,
+    computePaceOrSpeed,
+    getActivityConfig,
   };
 
   if (typeof module !== 'undefined' && module.exports) {

--- a/checkinEngine.js
+++ b/checkinEngine.js
@@ -548,7 +548,8 @@
       return globalScope.fetch(`/api/bodybuilding/checkins/${encodeURIComponent(resolvedUser)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(Array.isArray(state) ? state : [])
+        body: JSON.stringify(Array.isArray(state) ? state : []),
+        signal: AbortSignal.timeout(5000)
       }).then(() => true).catch(() => false);
     } catch (_error) {
       return false;

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -19,7 +19,7 @@ workflows:
         XCODE_WORKSPACE: ios/App/App.xcworkspace
         XCODE_SCHEME: App
         BUNDLE_ID: com.pocketcoach.app
-        CAP_VERSION: "6"          # major Capacitor version to install
+        CAP_VERSION: "6"
       node: 20
 
     scripts:
@@ -34,9 +34,27 @@ workflows:
             @capacitor/cli@^${CAP_VERSION} \
             @capacitor/ios@^${CAP_VERSION}
 
+      - name: Bundle web assets into www/
+        script: |
+          # Capacitor requires a named webDir folder (not ".").
+          # Copy all app files into www/, skipping native/build folders.
+          mkdir -p www
+          rsync -a --exclude='www' \
+                   --exclude='ios' \
+                   --exclude='android' \
+                   --exclude='node_modules' \
+                   --exclude='.git' \
+                   --exclude='.claude' \
+                   --exclude='scripts' \
+                   --exclude='tests' \
+                   --exclude='codemagic.yaml' \
+                   --exclude='server.js' \
+                   --exclude='package*.json' \
+                   --exclude='babel.config.json' \
+                   . www/
+
       - name: Generate iOS native project
         script: |
-          # Only add if the folder doesn't already exist in the repo
           if [ ! -d "ios" ]; then
             npx cap add ios
           fi
@@ -111,6 +129,23 @@ workflows:
             @capacitor/core@^${CAP_VERSION} \
             @capacitor/cli@^${CAP_VERSION} \
             @capacitor/android@^${CAP_VERSION}
+
+      - name: Bundle web assets into www/
+        script: |
+          mkdir -p www
+          rsync -a --exclude='www' \
+                   --exclude='ios' \
+                   --exclude='android' \
+                   --exclude='node_modules' \
+                   --exclude='.git' \
+                   --exclude='.claude' \
+                   --exclude='scripts' \
+                   --exclude='tests' \
+                   --exclude='codemagic.yaml' \
+                   --exclude='server.js' \
+                   --exclude='package*.json' \
+                   --exclude='babel.config.json' \
+                   . www/
 
       - name: Generate Android native project
         script: |

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,7 +1,9 @@
 workflows:
 
   # ─────────────────────────────────────────────────────────────────
-  # iOS – development / TestFlight build
+  # iOS – Capacitor build (no local Mac needed)
+  # Codemagic installs Capacitor and generates the ios/ project
+  # fresh on every build run.
   # ─────────────────────────────────────────────────────────────────
   ios-capacitor:
     name: Pocket Coach – iOS
@@ -9,35 +11,45 @@ workflows:
     instance_type: mac_mini_m2
 
     environment:
-      # Uncomment + configure once you have an Apple Developer account
+      # ── Uncomment + fill in once you have an Apple Developer account ──
       # ios_signing:
-      #   distribution_type: app_store          # or development
+      #   distribution_type: development          # change to app_store for TestFlight
       #   bundle_identifier: com.pocketcoach.app
       vars:
         XCODE_WORKSPACE: ios/App/App.xcworkspace
         XCODE_SCHEME: App
         BUNDLE_ID: com.pocketcoach.app
+        CAP_VERSION: "6"          # major Capacitor version to install
       node: 20
 
     scripts:
       - name: Install JS dependencies
         script: |
-          npm ci || npm install
+          npm install
 
-      - name: Install Capacitor packages (if not in package.json yet)
+      - name: Install Capacitor core + iOS
         script: |
-          npm list @capacitor/core >/dev/null 2>&1 || \
-            npm install @capacitor/core @capacitor/cli @capacitor/ios
+          npm install \
+            @capacitor/core@^${CAP_VERSION} \
+            @capacitor/cli@^${CAP_VERSION} \
+            @capacitor/ios@^${CAP_VERSION}
 
-      - name: Capacitor sync  (copies web assets → ios/)
+      - name: Generate iOS native project
+        script: |
+          # Only add if the folder doesn't already exist in the repo
+          if [ ! -d "ios" ]; then
+            npx cap add ios
+          fi
+
+      - name: Sync web assets into ios/
         script: |
           npx cap sync ios
 
-      - name: Install CocoaPods dependencies
+      - name: Install CocoaPods
         script: |
           cd ios/App && pod install --repo-update
 
-      - name: Build unsigned IPA (no signing required for simulator test)
+      - name: Build (simulator – unsigned, no Apple account needed)
         script: |
           xcodebuild \
             -workspace "$XCODE_WORKSPACE" \
@@ -48,9 +60,10 @@ workflows:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            build | xcpretty
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            build | xcpretty --color
 
-      # ── Uncomment this block when you're ready for a real device / TestFlight build ──
+      # ── REAL DEVICE / TESTFLIGHT (uncomment when Apple account is ready) ──
       # - name: Build signed IPA
       #   script: |
       #     xcode-project use-profiles
@@ -59,9 +72,10 @@ workflows:
       #       --scheme "$XCODE_SCHEME"
 
     artifacts:
-      - build/ios/ipa/*.ipa
       - /tmp/xcodebuild_logs/*.log
       - $HOME/Library/Developer/Xcode/DerivedData/**/Build/**/*.app
+      # Signed build artifact (uncomment with signing):
+      # - build/ios/ipa/*.ipa
 
     publishing:
       email:
@@ -70,15 +84,10 @@ workflows:
         notify:
           success: true
           failure: true
-      # Uncomment once signing is set up:
-      # app_store_connect:
-      #   api_key: $APP_STORE_CONNECT_PRIVATE_KEY
-      #   key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
-      #   issuer_id: $APP_STORE_CONNECT_ISSUER_ID
-      #   submit_to_testflight: true
+
 
   # ─────────────────────────────────────────────────────────────────
-  # Android – debug APK
+  # Android – debug APK (no Mac needed)
   # ─────────────────────────────────────────────────────────────────
   android-capacitor:
     name: Pocket Coach – Android
@@ -88,25 +97,34 @@ workflows:
     environment:
       vars:
         PACKAGE_NAME: com.pocketcoach.app
+        CAP_VERSION: "6"
       node: 20
 
     scripts:
       - name: Install JS dependencies
         script: |
-          npm ci || npm install
+          npm install
 
-      - name: Install Capacitor packages (if not in package.json yet)
+      - name: Install Capacitor core + Android
         script: |
-          npm list @capacitor/core >/dev/null 2>&1 || \
-            npm install @capacitor/core @capacitor/cli @capacitor/android
+          npm install \
+            @capacitor/core@^${CAP_VERSION} \
+            @capacitor/cli@^${CAP_VERSION} \
+            @capacitor/android@^${CAP_VERSION}
 
-      - name: Capacitor sync  (copies web assets → android/)
+      - name: Generate Android native project
+        script: |
+          if [ ! -d "android" ]; then
+            npx cap add android
+          fi
+
+      - name: Sync web assets into android/
         script: |
           npx cap sync android
 
       - name: Build debug APK
         script: |
-          cd android && ./gradlew assembleDebug
+          cd android && chmod +x gradlew && ./gradlew assembleDebug
 
     artifacts:
       - android/app/build/outputs/**/*.apk

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -69,12 +69,14 @@ workflows:
 
       - name: Build (simulator – unsigned, no Apple account needed)
         script: |
+          # Use explicit derivedDataPath so we always know where the .app lands
           xcodebuild \
             -workspace "$XCODE_WORKSPACE" \
             -scheme "$XCODE_SCHEME" \
             -configuration Debug \
             -sdk iphonesimulator \
             -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+            -derivedDataPath "$CM_BUILD_DIR/DerivedData" \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
@@ -83,14 +85,14 @@ workflows:
 
       - name: Zip .app for download
         script: |
-          # Find the built .app and zip it into the repo root for easy download
-          APP_PATH=$(find $HOME/Library/Developer/Xcode/DerivedData \
-            -name "App.app" -type d 2>/dev/null | head -1)
+          APP_PATH=$(find "$CM_BUILD_DIR/DerivedData" -name "*.app" -type d 2>/dev/null | head -1)
           echo "Found .app at: $APP_PATH"
           if [ -n "$APP_PATH" ]; then
             zip -r "$CM_BUILD_DIR/PocketCoach.app.zip" "$APP_PATH"
-            echo "Zipped to: $CM_BUILD_DIR/PocketCoach.app.zip"
+            echo "✅ Zipped to: $CM_BUILD_DIR/PocketCoach.app.zip"
           else
+            echo "Contents of DerivedData:"
+            find "$CM_BUILD_DIR/DerivedData" -type d | head -30
             echo "ERROR: .app not found"
             exit 1
           fi

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -76,7 +76,7 @@ workflows:
             -scheme "$XCODE_SCHEME" \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+            -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath "$CM_BUILD_DIR/DerivedData" \
             SYMROOT="$CM_BUILD_DIR/build" \
             CODE_SIGN_IDENTITY="" \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -69,7 +69,8 @@ workflows:
 
       - name: Build (simulator – unsigned, no Apple account needed)
         script: |
-          # Use explicit derivedDataPath so we always know where the .app lands
+          set -o pipefail
+          mkdir -p "$CM_BUILD_DIR/build"
           xcodebuild \
             -workspace "$XCODE_WORKSPACE" \
             -scheme "$XCODE_SCHEME" \
@@ -77,23 +78,29 @@ workflows:
             -sdk iphonesimulator \
             -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
             -derivedDataPath "$CM_BUILD_DIR/DerivedData" \
+            SYMROOT="$CM_BUILD_DIR/build" \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             COMPILER_INDEX_STORE_ENABLE=NO \
-            build | xcpretty --color
+            build 2>&1 | tee /tmp/xcodebuild.log | xcpretty --color
+          echo "--- xcodebuild exit: $?"
 
       - name: Zip .app for download
         script: |
-          APP_PATH=$(find "$CM_BUILD_DIR/DerivedData" -name "*.app" -type d 2>/dev/null | head -1)
+          echo "=== Searching for .app ==="
+          # Search both known locations
+          APP_PATH=$(find "$CM_BUILD_DIR/build" "$CM_BUILD_DIR/DerivedData" \
+            -name "*.app" -type d 2>/dev/null | grep -v "\.xctest" | head -1)
           echo "Found .app at: $APP_PATH"
           if [ -n "$APP_PATH" ]; then
             zip -r "$CM_BUILD_DIR/PocketCoach.app.zip" "$APP_PATH"
-            echo "✅ Zipped to: $CM_BUILD_DIR/PocketCoach.app.zip"
+            echo "✅ Zipped → PocketCoach.app.zip"
           else
-            echo "Contents of DerivedData:"
-            find "$CM_BUILD_DIR/DerivedData" -type d | head -30
-            echo "ERROR: .app not found"
+            echo "=== build tree ==="
+            find "$CM_BUILD_DIR/build" -type d 2>/dev/null | head -40
+            echo "=== last 50 lines of xcodebuild log ==="
+            tail -50 /tmp/xcodebuild.log
             exit 1
           fi
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -81,6 +81,20 @@ workflows:
             COMPILER_INDEX_STORE_ENABLE=NO \
             build | xcpretty --color
 
+      - name: Zip .app for download
+        script: |
+          # Find the built .app and zip it into the repo root for easy download
+          APP_PATH=$(find $HOME/Library/Developer/Xcode/DerivedData \
+            -name "App.app" -type d 2>/dev/null | head -1)
+          echo "Found .app at: $APP_PATH"
+          if [ -n "$APP_PATH" ]; then
+            zip -r "$CM_BUILD_DIR/PocketCoach.app.zip" "$APP_PATH"
+            echo "Zipped to: $CM_BUILD_DIR/PocketCoach.app.zip"
+          else
+            echo "ERROR: .app not found"
+            exit 1
+          fi
+
       # ── REAL DEVICE / TESTFLIGHT (uncomment when Apple account is ready) ──
       # - name: Build signed IPA
       #   script: |
@@ -90,8 +104,8 @@ workflows:
       #       --scheme "$XCODE_SCHEME"
 
     artifacts:
+      - PocketCoach.app.zip
       - /tmp/xcodebuild_logs/*.log
-      - $HOME/Library/Developer/Xcode/DerivedData/**/Build/**/*.app
       # Signed build artifact (uncomment with signing):
       # - build/ios/ipa/*.ipa
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,0 +1,120 @@
+workflows:
+
+  # ─────────────────────────────────────────────────────────────────
+  # iOS – development / TestFlight build
+  # ─────────────────────────────────────────────────────────────────
+  ios-capacitor:
+    name: Pocket Coach – iOS
+    max_build_duration: 60
+    instance_type: mac_mini_m2
+
+    environment:
+      # Uncomment + configure once you have an Apple Developer account
+      # ios_signing:
+      #   distribution_type: app_store          # or development
+      #   bundle_identifier: com.pocketcoach.app
+      vars:
+        XCODE_WORKSPACE: ios/App/App.xcworkspace
+        XCODE_SCHEME: App
+        BUNDLE_ID: com.pocketcoach.app
+      node: 20
+
+    scripts:
+      - name: Install JS dependencies
+        script: |
+          npm ci || npm install
+
+      - name: Install Capacitor packages (if not in package.json yet)
+        script: |
+          npm list @capacitor/core >/dev/null 2>&1 || \
+            npm install @capacitor/core @capacitor/cli @capacitor/ios
+
+      - name: Capacitor sync  (copies web assets → ios/)
+        script: |
+          npx cap sync ios
+
+      - name: Install CocoaPods dependencies
+        script: |
+          cd ios/App && pod install --repo-update
+
+      - name: Build unsigned IPA (no signing required for simulator test)
+        script: |
+          xcodebuild \
+            -workspace "$XCODE_WORKSPACE" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build | xcpretty
+
+      # ── Uncomment this block when you're ready for a real device / TestFlight build ──
+      # - name: Build signed IPA
+      #   script: |
+      #     xcode-project use-profiles
+      #     xcode-project build-ipa \
+      #       --workspace "$XCODE_WORKSPACE" \
+      #       --scheme "$XCODE_SCHEME"
+
+    artifacts:
+      - build/ios/ipa/*.ipa
+      - /tmp/xcodebuild_logs/*.log
+      - $HOME/Library/Developer/Xcode/DerivedData/**/Build/**/*.app
+
+    publishing:
+      email:
+        recipients:
+          - armanbahali@gmail.com
+        notify:
+          success: true
+          failure: true
+      # Uncomment once signing is set up:
+      # app_store_connect:
+      #   api_key: $APP_STORE_CONNECT_PRIVATE_KEY
+      #   key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
+      #   issuer_id: $APP_STORE_CONNECT_ISSUER_ID
+      #   submit_to_testflight: true
+
+  # ─────────────────────────────────────────────────────────────────
+  # Android – debug APK
+  # ─────────────────────────────────────────────────────────────────
+  android-capacitor:
+    name: Pocket Coach – Android
+    max_build_duration: 60
+    instance_type: linux_x2
+
+    environment:
+      vars:
+        PACKAGE_NAME: com.pocketcoach.app
+      node: 20
+
+    scripts:
+      - name: Install JS dependencies
+        script: |
+          npm ci || npm install
+
+      - name: Install Capacitor packages (if not in package.json yet)
+        script: |
+          npm list @capacitor/core >/dev/null 2>&1 || \
+            npm install @capacitor/core @capacitor/cli @capacitor/android
+
+      - name: Capacitor sync  (copies web assets → android/)
+        script: |
+          npx cap sync android
+
+      - name: Build debug APK
+        script: |
+          cd android && ./gradlew assembleDebug
+
+    artifacts:
+      - android/app/build/outputs/**/*.apk
+
+    publishing:
+      email:
+        recipients:
+          - armanbahali@gmail.com
+        notify:
+          success: true
+          failure: true

--- a/community.js
+++ b/community.js
@@ -566,7 +566,7 @@ function renderCompetition(metric = 'workouts') {
         <option value="engagement">Group Activity</option>
       </select>
       <div class="leaderboard">${rows}</div>
-      <canvas id="competitionChart"></canvas>
+      <canvas id="competitionChart" height="200"></canvas>
       <div id="leaderDetails" class="leader-details" style="display:none;"></div>
     </div>`;
 

--- a/community.js
+++ b/community.js
@@ -281,10 +281,10 @@ function loadGroups() {
 }
 
 function doGroupSearch() {
-  const search = document.getElementById('groupSearchInput').value.trim();
-  const goal = document.getElementById('goalFilter').value.trim();
-  const tag = document.getElementById('tagFilter').value.trim();
-  const sort = document.getElementById('sortFilter').value;
+  const search = document.getElementById('groupSearchInput')?.value.trim() ?? '';
+  const goal = document.getElementById('goalFilter')?.value.trim() ?? '';
+  const tag = document.getElementById('tagFilter')?.value.trim() ?? '';
+  const sort = document.getElementById('sortFilter')?.value ?? '';
   const btn = document.getElementById('groupSearchBtn');
   if (btn) btn.classList.add('loading');
   setTimeout(() => {
@@ -296,10 +296,11 @@ function doGroupSearch() {
 }
 
 function clearGroupFilters() {
-  document.getElementById('groupSearchInput').value = '';
-  document.getElementById('goalFilter').value = '';
-  document.getElementById('tagFilter').value = '';
-  document.getElementById('sortFilter').value = '';
+  const _g = id => document.getElementById(id);
+  if (_g('groupSearchInput')) _g('groupSearchInput').value = '';
+  if (_g('goalFilter'))       _g('goalFilter').value = '';
+  if (_g('tagFilter'))        _g('tagFilter').value = '';
+  if (_g('sortFilter'))       _g('sortFilter').value = '';
   renderGroups(sortGroups(groups));
 }
 

--- a/community.js
+++ b/community.js
@@ -474,12 +474,15 @@ function shareProgramInput(id, dataStr) {
 }
 
 function showCreateGroup() {
-  const name = prompt('Group name?');
-  if (!name) return;
-  const goal = prompt('Group goal? (optional)') || '';
-  const tagsStr = prompt('Tags? (comma separated)') || '';
-  const tags = tagsStr ? tagsStr.split(',').map(t => t.trim()).filter(Boolean) : [];
-  createGroup(name, goal, tags).then(() => renderGroups(groups));
+  window.showPrompt('Group name?').then(name => {
+    if (!name) return;
+    window.showPrompt('Group goal? (optional)').then(goal => {
+      window.showPrompt('Tags? (comma separated)').then(tagsStr => {
+        const tags = tagsStr ? tagsStr.split(',').map(t => t.trim()).filter(Boolean) : [];
+        createGroup(name, goal || '', tags).then(() => renderGroups(groups));
+      });
+    });
+  });
 }
 
 // ----- Competition Features -----

--- a/community.js
+++ b/community.js
@@ -78,11 +78,12 @@ async function createGroup(name, goal = '', tags = []) {
   if (typeof fetch !== 'undefined' && window && window.currentUser) {
     try {
       const res = await fetch(`${window.SERVER_URL}/community/groups`, {
-  method: 'POST',
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
-  body: JSON.stringify({ name, creatorId: window.currentUser, goal, tags })
-});
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({ name, creatorId: window.currentUser, goal, tags }),
+        signal: AbortSignal.timeout(5000)
+      });
       const g = normalizeGroup(await res.json());
       groups.push(g);
       saveGroups();
@@ -108,7 +109,8 @@ async function fetchGroups(userId) {
     const res = await fetch(`${window.SERVER_URL}/community/groups?userId=${encodeURIComponent(userId)}`, {
       method: 'GET',
       credentials: 'include',
-      headers: getAuthHeaders()
+      headers: getAuthHeaders(),
+      signal: AbortSignal.timeout(5000)
     });
     if (res.ok) {
       groups = normalizeGroups(await res.json());
@@ -129,7 +131,8 @@ async function searchGroups(opts = {}) {
     const res = await fetch(`${window.SERVER_URL}/community/groups?${params.toString()}`, {
       method: 'GET',
       credentials: 'include',
-      headers: getAuthHeaders()
+      headers: getAuthHeaders(),
+      signal: AbortSignal.timeout(5000)
     });
     if (res.ok) {
       groups = normalizeGroups(await res.json());
@@ -181,7 +184,8 @@ async function fetchPosts(groupId) {
     const res = await fetch(`${window.SERVER_URL}/community/groups/${groupId}/posts`, {
       method: 'GET',
       credentials: 'include',
-      headers: getAuthHeaders()
+      headers: getAuthHeaders(),
+      signal: AbortSignal.timeout(5000)
     });
     if (res.ok) {
       const posts = await res.json();
@@ -206,7 +210,8 @@ async function inviteUserToGroup(groupId, invitedUserId) {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
-      body: JSON.stringify({ invitedUserId })
+      body: JSON.stringify({ invitedUserId }),
+      signal: AbortSignal.timeout(5000)
     });
     if (res.ok) {
       const g = groups.find(gr => gr.id === groupId);
@@ -236,7 +241,8 @@ async function shareProgramToGroup(groupId, programData) {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
-      body: JSON.stringify({ senderId: window.currentUser, programData })
+      body: JSON.stringify({ senderId: window.currentUser, programData }),
+      signal: AbortSignal.timeout(5000)
     });
     if (res.ok) {
       alert('Program shared');
@@ -256,7 +262,8 @@ async function fetchProgress(groupId) {
     const res = await fetch(`${window.SERVER_URL}/community/groups/${groupId}/progress`, {
       method: 'GET',
       credentials: 'include',
-      headers: getAuthHeaders()
+      headers: getAuthHeaders(),
+      signal: AbortSignal.timeout(5000)
     });
     if (res.ok) return await res.json();
   } catch (e) {
@@ -306,7 +313,8 @@ async function addPost(groupId, user, text) {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
-        body: JSON.stringify({ userId: user, text })
+        body: JSON.stringify({ userId: user, text }),
+        signal: AbortSignal.timeout(5000)
       });
     } catch (e) {
       console.warn('addPost failed', e);

--- a/community.js
+++ b/community.js
@@ -505,6 +505,7 @@ function showCommunitySection(section) {
     competition: document.getElementById('competitionPanel'),
     posts:       document.getElementById('postsPanel'),
     feed:        document.getElementById('feedPanel'),
+    share:       document.getElementById('commSharePanel'),
   };
   Object.values(panels).forEach(p => { if (p) p.style.display = 'none'; });
   if (panels[section]) panels[section].style.display = 'block';
@@ -514,6 +515,7 @@ function showCommunitySection(section) {
     groups:      'commNavGroups',
     feed:        'commNavFeed',
     competition: 'commNavCompetition',
+    share:       'commNavShare',
   };
   document.querySelectorAll('.comm-nav-btn').forEach(b => b.classList.remove('active'));
   const activeBtn = document.getElementById(navMap[section]);
@@ -526,6 +528,8 @@ function showCommunitySection(section) {
     renderCompetition();
   } else if (section === 'feed') {
     if (window.renderActivityFeed) renderActivityFeed();
+  } else if (section === 'share') {
+    if (typeof window.renderSharePanel === 'function') window.renderSharePanel();
   }
 }
 

--- a/complianceEngine.js
+++ b/complianceEngine.js
@@ -122,7 +122,8 @@
       return globalScope.fetch(`/api/bodybuilding/compliance-summary/${encodeURIComponent(resolvedUser)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(state || {})
+        body: JSON.stringify(state || {}),
+        signal: AbortSignal.timeout(5000)
       }).then(() => true).catch(() => false);
     } catch (_error) {
       return false;

--- a/css/archetype-features.css
+++ b/css/archetype-features.css
@@ -296,24 +296,27 @@
 }
 
 .attempt-weight-input {
-  width: 80px;
-  padding: 6px 8px;
+  width: 100%;
+  min-width: 72px;
+  padding: 9px 8px;
   margin: 0;
-  font-size: 0.88rem;
+  font-size: 1rem;        /* ≥16px prevents iOS auto-zoom */
   text-align: center;
 }
 
 .attempt-status-btn {
-  padding: 4px 10px;
-  border-radius: 6px;
-  font-size: 0.72rem;
+  padding: 9px 12px;      /* min 44px tap target height */
+  border-radius: 8px;
+  font-size: 0.9rem;
   font-weight: 700;
   border: none;
   cursor: pointer;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.02em;
   box-shadow: none;
   margin: 0;
   white-space: nowrap;
+  min-height: 36px;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .attempt-status-btn.pending  { background: rgba(255,255,255,0.08); color: var(--secondary-text); }
@@ -425,7 +428,7 @@
   width: 110px;
   padding: 8px 10px;
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 1rem;    /* ≥16px prevents iOS auto-zoom */
   text-align: center;
 }
 
@@ -436,4 +439,10 @@
   font-weight: 700;
   margin: 0;
   box-shadow: none;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 }
+.step-save-btn:active { background: var(--primary-dark); }

--- a/css/base.css
+++ b/css/base.css
@@ -19,6 +19,7 @@ body {
   margin: 0;
   width: 100vw;
   min-height: 100vh;
+  min-height: 100dvh; /* dynamic viewport — hides mobile browser chrome */
   overflow-x: hidden;
 }
 
@@ -190,6 +191,7 @@ th {
 #pocketFitContainer {
   width: 100vw;
   min-height: 100vh;
+  min-height: 100dvh; /* dynamic viewport */
   overflow-x: hidden;
   transition: margin-left 0.3s ease;
   margin-left: 0;

--- a/css/base.css
+++ b/css/base.css
@@ -263,3 +263,121 @@ th {
   from { transform: translateY(20px); opacity: 0; }
   to   { transform: translateY(0);    opacity: 1; }
 }
+
+/* ── Native UI — Toast & Modal (native-ui.js) ─────────────────── */
+
+/* Toast */
+#nativeToast {
+  position: fixed;
+  bottom: 80px;          /* above bottom nav */
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  max-width: calc(100vw - 32px);
+  min-width: 220px;
+  background: #1c2e22;
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 14px;
+  padding: 12px 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.88rem;
+  color: var(--text, #e8f5e9);
+  z-index: 9999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s, transform 0.25s;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+}
+
+#nativeToast.native-toast--show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+
+.native-toast--success { border-color: var(--primary, #5fa87e); }
+.native-toast--error   { border-color: #e05060; }
+.native-toast--warn    { border-color: #e6a817; }
+
+.nt-icon { font-size: 1rem; flex-shrink: 0; }
+.nt-msg  { flex: 1; line-height: 1.4; }
+
+/* Modal overlay */
+.nm-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0,0,0,0.65);
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  backdrop-filter: blur(2px);
+}
+
+.nm-dialog {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 18px;
+  padding: 24px 20px 20px;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+}
+
+.nm-body {
+  font-size: 0.95rem;
+  color: var(--text, #e8f5e9);
+  line-height: 1.5;
+  margin: 0 0 20px;
+  text-align: center;
+}
+
+.nm-input {
+  width: 100%;
+  padding: 11px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border, #2a3a2e);
+  background: var(--bg, #0b130d);
+  color: var(--text, #e8f5e9);
+  font-size: 1rem;       /* ≥16px — no iOS auto-zoom */
+  margin-bottom: 16px;
+  box-sizing: border-box;
+  outline: none;
+}
+
+.nm-input:focus { border-color: var(--primary, #5fa87e); }
+
+.nm-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.nm-btn {
+  flex: 1;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border, #2a3a2e);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.nm-btn--cancel {
+  background: transparent;
+  color: var(--text-muted, #7a8f7d);
+}
+
+.nm-btn--confirm {
+  background: var(--primary, #5fa87e);
+  border-color: var(--primary, #5fa87e);
+  color: #0b130d;
+}
+
+.nm-btn--danger {
+  background: #e05060;
+  border-color: #e05060;
+  color: #fff;
+}

--- a/css/cardio.css
+++ b/css/cardio.css
@@ -1,0 +1,329 @@
+/* =============================================================
+   CARDIO TAB
+   Card-based cardio tracker with activity-type pills,
+   live pace/speed preview, weekly summary strip, and
+   grouped history cards.
+   ============================================================= */
+
+/* ── Tab wrapper ────────────────────────────────────────────── */
+#cardioTab {
+  padding: 14px 12px 80px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* ── Weekly summary strip ───────────────────────────────────── */
+.cardio-weekly-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.cardio-stat-chip {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 10px 8px;
+  text-align: center;
+}
+
+.cardio-stat-chip .chip-val {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--primary);
+  line-height: 1.1;
+}
+
+.cardio-stat-chip .chip-lbl {
+  display: block;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  margin-top: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+/* ── Form card ──────────────────────────────────────────────── */
+.cardio-form-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 16px;
+  margin-bottom: 20px;
+}
+
+.cardio-form-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 0 0 14px;
+}
+
+/* ── Activity type pill picker ──────────────────────────────── */
+.cardio-type-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 14px;
+}
+
+.cardio-type-btn {
+  padding: 6px 13px;
+  border-radius: 20px;
+  border: 1.5px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--secondary-text);
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.cardio-type-btn:active {
+  transform: scale(0.95);
+}
+
+.cardio-type-btn.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+  font-weight: 600;
+}
+
+/* ── Custom type input (shown when Other is selected) ───────── */
+.cardio-custom-type-wrap {
+  margin-bottom: 12px;
+}
+
+.cardio-custom-type-wrap input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--text-color);
+  font-size: 1rem;
+}
+
+.cardio-custom-type-wrap input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+/* ── Two-column form rows ───────────────────────────────────── */
+.cardio-form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.cardio-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.cardio-form-field label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.cardio-form-field input {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--text-color);
+  font-size: 1rem;          /* ≥ 16px — prevents iOS auto-zoom */
+  width: 100%;
+  -webkit-appearance: none;
+}
+
+.cardio-form-field input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(45, 125, 91, 0.2);
+}
+
+.cardio-form-field input::placeholder {
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+/* ── Live pace / speed preview ──────────────────────────────── */
+.cardio-pace-preview {
+  background: var(--elevated-bg);
+  border: 1px solid var(--primary);
+  border-radius: 10px;
+  padding: 9px 14px;
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: var(--primary);
+}
+
+.cardio-pace-preview .pace-icon {
+  font-size: 1.1rem;
+}
+
+.cardio-pace-preview .pace-value {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+/* ── Submit button ──────────────────────────────────────────── */
+.cardio-submit-btn {
+  width: 100%;
+  padding: 13px;
+  border-radius: 12px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 6px;
+  transition: background 0.15s, transform 0.1s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.cardio-submit-btn:active {
+  background: var(--primary-dark);
+  transform: scale(0.98);
+}
+
+/* ── History section ────────────────────────────────────────── */
+.cardio-history-section-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--secondary-text);
+  margin: 0 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cardio-history-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  padding: 32px 16px;
+  background: var(--card-bg);
+  border: 1px dashed var(--border-color);
+  border-radius: 14px;
+}
+
+/* ── Day group ──────────────────────────────────────────────── */
+.cardio-day-group {
+  margin-bottom: 18px;
+}
+
+.cardio-day-header {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 4px 4px 8px;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 10px;
+}
+
+/* ── Individual entry card ──────────────────────────────────── */
+.cardio-entry-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--c-accent, var(--primary));
+  border-radius: 12px;
+  padding: 12px 12px 12px 14px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.cardio-entry-icon {
+  font-size: 1.6rem;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.cardio-entry-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.cardio-entry-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin-bottom: 6px;
+  text-transform: capitalize;
+}
+
+.cardio-entry-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.cardio-stat-tag {
+  background: var(--elevated-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 3px 8px;
+  font-size: 0.78rem;
+  color: var(--secondary-text);
+  white-space: nowrap;
+}
+
+.cardio-stat-tag.highlight {
+  color: var(--primary);
+  border-color: rgba(45, 125, 91, 0.4);
+  background: rgba(45, 125, 91, 0.08);
+}
+
+.cardio-entry-notes {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 6px;
+  font-style: italic;
+}
+
+.cardio-remove-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 1rem;
+  cursor: pointer;
+  opacity: 0.45;
+  padding: 4px;
+  border-radius: 6px;
+  color: var(--danger);
+  transition: opacity 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.cardio-remove-btn:hover,
+.cardio-remove-btn:active {
+  opacity: 1;
+}
+
+/* ── Responsive: narrow screens collapse the 4-stat grid ───── */
+@media (max-width: 360px) {
+  .cardio-weekly-strip {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/css/cardio.css
+++ b/css/cardio.css
@@ -54,11 +54,28 @@
   margin-bottom: 20px;
 }
 
+.cardio-form-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
 .cardio-form-title {
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text-color);
-  margin: 0 0 14px;
+  margin: 0;
+}
+
+.cardio-form-date-chip {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--elevated-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 3px 10px;
 }
 
 /* ── Activity type pill picker ──────────────────────────────── */
@@ -98,106 +115,239 @@
   margin-bottom: 12px;
 }
 
-.cardio-custom-type-wrap input {
-  width: 100%;
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--border-color);
-  background: var(--elevated-bg);
-  color: var(--text-color);
-  font-size: 1rem;
+/* ── Section divider label ──────────────────────────────────── */
+.cardio-section-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 8px;
 }
 
-.cardio-custom-type-wrap input:focus {
-  outline: none;
-  border-color: var(--primary);
-}
-
-/* ── Two-column form rows ───────────────────────────────────── */
-.cardio-form-row {
+/* ── Two-column rows ────────────────────────────────────────── */
+.cardio-row-2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 12px;
 }
 
-.cardio-form-field {
+/* ── Field (label + input-wrap) ─────────────────────────────── */
+.cardio-field {
   display: flex;
   flex-direction: column;
   gap: 5px;
 }
 
-.cardio-form-field label {
-  font-size: 0.75rem;
+.cardio-field-label {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   color: var(--text-muted);
-  font-weight: 500;
-  letter-spacing: 0.02em;
 }
 
-.cardio-form-field input {
-  padding: 10px 12px;
-  border-radius: 10px;
+.cardio-opt {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 0.68rem;
+  opacity: 0.75;
+}
+
+/* ── Icon-wrapped input ─────────────────────────────────────── */
+.cardio-input-wrap {
+  display: flex;
+  align-items: center;
   border: 1px solid var(--border-color);
+  border-radius: 10px;
   background: var(--elevated-bg);
+  overflow: hidden;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.cardio-input-wrap:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(45, 125, 91, 0.18);
+}
+
+.cardio-input-icon {
+  flex-shrink: 0;
+  width: 36px;
+  text-align: center;
+  font-size: 0.95rem;
+  line-height: 1;
+  color: var(--text-muted);
+  pointer-events: none;
+  user-select: none;
+}
+
+.cardio-input-wrap input {
+  flex: 1;
+  min-width: 0;
+  padding: 10px 6px;
+  border: none;
+  background: transparent;
   color: var(--text-color);
   font-size: 1rem;          /* ≥ 16px — prevents iOS auto-zoom */
-  width: 100%;
+  font-family: inherit;
   -webkit-appearance: none;
 }
 
-.cardio-form-field input:focus {
-  outline: none;
-  border-color: var(--primary);
-  box-shadow: 0 0 0 2px rgba(45, 125, 91, 0.2);
+.cardio-input-wrap input:focus { outline: none; }
+
+.cardio-input-wrap input::placeholder {
+  color: var(--text-muted);
+  opacity: 0.6;
 }
 
-.cardio-form-field input::placeholder {
+.cardio-input-unit {
+  flex-shrink: 0;
+  padding: 0 10px 0 2px;
+  font-size: 0.75rem;
+  font-weight: 600;
   color: var(--text-muted);
-  opacity: 0.7;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* date inputs need right padding */
+.cardio-input-wrap input[type="date"] {
+  padding-right: 10px;
+}
+
+/* ── Intensity / effort pill row ────────────────────────────── */
+.cardio-intensity-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.cardio-intensity-btn {
+  flex: 1;
+  min-width: 64px;
+  padding: 8px 6px;
+  border-radius: 10px;
+  border: 1.5px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--secondary-text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.15s;
+  white-space: nowrap;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.cardio-intensity-btn:active { transform: scale(0.96); }
+
+.cardio-intensity-btn[data-intensity="easy"].active    { background: rgba(82,214,138,0.15);  border-color: #52d68a; color: #52d68a; }
+.cardio-intensity-btn[data-intensity="moderate"].active{ background: rgba(45,125,91,0.15);   border-color: var(--primary); color: var(--primary); }
+.cardio-intensity-btn[data-intensity="hard"].active    { background: rgba(240,160,64,0.15);  border-color: #f0a040; color: #f0a040; }
+.cardio-intensity-btn[data-intensity="max"].active     { background: rgba(224,80,80,0.15);   border-color: #e05050; color: #e05050; }
+
+/* ── "More options" collapsible ─────────────────────────────── */
+.cardio-optional {
+  margin-bottom: 14px;
+}
+
+.cardio-optional-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--elevated-bg);
+  cursor: pointer;
+  list-style: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.12s;
+}
+
+.cardio-optional-toggle::-webkit-details-marker { display: none; }
+.cardio-optional[open] .cardio-optional-toggle  { border-radius: 10px 10px 0 0; border-bottom-color: transparent; }
+.cardio-optional-toggle:active { background: rgba(45,125,91,0.08); }
+
+.cardio-optional-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--secondary-text);
+}
+
+.cardio-optional-arrow {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  transition: transform 0.2s;
+  line-height: 1;
+}
+
+.cardio-optional[open] .cardio-optional-arrow { transform: rotate(90deg); }
+
+.cardio-optional-body {
+  border: 1px solid var(--border-color);
+  border-top: none;
+  border-radius: 0 0 10px 10px;
+  padding: 12px 12px 4px;
+  background: var(--elevated-bg);
 }
 
 /* ── Live pace / speed preview ──────────────────────────────── */
 .cardio-pace-preview {
-  background: var(--elevated-bg);
-  border: 1px solid var(--primary);
+  background: rgba(45,125,91,0.07);
+  border: 1px solid rgba(45,125,91,0.3);
   border-radius: 10px;
-  padding: 9px 14px;
-  margin-bottom: 10px;
+  padding: 10px 14px;
+  margin-bottom: 12px;
   display: flex;
   align-items: center;
   gap: 10px;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   color: var(--primary);
+  animation: cardio-fadein 0.2s ease;
 }
 
-.cardio-pace-preview .pace-icon {
-  font-size: 1.1rem;
+@keyframes cardio-fadein {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
+
+.cardio-pace-preview .pace-icon { font-size: 1.05rem; }
 
 .cardio-pace-preview .pace-value {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 0.95rem;
 }
 
 /* ── Submit button ──────────────────────────────────────────── */
 .cardio-submit-btn {
   width: 100%;
-  padding: 13px;
+  padding: 14px;
   border-radius: 12px;
   border: none;
   background: var(--primary);
   color: #fff;
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  margin-top: 6px;
-  transition: background 0.15s, transform 0.1s;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  letter-spacing: 0.02em;
+  transition: background 0.15s, transform 0.1s, box-shadow 0.15s;
+  box-shadow: 0 2px 8px rgba(45,125,91,0.25);
   -webkit-tap-highlight-color: transparent;
 }
 
 .cardio-submit-btn:active {
   background: var(--primary-dark);
   transform: scale(0.98);
+  box-shadow: none;
 }
 
 /* ── History section ────────────────────────────────────────── */
@@ -321,9 +471,9 @@
   opacity: 1;
 }
 
-/* ── Responsive: narrow screens collapse the 4-stat grid ───── */
+/* ── Responsive: narrow screens ────────────────────────────── */
 @media (max-width: 360px) {
-  .cardio-weekly-strip {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  .cardio-weekly-strip { grid-template-columns: repeat(2, 1fr); }
+  .cardio-row-2        { grid-template-columns: 1fr; }
+  .cardio-intensity-btn { font-size: 0.72rem; padding: 7px 4px; }
 }

--- a/css/checkin.css
+++ b/css/checkin.css
@@ -1,0 +1,530 @@
+/* =============================================================
+   CHECK-IN TAB  (ci-* namespace)
+   Modern sub-tabbed weekly check-in with cards, sliders,
+   adjustment toggles, and timeline history cards.
+   ============================================================= */
+
+/* ── Tab wrapper ────────────────────────────────────────────── */
+#checkInTab {
+  padding: 0 0 80px;
+  max-width: 620px;
+  margin: 0 auto;
+}
+
+/* ── Sub-tab nav strip ──────────────────────────────────────── */
+.ci-nav {
+  display: flex;
+  gap: 4px;
+  padding: 10px 12px 0;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--surface-bg);
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.ci-nav::-webkit-scrollbar { display: none; }
+
+.ci-nav-btn {
+  flex-shrink: 0;
+  padding: 8px 16px 10px;
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+  -webkit-tap-highlight-color: transparent;
+  margin-bottom: -1px; /* overlap the border-bottom of .ci-nav */
+}
+
+.ci-nav-btn.active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+}
+
+/* ── Phase banner ───────────────────────────────────────────── */
+.ci-phase-banner {
+  margin: 14px 12px 0;
+  padding: 10px 14px;
+  background: linear-gradient(135deg, rgba(45,125,91,0.15), rgba(45,125,91,0.06));
+  border: 1px solid rgba(45,125,91,0.3);
+  border-radius: 12px;
+  font-size: 0.82rem;
+  color: var(--primary);
+  font-weight: 500;
+}
+
+/* ── Panel (each sub-tab content area) ──────────────────────── */
+.ci-panel {
+  padding: 12px;
+}
+
+/* ── Card container ─────────────────────────────────────────── */
+.ci-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 16px;
+  margin-bottom: 12px;
+}
+
+.ci-card-title {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--text-color);
+  margin: 0 0 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ci-card-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: -8px 0 12px;
+  line-height: 1.5;
+}
+
+/* ── Field rows ─────────────────────────────────────────────── */
+.ci-row-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.ci-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.ci-field label {
+  font-size: 0.73rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.ci-opt {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 0.7rem;
+}
+
+.ci-field input,
+.ci-field select,
+.ci-field textarea {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--text-color);
+  font-size: 1rem;           /* ≥ 16px – prevents iOS auto-zoom */
+  width: 100%;
+  -webkit-appearance: none;
+  font-family: inherit;
+}
+
+.ci-field input:focus,
+.ci-field select:focus,
+.ci-field textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(45,125,91,0.2);
+}
+
+.ci-field input::placeholder,
+.ci-field textarea::placeholder {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.ci-field textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+/* full-width field variant */
+.ci-field-full {
+  margin-bottom: 10px;
+}
+
+/* ── Sliders ────────────────────────────────────────────────── */
+/* Keep existing .checkin-slider-* class names for JS compat;
+   override / enhance visuals here */
+
+.checkin-slider-field {
+  margin-bottom: 14px;
+}
+.checkin-slider-field:last-child { margin-bottom: 0; }
+
+.checkin-slider-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.checkin-slider-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.checkin-slider-value {
+  min-width: 32px;
+  text-align: center;
+  padding: 2px 8px;
+  border-radius: 20px;
+  background: var(--primary);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  transition: background 0.2s;
+}
+
+/* color-code slider value badge */
+.checkin-slider-value[data-score-low]   { background: #c62828; }
+.checkin-slider-value[data-score-mid]   { background: #e65100; }
+.checkin-slider-value[data-score-high]  { background: var(--primary); }
+
+.checkin-slider-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-top: 3px;
+}
+
+/* ── Adjustment toggle rows ─────────────────────────────────── */
+.ci-adjust-row {
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+.ci-adjust-row:last-of-type { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
+
+.ci-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  padding: 6px 0;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Hide the native checkbox */
+.ci-toggle-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Custom toggle track */
+.ci-toggle-track {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  flex-shrink: 0;
+  background: var(--elevated-bg);
+  border: 1.5px solid var(--border-color);
+  border-radius: 11px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.ci-toggle-track::after {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: left 0.2s, background 0.2s;
+}
+
+.ci-toggle-input:checked + .ci-toggle-track {
+  background: rgba(45,125,91,0.25);
+  border-color: var(--primary);
+}
+.ci-toggle-input:checked + .ci-toggle-track::after {
+  left: 20px;
+  background: var(--primary);
+}
+
+.ci-toggle-text {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.ci-adjust-notes {
+  display: block;
+  width: 100%;
+  margin-top: 8px;
+  padding: 9px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--text-color);
+  font-size: 1rem;
+  font-family: inherit;
+}
+.ci-adjust-notes:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+.ci-adjust-notes::placeholder { color: var(--text-muted); opacity: 0.6; }
+
+/* ── Save / action buttons ──────────────────────────────────── */
+.ci-save-btn {
+  width: 100%;
+  padding: 14px;
+  border-radius: 12px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  margin-top: 4px;
+  margin-bottom: 8px;
+  transition: background 0.15s, transform 0.1s;
+  -webkit-tap-highlight-color: transparent;
+}
+.ci-save-btn:active {
+  background: var(--primary-dark);
+  transform: scale(0.98);
+}
+
+.ci-sec-btn {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1.5px solid var(--primary);
+  background: transparent;
+  color: var(--primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+.ci-sec-btn:active { background: rgba(45,125,91,0.12); }
+
+.ci-btn-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+/* ── Summary output card ────────────────────────────────────── */
+.ci-summary-output {
+  background: var(--elevated-bg);
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 0.85rem;
+  color: var(--secondary-text);
+  line-height: 1.6;
+  margin-bottom: 10px;
+  min-height: 52px;
+}
+.ci-summary-output strong { color: var(--primary); }
+
+/* ── Photos grid ────────────────────────────────────────────── */
+.ci-photo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.ci-photo-slot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.ci-photo-slot label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.ci-photo-preview {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  border-radius: 10px;
+  border: 2px dashed var(--border-color);
+  background: var(--elevated-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+  cursor: pointer;
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+.ci-photo-preview:active { border-color: var(--primary); }
+.ci-photo-preview.has-photo {
+  border-style: solid;
+  border-color: var(--primary);
+}
+.ci-photo-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ── Timeline cards ─────────────────────────────────────────── */
+.ci-timeline-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  padding: 32px 16px;
+  background: var(--card-bg);
+  border: 1px dashed var(--border-color);
+  border-radius: 14px;
+}
+
+.ci-timeline-group {
+  margin-bottom: 20px;
+}
+
+.ci-timeline-group-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 0 2px 8px;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 10px;
+}
+
+.ci-tc {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--ci-status-color, var(--primary));
+  border-radius: 12px;
+  padding: 14px;
+  margin-bottom: 8px;
+}
+
+/* Status colours for left border */
+.ci-tc[data-status="approved"]       { --ci-status-color: #2e7d55; }
+.ci-tc[data-status="reviewed"]       { --ci-status-color: #3a8fc9; }
+.ci-tc[data-status="needs_changes"]  { --ci-status-color: #e07c30; }
+.ci-tc[data-status="pending"]        { --ci-status-color: #636e72; }
+
+.ci-tc-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.ci-tc-date {
+  font-weight: 700;
+  font-size: 0.92rem;
+  color: var(--text-color);
+}
+
+.ci-tc-badge {
+  padding: 2px 8px;
+  border-radius: 20px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background: var(--elevated-bg);
+  color: var(--secondary-text);
+}
+
+.ci-tc-status-badge {
+  padding: 2px 8px;
+  border-radius: 20px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  margin-left: auto;
+}
+.ci-tc-status-badge.approved      { background: rgba(46,125,85,0.15); color: #52d68a; }
+.ci-tc-status-badge.reviewed      { background: rgba(58,143,201,0.15); color: #67b4e8; }
+.ci-tc-status-badge.needs_changes { background: rgba(224,124,48,0.15); color: #f0a060; }
+.ci-tc-status-badge.pending       { background: rgba(99,110,114,0.15); color: #9eabb0; }
+
+.ci-tc-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.ci-tc-stat {
+  padding: 4px 9px;
+  border-radius: 8px;
+  background: var(--elevated-bg);
+  border: 1px solid var(--border-color);
+  font-size: 0.78rem;
+  color: var(--secondary-text);
+  white-space: nowrap;
+}
+.ci-tc-stat.good   { color: #52d68a; border-color: rgba(82,214,138,0.3);  background: rgba(82,214,138,0.07);  }
+.ci-tc-stat.mid    { color: #f0c060; border-color: rgba(240,192,96,0.3);  background: rgba(240,192,96,0.07);  }
+.ci-tc-stat.poor   { color: #f07070; border-color: rgba(240,112,112,0.3); background: rgba(240,112,112,0.07); }
+
+.ci-tc-archetype {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  line-height: 1.5;
+}
+
+.ci-tc-insight {
+  font-size: 0.8rem;
+  color: var(--secondary-text);
+  background: rgba(45,125,91,0.08);
+  border-left: 3px solid var(--primary);
+  border-radius: 0 8px 8px 0;
+  padding: 6px 10px;
+  margin-bottom: 6px;
+  line-height: 1.5;
+}
+
+.ci-tc-adjust {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.ci-tc-notes {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.ci-tc-coach {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--border-color);
+}
+
+/* ── Narrow screens ─────────────────────────────────────────── */
+@media (max-width: 380px) {
+  .ci-nav-btn { padding: 8px 12px 10px; font-size: 0.78rem; }
+  .ci-row-2   { grid-template-columns: 1fr; }
+}

--- a/css/community-share.css
+++ b/css/community-share.css
@@ -1,0 +1,356 @@
+/* =============================================================
+   COMMUNITY SHARE PANEL  (comm-share-* / comm-inbox-* namespace)
+   Peer-to-peer program & template sharing inside the
+   Community tab.
+   ============================================================= */
+
+/* ── Panel wrapper ──────────────────────────────────────────── */
+#commSharePanel {
+  padding: 12px 12px 80px;
+}
+
+/* ── Section card ───────────────────────────────────────────── */
+.comm-share-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 16px;
+  margin-bottom: 12px;
+}
+
+.comm-share-card-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text-color);
+  margin: 0 0 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* ── Mode toggle (To a User / To a Group) ───────────────────── */
+.comm-share-mode-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.comm-share-mode-btn {
+  flex: 1;
+  padding: 9px 6px;
+  border-radius: 10px;
+  border: 1.5px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--secondary-text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.comm-share-mode-btn.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+/* ── Type tabs (Templates / Programs) ───────────────────────── */
+.comm-share-type-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.comm-share-type-btn {
+  flex: 1;
+  padding: 7px;
+  border-radius: 8px;
+  border: 1.5px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--secondary-text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.comm-share-type-btn.active {
+  background: rgba(45,125,91,0.15);
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+/* ── Field (label + input) ──────────────────────────────────── */
+.comm-share-field {
+  margin-bottom: 10px;
+}
+
+.comm-share-field label {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+  margin-bottom: 5px;
+}
+
+.comm-share-field input,
+.comm-share-field select,
+.comm-share-field textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--text-color);
+  font-size: 1rem;
+  font-family: inherit;
+  -webkit-appearance: none;
+}
+
+.comm-share-field input:focus,
+.comm-share-field select:focus,
+.comm-share-field textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(45,125,91,0.18);
+}
+
+.comm-share-field input::placeholder,
+.comm-share-field textarea::placeholder { color: var(--text-muted); opacity: 0.6; }
+.comm-share-field textarea { min-height: 60px; resize: vertical; }
+
+/* ── Selectable item list ───────────────────────────────────── */
+.comm-share-item-list {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+  max-height: 230px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.comm-share-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-color);
+  transition: background 0.12s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.comm-share-item:last-child { border-bottom: none; }
+.comm-share-item:active     { background: rgba(45,125,91,0.08); }
+
+.comm-share-item.selected {
+  background: rgba(45,125,91,0.1);
+}
+
+.comm-share-item-check {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  color: transparent;
+  transition: all 0.15s;
+}
+
+.comm-share-item.selected .comm-share-item-check {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.comm-share-item-info { flex: 1; min-width: 0; }
+
+.comm-share-item-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.comm-share-item-desc {
+  font-size: 0.74rem;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+/* ── Empty state ────────────────────────────────────────────── */
+.comm-share-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding: 24px 16px;
+  line-height: 1.6;
+}
+
+/* ── Send button ────────────────────────────────────────────── */
+.comm-share-send-btn {
+  width: 100%;
+  padding: 13px;
+  border-radius: 12px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  margin-top: 2px;
+  transition: background 0.15s, transform 0.1s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.comm-share-send-btn:active {
+  background: var(--primary-dark);
+  transform: scale(0.98);
+}
+
+/* ── Inbox items (received) ─────────────────────────────────── */
+.comm-inbox-item {
+  background: var(--elevated-bg);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--primary);
+  border-radius: 12px;
+  padding: 13px;
+  margin-bottom: 8px;
+}
+
+.comm-inbox-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.comm-inbox-from {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.comm-inbox-type-badge {
+  padding: 2px 8px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.comm-inbox-date {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+.comm-inbox-item-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--primary);
+  margin-bottom: 4px;
+}
+
+.comm-inbox-message {
+  font-size: 0.8rem;
+  color: var(--secondary-text);
+  font-style: italic;
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.comm-inbox-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.comm-inbox-accept-btn {
+  flex: 1;
+  padding: 9px;
+  border-radius: 8px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  font-size: 0.84rem;
+  font-weight: 600;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s;
+}
+.comm-inbox-accept-btn:active { background: var(--primary-dark); }
+
+.comm-inbox-dismiss-btn {
+  padding: 9px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* ── Sent history items ─────────────────────────────────────── */
+.comm-outbox-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--elevated-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  margin-bottom: 6px;
+}
+
+.comm-outbox-to { flex: 1; min-width: 0; }
+
+.comm-outbox-to-name {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--text-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.comm-outbox-to-desc {
+  font-size: 0.74rem;
+  color: var(--text-muted);
+  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.comm-outbox-date {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+/* ── Inbox badge on nav button ──────────────────────────────── */
+.comm-nav-badge {
+  display: inline-block;
+  background: var(--danger);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 10px;
+  padding: 1px 5px;
+  margin-left: 3px;
+  vertical-align: middle;
+  line-height: 1.4;
+}

--- a/css/home.css
+++ b/css/home.css
@@ -689,3 +689,81 @@
   border-radius: 50%;
   background: var(--primary, #5fa87e);
 }
+
+/* ── Vacation Mode card (session-context.js) ──────────────────── */
+
+.vm-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 16px;
+  padding: 14px 16px;
+  margin: 0 0 10px;
+  transition: border-color 0.2s;
+}
+
+.vm-card--active {
+  border-color: #e6a817;
+  background: rgba(230, 168, 23, 0.06);
+}
+
+.vm-card-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.vm-icon { font-size: 1.5rem; }
+
+.vm-title {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text, #e8f5e9);
+}
+
+.vm-sub {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--text-muted, #7a8f7d);
+  margin-top: 2px;
+}
+
+.vm-toggle {
+  flex-shrink: 0;
+  padding: 7px 16px;
+  border-radius: 20px;
+  border: 1px solid var(--border, #2a3a2e);
+  background: transparent;
+  color: var(--text, #e8f5e9);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.vm-toggle--on {
+  background: rgba(230, 168, 23, 0.15);
+  border-color: #e6a817;
+  color: #e6a817;
+}
+
+/* Active vacation banner (top of home tab) */
+#vacationModeBanner {
+  display: none;
+  align-items: center;
+  gap: 10px;
+  background: rgba(230, 168, 23, 0.1);
+  border: 1px solid #e6a817;
+  border-radius: 12px;
+  padding: 10px 14px;
+  margin: 0 0 10px;
+  font-size: 0.82rem;
+  color: #e6a817;
+}
+
+#vacationModeBanner .vm-banner-icon { font-size: 1.1rem; }
+#vacationModeBanner .vm-since { margin-left: auto; opacity: 0.7; font-size: 0.72rem; }

--- a/css/home.css
+++ b/css/home.css
@@ -575,3 +575,117 @@
   from { width: 0%; }
   to   { width: var(--fill-target, 0%); }
 }
+
+/* ── Today's Program Card (today-program.js) ──────────────────── */
+
+.tpc-card {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 16px;
+  padding: 14px 16px 12px;
+  margin: 0 0 10px;
+}
+
+.tpc-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.tpc-eyebrow {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--primary, #5fa87e);
+}
+
+.tpc-week-badge {
+  font-size: 0.72rem;
+  color: var(--text-muted, #7a8f7d);
+  background: var(--bg, #0b130d);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 20px;
+  padding: 2px 10px;
+}
+
+.tpc-main {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.tpc-day-name {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: var(--text, #e8f5e9);
+  line-height: 1.1;
+}
+
+.tpc-day-name--rest {
+  color: var(--text-muted, #7a8f7d);
+}
+
+.tpc-program-name {
+  font-size: 0.78rem;
+  color: var(--text-muted, #7a8f7d);
+}
+
+/* Weekly split strip */
+.tpc-strip {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+
+.tpc-split-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 6px 2px 9px;
+  border-radius: 10px;
+  background: var(--bg, #0b130d);
+  border: 1px solid transparent;
+  position: relative;
+  transition: border-color 0.2s;
+}
+
+.tpc-split-cell--today {
+  border-color: var(--primary, #5fa87e);
+  background: rgba(95, 168, 126, 0.1);
+}
+
+.tpc-split-cell--rest {
+  opacity: 0.4;
+}
+
+.tpc-split-cell--done .tpc-split-name {
+  color: var(--primary, #5fa87e);
+}
+
+.tpc-split-abbr {
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--text-muted, #7a8f7d);
+  text-transform: uppercase;
+}
+
+.tpc-split-name {
+  font-size: 0.58rem;
+  color: var(--text, #e8f5e9);
+  text-align: center;
+  line-height: 1.2;
+  word-break: break-word;
+}
+
+.tpc-split-dot {
+  position: absolute;
+  bottom: 3px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--primary, #5fa87e);
+}

--- a/css/log.css
+++ b/css/log.css
@@ -180,3 +180,72 @@
     gap: 8px;
   }
 }
+
+/* ── Session Context Bar (alt-machine / alt-gym) ──────────────── */
+
+#sessionContextBar {
+  margin: 0 0 10px;
+}
+
+.scb-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.scb-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--border, #2a3a2e);
+  background: var(--card-bg, #0f1510);
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.scb-chip--on {
+  border-color: var(--primary, #5fa87e);
+  background: rgba(95, 168, 126, 0.12);
+  color: var(--primary, #5fa87e);
+}
+
+.scb-chip-icon { font-size: 0.9rem; }
+
+.scb-chip-badge {
+  font-size: 0.62rem;
+  font-weight: 700;
+  background: var(--primary, #5fa87e);
+  color: #0b130d;
+  border-radius: 6px;
+  padding: 1px 5px;
+  margin-left: 2px;
+}
+
+.scb-gym-input {
+  flex: 1;
+  min-width: 130px;
+  max-width: 220px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--primary, #5fa87e);
+  background: var(--card-bg, #0f1510);
+  color: var(--text, #e8f5e9);
+  font-size: 0.78rem;
+  outline: none;
+}
+
+.scb-note {
+  margin: 6px 0 0;
+  font-size: 0.72rem;
+  color: #e6a817;
+  padding: 6px 10px;
+  background: rgba(230, 168, 23, 0.07);
+  border-radius: 8px;
+  border: 1px solid rgba(230, 168, 23, 0.25);
+}

--- a/dailyMissionEngine.js
+++ b/dailyMissionEngine.js
@@ -157,7 +157,8 @@
       return globalScope.fetch(`/api/bodybuilding/daily-mission/${encodeURIComponent(resolvedUser)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(state || {})
+        body: JSON.stringify(state || {}),
+        signal: AbortSignal.timeout(5000)
       }).then(() => true).catch(() => false);
     } catch (_error) {
       return false;

--- a/gamification.js
+++ b/gamification.js
@@ -210,7 +210,8 @@
       return globalScope.fetch(`/api/bodybuilding/gamification/${encodeURIComponent(resolvedUser)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(state || defaultState(resolvedUser))
+        body: JSON.stringify(state || defaultState(resolvedUser)),
+        signal: AbortSignal.timeout(5000)
       }).then(() => true).catch(() => false);
     } catch (_error) {
       return false;

--- a/goals.js
+++ b/goals.js
@@ -189,7 +189,8 @@ async function syncGoalsToBackend(user, goals, options = {}) {
         'Content-Type': 'application/json',
         Authorization: options?.token ? `Bearer ${options.token}` : ''
       },
-      body: JSON.stringify({ user, goals })
+      body: JSON.stringify({ user, goals }),
+      signal: AbortSignal.timeout(5000)
     });
     return { skipped: false, ok: response.ok };
   } catch (error) {

--- a/history.js
+++ b/history.js
@@ -234,7 +234,8 @@ export async function syncWorkoutToBackend(workout) {
         ...getAuthHeaders()
       },
       credentials: 'include',
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(5000)
     });
 
     const data = await res.json().catch(() => null);
@@ -288,7 +289,8 @@ async function fetchWorkoutHistoryResponse(username) {
     headers: {
       ...authHeaders,
       Authorization: `Bearer ${token}`
-    }
+    },
+    signal: AbortSignal.timeout(5000)
   });
 
   return { response, url, hasAuth };

--- a/index.html
+++ b/index.html
@@ -24,6 +24,18 @@
   <link rel="stylesheet" href="css/ui-declutter.css">
   <link rel="stylesheet" href="css/features.css">
   <link rel="manifest" href="/manifest.json">
+  <!-- iOS PWA / Capacitor meta tags -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="Pocket Coach">
+  <link rel="apple-touch-icon" href="/public/icons/icon-180.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/public/icons/icon-152.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="/public/icons/icon-144.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="/public/icons/icon-128.png">
+  <link rel="apple-touch-icon" sizes="76x76" href="/public/icons/icon-96.png">
+  <!-- Favicon -->
+  <link rel="icon" type="image/png" sizes="32x32" href="/public/icons/favicon-32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/public/icons/favicon-16.png">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
 </head>

--- a/index.html
+++ b/index.html
@@ -1408,7 +1408,10 @@
 
     <!-- Log form -->
     <div class="cardio-form-card">
-      <h3 class="cardio-form-title">🏃 Log Cardio</h3>
+      <div class="cardio-form-header">
+        <h3 class="cardio-form-title">Log Cardio</h3>
+        <span class="cardio-form-date-chip" id="cardioDateChip"></span>
+      </div>
 
       <!-- Activity type pills -->
       <div class="cardio-type-picker" id="cardioTypePicker">
@@ -1426,21 +1429,33 @@
       <input type="hidden" id="cardioType" value="run">
       <!-- Custom type text input, shown only when "Other" is active -->
       <div class="cardio-custom-type-wrap" id="cardioCustomTypeWrap" style="display:none">
-        <input type="text" id="cardioCustomType" placeholder="Describe activity…"
-               oninput="document.getElementById('cardioType').value = this.value.trim() || 'other'">
+        <div class="cardio-input-wrap">
+          <span class="cardio-input-icon">✏️</span>
+          <input type="text" id="cardioCustomType" placeholder="Describe activity…"
+                 oninput="document.getElementById('cardioType').value = this.value.trim() || 'other'">
+        </div>
       </div>
 
-      <!-- Duration + Distance -->
-      <div class="cardio-form-row">
-        <div class="cardio-form-field">
-          <label for="cardioDuration">Duration (min)</label>
-          <input type="number" id="cardioDuration" placeholder="30" min="1"
-                 oninput="updateCardioPacePreview()">
+      <!-- Core metrics: Duration + Distance -->
+      <div class="cardio-section-label">Core Metrics</div>
+      <div class="cardio-row-2">
+        <div class="cardio-field">
+          <label class="cardio-field-label" for="cardioDuration">Duration</label>
+          <div class="cardio-input-wrap">
+            <span class="cardio-input-icon">⏱</span>
+            <input type="number" id="cardioDuration" placeholder="30" min="1" inputmode="decimal"
+                   oninput="updateCardioPacePreview()">
+            <span class="cardio-input-unit">min</span>
+          </div>
         </div>
-        <div class="cardio-form-field">
-          <label for="cardioDistance">Distance (km)</label>
-          <input type="number" id="cardioDistance" placeholder="optional" step="0.1" min="0"
-                 oninput="updateCardioPacePreview()">
+        <div class="cardio-field">
+          <label class="cardio-field-label" for="cardioDistance">Distance <span class="cardio-opt">optional</span></label>
+          <div class="cardio-input-wrap">
+            <span class="cardio-input-icon">📍</span>
+            <input type="number" id="cardioDistance" placeholder="—" step="0.1" min="0" inputmode="decimal"
+                   oninput="updateCardioPacePreview()">
+            <span class="cardio-input-unit">km</span>
+          </div>
         </div>
       </div>
 
@@ -1450,19 +1465,69 @@
         <span class="pace-value" id="cardioPaceValue"></span>
       </div>
 
-      <!-- Calories (optional) + Notes -->
-      <div class="cardio-form-row">
-        <div class="cardio-form-field">
-          <label for="cardioCalories">Calories (optional)</label>
-          <input type="number" id="cardioCalories" placeholder="auto-estimated" min="0">
+      <!-- Effort level -->
+      <div class="cardio-field" style="margin-bottom:14px;">
+        <label class="cardio-field-label">Effort level</label>
+        <div class="cardio-intensity-row" id="cardioIntensityPicker">
+          <button class="cardio-intensity-btn" data-intensity="easy"     onclick="selectCardioIntensity('easy')">😌 Easy</button>
+          <button class="cardio-intensity-btn active" data-intensity="moderate" onclick="selectCardioIntensity('moderate')">💪 Moderate</button>
+          <button class="cardio-intensity-btn" data-intensity="hard"     onclick="selectCardioIntensity('hard')">🔥 Hard</button>
+          <button class="cardio-intensity-btn" data-intensity="max"      onclick="selectCardioIntensity('max')">⚡ Max</button>
         </div>
-        <div class="cardio-form-field">
-          <label for="cardioNotes">Notes</label>
-          <input type="text" id="cardioNotes" placeholder="e.g. morning run">
-        </div>
+        <input type="hidden" id="cardioIntensity" value="moderate">
       </div>
 
-      <button class="cardio-submit-btn" onclick="addCardioEntry()">➕ Add Session</button>
+      <!-- Optional fields accordion -->
+      <details class="cardio-optional" id="cardioOptional">
+        <summary class="cardio-optional-toggle">
+          <span class="cardio-optional-label">More options</span>
+          <span class="cardio-optional-arrow">›</span>
+        </summary>
+        <div class="cardio-optional-body">
+
+          <div class="cardio-section-label" style="margin-top:4px;">Performance</div>
+          <div class="cardio-row-2">
+            <div class="cardio-field">
+              <label class="cardio-field-label" for="cardioCalories">Calories <span class="cardio-opt">override</span></label>
+              <div class="cardio-input-wrap">
+                <span class="cardio-input-icon">🔥</span>
+                <input type="number" id="cardioCalories" placeholder="auto" min="0" inputmode="decimal">
+                <span class="cardio-input-unit">kcal</span>
+              </div>
+            </div>
+            <div class="cardio-field">
+              <label class="cardio-field-label" for="cardioHeartRate">Avg heart rate <span class="cardio-opt">optional</span></label>
+              <div class="cardio-input-wrap">
+                <span class="cardio-input-icon">❤️</span>
+                <input type="number" id="cardioHeartRate" placeholder="—" min="40" max="230" inputmode="numeric">
+                <span class="cardio-input-unit">bpm</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="cardio-row-2">
+            <div class="cardio-field">
+              <label class="cardio-field-label" for="cardioDate">Date</label>
+              <div class="cardio-input-wrap">
+                <span class="cardio-input-icon">📅</span>
+                <input type="date" id="cardioDate">
+              </div>
+            </div>
+            <div class="cardio-field">
+              <label class="cardio-field-label" for="cardioNotes">Notes</label>
+              <div class="cardio-input-wrap">
+                <span class="cardio-input-icon">📝</span>
+                <input type="text" id="cardioNotes" placeholder="e.g. felt great">
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </details>
+
+      <button class="cardio-submit-btn" onclick="addCardioEntry()">
+        <span id="cardioSubmitIcon">🏃</span> Log Session
+      </button>
     </div>
 
     <!-- History list (populated by renderCardio) -->
@@ -2494,6 +2559,7 @@ async function startLogin() {
       renderMacroTargets({ useFallback: !fetchedTargets });
       renderWeights();
       renderCardio();
+      initCardioDateChip?.();
       renderPosingTab();
       renderCrossfitWorkouts();
       loadTemplateDropdown(); // ✅ Load saved templates
@@ -9494,7 +9560,29 @@ function selectCardioType(type) {
       if (customInput) customInput.value = '';
     }
   }
+  // Update submit button icon to match selected activity
+  const cfg = window.cardioTab?.getActivityConfig?.(type);
+  const iconEl = document.getElementById('cardioSubmitIcon');
+  if (iconEl && cfg?.icon) iconEl.textContent = cfg.icon;
   updateCardioPacePreview();
+}
+
+function selectCardioIntensity(level) {
+  document.getElementById('cardioIntensity').value = level;
+  document.querySelectorAll('#cardioIntensityPicker .cardio-intensity-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.intensity === level);
+  });
+}
+
+/** Initialise date chip in the form header to show today */
+function initCardioDateChip() {
+  const chip = document.getElementById('cardioDateChip');
+  if (!chip) return;
+  const d = new Date();
+  chip.textContent = d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+  // Default the hidden date input to today
+  const dateInput = document.getElementById('cardioDate');
+  if (dateInput && !dateInput.value) dateInput.value = d.toISOString().slice(0, 10);
 }
 
 /** Live-update the pace/speed preview chip under duration+distance fields */
@@ -9527,7 +9615,10 @@ function addCardioEntry() {
   const distance = Number.isFinite(distanceRaw) && distanceRaw > 0 ? distanceRaw : null;
   const caloriesInput = parseFloat(document.getElementById('cardioCalories')?.value) || 0;
   const notes = document.getElementById('cardioNotes')?.value.trim() || '';
-  const date = new Date().toISOString().split('T')[0];
+  const intensity = document.getElementById('cardioIntensity')?.value || 'moderate';
+  const hrRaw = parseFloat(document.getElementById('cardioHeartRate')?.value);
+  const heartRate = Number.isFinite(hrRaw) && hrRaw > 0 ? hrRaw : null;
+  const date = document.getElementById('cardioDate')?.value || new Date().toISOString().split('T')[0];
 
   if (!type || !Number.isFinite(duration) || duration <= 0) {
     window.showToast?.('Choose an activity and enter a duration.', 'warn') ||
@@ -9551,7 +9642,7 @@ function addCardioEntry() {
     : null;
 
   const log = JSON.parse(localStorage.getItem(`cardioLog_${currentUser}`)) || [];
-  const entry = { date, type, duration, distance, calories, estimatedCalories, met, paceOrSpeed, notes };
+  const entry = { date, type, duration, distance, calories, estimatedCalories, met, paceOrSpeed, notes, intensity, heartRate };
   log.push(entry);
   localStorage.setItem(`cardioLog_${currentUser}`, JSON.stringify(log));
 
@@ -9562,10 +9653,17 @@ function addCardioEntry() {
   }
 
   // Clear form
-  if (document.getElementById('cardioDuration'))  document.getElementById('cardioDuration').value  = '';
-  if (document.getElementById('cardioDistance'))  document.getElementById('cardioDistance').value  = '';
-  if (document.getElementById('cardioCalories'))  document.getElementById('cardioCalories').value  = '';
-  if (document.getElementById('cardioNotes'))     document.getElementById('cardioNotes').value     = '';
+  ['cardioDuration','cardioDistance','cardioCalories','cardioNotes','cardioHeartRate'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.value = '';
+  });
+  // Reset date to today and close optional accordion
+  const dateInput = document.getElementById('cardioDate');
+  if (dateInput) dateInput.value = new Date().toISOString().slice(0, 10);
+  const opt = document.getElementById('cardioOptional');
+  if (opt) opt.removeAttribute('open');
+  // Reset intensity to moderate
+  selectCardioIntensity('moderate');
   updateCardioPacePreview();
 
   const cfg = window.cardioTab?.getActivityConfig?.(type) || { icon: '🏃', label: type };
@@ -9666,9 +9764,13 @@ function renderCardio() {
               })()
             : null);
       const kcal  = parseFloat(entry.calories) > 0 ? `🔥 ${Math.round(entry.calories)} kcal` : null;
+      const hr    = parseFloat(entry.heartRate) > 0 ? `❤️ ${Math.round(entry.heartRate)} bpm` : null;
+      const intBadge = entry.intensity && entry.intensity !== 'moderate'
+        ? { easy: '😌 Easy', hard: '🔥 Hard', max: '⚡ Max' }[entry.intensity] || null
+        : null;
 
-      const tags  = [dur, dist, pace, kcal].filter(Boolean).map((t, i) =>
-        `<span class="cardio-stat-tag${i === 2 && pace ? ' highlight' : ''}">${t}</span>`
+      const tags  = [dur, dist, pace, kcal, hr, intBadge].filter(Boolean).map((t, i) =>
+        `<span class="cardio-stat-tag${t === pace && pace ? ' highlight' : ''}">${t}</span>`
       ).join('');
 
       return `

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
   <link rel="stylesheet" href="css/coaching.css">
   <link rel="stylesheet" href="css/ui-declutter.css">
   <link rel="stylesheet" href="css/features.css">
+  <link rel="stylesheet" href="css/cardio.css">
   <link rel="manifest" href="/manifest.json">
   <!-- iOS PWA / Capacitor meta tags -->
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -1068,22 +1069,74 @@
 </div>
 
   <div id="cardioTab" class="tab-content">
-    <div id="cardioFormPanel" class="panel active">
-    <h2>Cardio Tracker</h2>
-    <input type="text" id="cardioType" placeholder="Type (e.g. Running)">
-    <input type="number" id="cardioDuration" placeholder="Duration (min)">
-    <input type="number" id="cardioDistance" placeholder="Distance (km)">
-    <input type="number" id="cardioCalories" placeholder="Calories burned (optional)">
-    <input type="text" id="cardioNotes" placeholder="Notes (optional)">
-    <button onclick="addCardioEntry()">Add Cardio</button>
-    <button onclick="completeCardioSession()">Complete Cardio Session</button>
+
+    <!-- Weekly summary chips -->
+    <div id="cardioWeeklySummary" class="cardio-weekly-strip"></div>
+
+    <!-- Log form -->
+    <div class="cardio-form-card">
+      <h3 class="cardio-form-title">🏃 Log Cardio</h3>
+
+      <!-- Activity type pills -->
+      <div class="cardio-type-picker" id="cardioTypePicker">
+        <button class="cardio-type-btn active" data-type="run"        onclick="selectCardioType('run')">🏃 Run</button>
+        <button class="cardio-type-btn"        data-type="walk"       onclick="selectCardioType('walk')">🚶 Walk</button>
+        <button class="cardio-type-btn"        data-type="cycle"      onclick="selectCardioType('cycle')">🚴 Cycle</button>
+        <button class="cardio-type-btn"        data-type="swim"       onclick="selectCardioType('swim')">🏊 Swim</button>
+        <button class="cardio-type-btn"        data-type="row"        onclick="selectCardioType('row')">🚣 Row</button>
+        <button class="cardio-type-btn"        data-type="hiit"       onclick="selectCardioType('hiit')">💪 HIIT</button>
+        <button class="cardio-type-btn"        data-type="hike"       onclick="selectCardioType('hike')">🥾 Hike</button>
+        <button class="cardio-type-btn"        data-type="yoga"       onclick="selectCardioType('yoga')">🧘 Yoga</button>
+        <button class="cardio-type-btn"        data-type="other"      onclick="selectCardioType('other')">＋ Other</button>
+      </div>
+      <!-- Hidden canonical type value -->
+      <input type="hidden" id="cardioType" value="run">
+      <!-- Custom type text input, shown only when "Other" is active -->
+      <div class="cardio-custom-type-wrap" id="cardioCustomTypeWrap" style="display:none">
+        <input type="text" id="cardioCustomType" placeholder="Describe activity…"
+               oninput="document.getElementById('cardioType').value = this.value.trim() || 'other'">
+      </div>
+
+      <!-- Duration + Distance -->
+      <div class="cardio-form-row">
+        <div class="cardio-form-field">
+          <label for="cardioDuration">Duration (min)</label>
+          <input type="number" id="cardioDuration" placeholder="30" min="1"
+                 oninput="updateCardioPacePreview()">
+        </div>
+        <div class="cardio-form-field">
+          <label for="cardioDistance">Distance (km)</label>
+          <input type="number" id="cardioDistance" placeholder="optional" step="0.1" min="0"
+                 oninput="updateCardioPacePreview()">
+        </div>
+      </div>
+
+      <!-- Live pace / speed preview -->
+      <div id="cardioPacePreview" class="cardio-pace-preview" style="display:none">
+        <span class="pace-icon" id="cardioPaceIcon">⚡</span>
+        <span class="pace-value" id="cardioPaceValue"></span>
+      </div>
+
+      <!-- Calories (optional) + Notes -->
+      <div class="cardio-form-row">
+        <div class="cardio-form-field">
+          <label for="cardioCalories">Calories (optional)</label>
+          <input type="number" id="cardioCalories" placeholder="auto-estimated" min="0">
+        </div>
+        <div class="cardio-form-field">
+          <label for="cardioNotes">Notes</label>
+          <input type="text" id="cardioNotes" placeholder="e.g. morning run">
+        </div>
+      </div>
+
+      <button class="cardio-submit-btn" onclick="addCardioEntry()">➕ Add Session</button>
     </div>
-    <div id="cardioHistoryPanel" class="panel">
-      <table>
-        <thead><tr><th>Date</th><th>Type</th><th>Duration</th><th>Distance</th><th>Calories</th><th>Notes</th><th>Remove</th></tr></thead>
-        <tbody id="cardioBody"></tbody>
-      </table>
-    </div>
+
+    <!-- History list (populated by renderCardio) -->
+    <div id="cardioHistoryList" class="cardio-history-list"></div>
+
+    <!-- Legacy table body kept for backward compat with any direct cardioBody refs -->
+    <table style="display:none"><tbody id="cardioBody"></tbody></table>
   </div>
 
   <div id="posingTab" class="tab-content">
@@ -8901,64 +8954,227 @@ function calculateCaloriesEquation() {
 }
 
 // ===== CARDIO TRACKER =====
+
+/** Switch the active activity-type pill and update the hidden input */
+function selectCardioType(type) {
+  document.getElementById('cardioType').value = type;
+  document.querySelectorAll('#cardioTypePicker .cardio-type-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.type === type);
+  });
+  const customWrap = document.getElementById('cardioCustomTypeWrap');
+  if (customWrap) {
+    customWrap.style.display = type === 'other' ? 'block' : 'none';
+    if (type !== 'other') {
+      const customInput = document.getElementById('cardioCustomType');
+      if (customInput) customInput.value = '';
+    }
+  }
+  updateCardioPacePreview();
+}
+
+/** Live-update the pace/speed preview chip under duration+distance fields */
+function updateCardioPacePreview() {
+  const previewEl = document.getElementById('cardioPacePreview');
+  if (!previewEl) return;
+  const type     = document.getElementById('cardioType')?.value || 'run';
+  const duration = parseFloat(document.getElementById('cardioDuration')?.value);
+  const distance = parseFloat(document.getElementById('cardioDistance')?.value);
+
+  const result = window.cardioTab?.computePaceOrSpeed
+    ? window.cardioTab.computePaceOrSpeed({ type, durationMinutes: duration, distanceKm: distance })
+    : null;
+
+  if (result) {
+    previewEl.style.display = 'flex';
+    const iconEl  = document.getElementById('cardioPaceIcon');
+    const valueEl = document.getElementById('cardioPaceValue');
+    if (iconEl)  iconEl.textContent  = result.icon;
+    if (valueEl) valueEl.textContent = `${result.label}: ${result.value}`;
+  } else {
+    previewEl.style.display = 'none';
+  }
+}
+
 function addCardioEntry() {
-  const type = document.getElementById("cardioType").value.trim();
-  const duration = +document.getElementById("cardioDuration").value;
-  const distance = document.getElementById("cardioDistance").value;
-  const caloriesInput = +document.getElementById("cardioCalories").value || 0;
-  const notes = document.getElementById("cardioNotes").value;
+  const type = document.getElementById('cardioType')?.value.trim() || '';
+  const duration = parseFloat(document.getElementById('cardioDuration')?.value);
+  const distanceRaw = parseFloat(document.getElementById('cardioDistance')?.value);
+  const distance = Number.isFinite(distanceRaw) && distanceRaw > 0 ? distanceRaw : null;
+  const caloriesInput = parseFloat(document.getElementById('cardioCalories')?.value) || 0;
+  const notes = document.getElementById('cardioNotes')?.value.trim() || '';
   const date = new Date().toISOString().split('T')[0];
-  if (!type || !duration) return alert("Type and Duration are required");
+
+  if (!type || !Number.isFinite(duration) || duration <= 0) {
+    window.showToast?.('Choose an activity and enter a duration.', 'warn') ||
+      alert('Choose an activity and enter a duration.');
+    return;
+  }
 
   const bodyweightLog = JSON.parse(localStorage.getItem(`bodyweightLog_${currentUser}`)) || [];
   const fallbackWeightKg = Number(JSON.parse(localStorage.getItem('personalDetails') || 'null')?.weightKg) || 70;
-  const latestWeightKg = bodyweightLog.length ? (getEntryWeightKg(bodyweightLog[bodyweightLog.length - 1]) || fallbackWeightKg) : fallbackWeightKg;
+  const latestWeightKg = bodyweightLog.length
+    ? (getEntryWeightKg(bodyweightLog[bodyweightLog.length - 1]) || fallbackWeightKg)
+    : fallbackWeightKg;
+
   const estimatedCalories = window.cardioTab?.estimateCardioCalories
     ? window.cardioTab.estimateCardioCalories({ type, durationMinutes: duration, weightKg: latestWeightKg })
     : 0;
   const calories = caloriesInput > 0 ? caloriesInput : estimatedCalories;
-  const met = window.cardioTab?.resolveMET ? window.cardioTab.resolveMET(type) : null;
+  const met      = window.cardioTab?.resolveMET ? window.cardioTab.resolveMET(type) : null;
+  const paceOrSpeed = window.cardioTab?.computePaceOrSpeed
+    ? window.cardioTab.computePaceOrSpeed({ type, durationMinutes: duration, distanceKm: distance })
+    : null;
 
   const log = JSON.parse(localStorage.getItem(`cardioLog_${currentUser}`)) || [];
-  const entry = { date, type, duration, distance, calories, estimatedCalories, met, notes };
+  const entry = { date, type, duration, distance, calories, estimatedCalories, met, paceOrSpeed, notes };
   log.push(entry);
   localStorage.setItem(`cardioLog_${currentUser}`, JSON.stringify(log));
+
   try {
-    if (window.dailyMissionEngine?.syncMissionFromCardioEntry) {
-      window.dailyMissionEngine.syncMissionFromCardioEntry(entry, currentUser);
-    }
+    window.dailyMissionEngine?.syncMissionFromCardioEntry?.(entry, currentUser);
   } catch (missionErr) {
     console.warn('Daily mission cardio sync failed.', missionErr);
   }
+
+  // Clear form
+  if (document.getElementById('cardioDuration'))  document.getElementById('cardioDuration').value  = '';
+  if (document.getElementById('cardioDistance'))  document.getElementById('cardioDistance').value  = '';
+  if (document.getElementById('cardioCalories'))  document.getElementById('cardioCalories').value  = '';
+  if (document.getElementById('cardioNotes'))     document.getElementById('cardioNotes').value     = '';
+  updateCardioPacePreview();
+
+  const cfg = window.cardioTab?.getActivityConfig?.(type) || { icon: '🏃', label: type };
+  const calText = calories > 0 ? ` · ${calories} kcal` : '';
+  const paceText = paceOrSpeed ? ` · ${paceOrSpeed.value}` : '';
+  window.showToast?.(`${cfg.icon} ${Math.round(duration)} min ${cfg.label}${paceText}${calText} logged!`, 'success', 3000);
+
   renderCardio();
   updateMacroUI();
 }
 
+/** Legacy function kept so any external references don't break.
+ *  The old "Session Complete" dummy entry is no longer created.
+ *  Calling this now just signals the mission engine directly. */
 function completeCardioSession() {
-  const log = JSON.parse(localStorage.getItem(`cardioLog_${currentUser}`)) || [];
-  const date = new Date().toISOString().split('T')[0];
-  const entry = { date, type: 'Session Complete', duration: 0, distance: 0, calories: 0, notes: '' };
-  log.push(entry);
-  localStorage.setItem(`cardioLog_${currentUser}`, JSON.stringify(log));
   try {
-    if (window.dailyMissionEngine?.syncMissionFromCardioEntry) {
-      window.dailyMissionEngine.syncMissionFromCardioEntry(entry, currentUser);
-    }
-  } catch (missionErr) {
-    console.warn('Daily mission cardio completion sync failed.', missionErr);
-  }
-  renderCardio();
-  updateMacroUI();
+    const entry = { date: new Date().toISOString().split('T')[0], type: 'session_complete' };
+    window.dailyMissionEngine?.syncMissionFromCardioEntry?.(entry, currentUser);
+  } catch (e) { /* silent */ }
+  window.showToast?.('Cardio session marked complete! 🎉', 'success', 3000);
 }
 
 function renderCardio() {
+  if (!currentUser) return;
   const log = JSON.parse(localStorage.getItem(`cardioLog_${currentUser}`)) || [];
-  const body = document.getElementById("cardioBody");
-  body.innerHTML = '';
-  log.forEach((entry, index) => {
-    body.innerHTML += `<tr><td>${entry.date}</td><td>${entry.type}</td><td>${entry.duration}</td><td>${entry.distance || '-'}</td><td>${entry.calories || '-'}</td><td>${entry.notes}</td><td><button onclick="removeCardioEntry(${index})" class="remove-btn">❌</button></td></tr>`;
+
+  /* ── Weekly summary (rolling 7 days) ────────────────────── */
+  const today = new Date();
+  const weekAgo = new Date(today); weekAgo.setDate(weekAgo.getDate() - 6);
+  const weekStart = weekAgo.toISOString().slice(0, 10);
+  const weekEntries = log.filter(e => (e.date || '') >= weekStart);
+
+  const weekSessions = weekEntries.length;
+  const weekMins     = weekEntries.reduce((s, e) => s + (parseFloat(e.duration) || 0), 0);
+  const weekKm       = weekEntries.reduce((s, e) => s + (parseFloat(e.distance) || 0), 0);
+  const weekKcal     = weekEntries.reduce((s, e) => s + (parseFloat(e.calories) || 0), 0);
+
+  const summaryEl = document.getElementById('cardioWeeklySummary');
+  if (summaryEl) {
+    summaryEl.innerHTML = [
+      { val: weekSessions,                        lbl: 'Sessions (7d)' },
+      { val: Math.round(weekMins) + ' min',       lbl: 'Active time'   },
+      { val: weekKm > 0 ? weekKm.toFixed(1)+' km' : '—', lbl: 'Distance' },
+      { val: weekKcal > 0 ? Math.round(weekKcal)+' kcal' : '—', lbl: 'Calories' },
+    ].map(c => `
+      <div class="cardio-stat-chip">
+        <span class="chip-val">${c.val}</span>
+        <span class="chip-lbl">${c.lbl}</span>
+      </div>`).join('');
+  }
+
+  /* ── History cards grouped by date ──────────────────────── */
+  const historyEl = document.getElementById('cardioHistoryList');
+  if (!historyEl) return;
+
+  if (log.length === 0) {
+    historyEl.innerHTML = `
+      <div class="cardio-history-empty">
+        No cardio sessions logged yet.<br>
+        <span style="font-size:1.6rem;display:block;margin-top:8px">🏃</span>
+      </div>`;
+    return;
+  }
+
+  // Group entries by date descending
+  const grouped = {};
+  // Iterate in reverse so we render newest first and index is preserved
+  [...log].forEach((entry, idx) => {
+    const d = entry.date || 'Unknown';
+    if (!grouped[d]) grouped[d] = [];
+    grouped[d].push({ entry, idx });
   });
-  if (document.getElementById('progressTab').classList.contains('active')) {
+
+  const sortedDates = Object.keys(grouped).sort((a, b) => b.localeCompare(a));
+  const todayStr     = today.toISOString().slice(0, 10);
+  const yesterdayStr = new Date(today.getTime() - 86400000).toISOString().slice(0, 10);
+
+  function _dateLabel(d) {
+    if (d === todayStr)     return 'Today';
+    if (d === yesterdayStr) return 'Yesterday';
+    try {
+      return new Date(d + 'T00:00:00').toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+    } catch { return d; }
+  }
+
+  historyEl.innerHTML = sortedDates.map(date => {
+    const entries = grouped[date];
+    const cards   = entries.map(({ entry, idx }) => {
+      const cfg   = window.cardioTab?.getActivityConfig?.(entry.type) || { icon: '🏅', label: entry.type || 'Other', color: '#8c9891' };
+      const dur   = entry.duration > 0 ? `⏱ ${Math.round(entry.duration)} min` : null;
+      const dist  = parseFloat(entry.distance) > 0 ? `📏 ${parseFloat(entry.distance).toFixed(1)} km` : null;
+      const pace  = entry.paceOrSpeed
+        ? `${entry.paceOrSpeed.icon} ${entry.paceOrSpeed.value}`
+        : (dist && dur
+            ? (() => {
+                const r = window.cardioTab?.computePaceOrSpeed?.({ type: entry.type, durationMinutes: entry.duration, distanceKm: entry.distance });
+                return r ? `${r.icon} ${r.value}` : null;
+              })()
+            : null);
+      const kcal  = parseFloat(entry.calories) > 0 ? `🔥 ${Math.round(entry.calories)} kcal` : null;
+
+      const tags  = [dur, dist, pace, kcal].filter(Boolean).map((t, i) =>
+        `<span class="cardio-stat-tag${i === 2 && pace ? ' highlight' : ''}">${t}</span>`
+      ).join('');
+
+      return `
+        <div class="cardio-entry-card" style="--c-accent:${cfg.color}">
+          <div class="cardio-entry-icon">${cfg.icon}</div>
+          <div class="cardio-entry-info">
+            <div class="cardio-entry-title">${cfg.label}</div>
+            <div class="cardio-entry-stats">${tags}</div>
+            ${entry.notes ? `<div class="cardio-entry-notes">${entry.notes}</div>` : ''}
+          </div>
+          <button class="cardio-remove-btn" onclick="removeCardioEntry(${idx})" title="Remove">🗑</button>
+        </div>`;
+    }).join('');
+
+    return `
+      <div class="cardio-day-group">
+        <div class="cardio-day-header">${_dateLabel(date)} &nbsp;·&nbsp; ${date}</div>
+        ${cards}
+      </div>`;
+  }).join('');
+
+  // Keep legacy cardioBody in sync for anything that still reads it
+  const legacyBody = document.getElementById('cardioBody');
+  if (legacyBody) {
+    legacyBody.innerHTML = '';
+    log.forEach((entry, index) => {
+      legacyBody.innerHTML += `<tr><td>${entry.date}</td><td>${entry.type}</td><td>${entry.duration}</td><td>${entry.distance || '-'}</td><td>${entry.calories || '-'}</td><td>${entry.notes || ''}</td><td><button onclick="removeCardioEntry(${index})" class="remove-btn">❌</button></td></tr>`;
+    });
+  }
+
+  if (document.getElementById('progressTab')?.classList.contains('active')) {
     showWorkoutProgress();
   }
 }

--- a/index.html
+++ b/index.html
@@ -716,23 +716,61 @@
           <div class="ci-photo-slot">
             <label>Front</label>
             <div class="ci-photo-preview photo-upload-preview" id="photoSlot_front"
-                 onclick="document.getElementById('photoFile_front').click()">📷</div>
+                 onclick="document.getElementById('photoFile_front').click()">
+              <span class="photo-placeholder">📷</span>
+              <img id="photoPreview_front" style="display:none;width:100%;height:100%;object-fit:cover;" alt="Front progress photo">
+            </div>
             <input type="file" class="photo-upload-input" id="photoFile_front" accept="image/*">
           </div>
           <div class="ci-photo-slot">
             <label>Side</label>
             <div class="ci-photo-preview photo-upload-preview" id="photoSlot_side"
-                 onclick="document.getElementById('photoFile_side').click()">📷</div>
+                 onclick="document.getElementById('photoFile_side').click()">
+              <span class="photo-placeholder">📷</span>
+              <img id="photoPreview_side" style="display:none;width:100%;height:100%;object-fit:cover;" alt="Side progress photo">
+            </div>
             <input type="file" class="photo-upload-input" id="photoFile_side" accept="image/*">
           </div>
           <div class="ci-photo-slot">
             <label>Back</label>
             <div class="ci-photo-preview photo-upload-preview" id="photoSlot_back"
-                 onclick="document.getElementById('photoFile_back').click()">📷</div>
+                 onclick="document.getElementById('photoFile_back').click()">
+              <span class="photo-placeholder">📷</span>
+              <img id="photoPreview_back" style="display:none;width:100%;height:100%;object-fit:cover;" alt="Back progress photo">
+            </div>
             <input type="file" class="photo-upload-input" id="photoFile_back" accept="image/*">
           </div>
         </div>
       </div>
+
+      <!-- Side-by-side comparison card -->
+      <div class="ci-card">
+        <h3 class="ci-card-title">🔄 Side-by-Side Comparison</h3>
+        <p class="ci-card-desc">Compare your current photos with a previous check-in.</p>
+        <div style="margin-bottom:10px;">
+          <label for="photoCompareSelect" style="font-size:0.78rem;color:var(--text-muted);font-weight:600;text-transform:uppercase;letter-spacing:0.03em;display:block;margin-bottom:5px;">Compare with</label>
+          <select id="photoCompareSelect" onchange="renderPhotoComparison()" style="width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--border-color);background:var(--elevated-bg);color:var(--text-color);font-size:1rem;-webkit-appearance:none;">
+            <option value="">-- Select a previous check-in --</option>
+          </select>
+        </div>
+        <div id="photoComparisonGrid" style="display:none;">
+          <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);margin:0 0 8px;">Front view</p>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px;">
+            <div style="text-align:center;">
+              <div style="font-size:0.72rem;color:var(--text-muted);margin-bottom:4px;">Then</div>
+              <img id="photoCompare_front_old" style="width:100%;border-radius:10px;aspect-ratio:3/4;object-fit:cover;background:var(--elevated-bg);" alt="Previous front">
+            </div>
+            <div style="text-align:center;">
+              <div style="font-size:0.72rem;color:var(--text-muted);margin-bottom:4px;">Now</div>
+              <img id="photoCompare_front_new" style="width:100%;border-radius:10px;aspect-ratio:3/4;object-fit:cover;background:var(--elevated-bg);" alt="Current front">
+            </div>
+          </div>
+        </div>
+        <div id="photoComparisonEmpty" style="text-align:center;color:var(--text-muted);font-size:0.85rem;padding:16px 0;">
+          Add photos and save a check-in to unlock comparisons.
+        </div>
+      </div>
+
       <button class="ci-save-btn" onclick="saveWeeklyCheckIn('athlete')">Save with Photos ✓</button>
     </div><!-- /ciPanel_photos -->
 
@@ -829,6 +867,7 @@
     <div class="pl-subtabs">
       <button class="pl-subtab active" data-pl-subtab="plates">🏋️ Plate Calc</button>
       <button class="pl-subtab" data-pl-subtab="oneRM">📈 1RM Tracker</button>
+      <button class="pl-subtab" data-pl-subtab="scores">🏅 Scores</button>
       <button class="pl-subtab" data-pl-subtab="meet">🗓️ Meet Prep</button>
       <button class="pl-subtab" data-pl-subtab="meetday">🎯 Meet Day</button>
     </div>
@@ -975,6 +1014,81 @@
     </div>
 
     <!-- ── MEET PREP ── -->
+    <!-- ── STRENGTH SCORES (Wilks / DOTS / IPF GL) ── -->
+    <div id="plSubScores" class="pl-subview">
+      <h3 style="margin-top:0;">Strength Scores</h3>
+      <p style="font-size:0.82rem;color:var(--text-muted);margin:-4px 0 14px;">Compare your total across weight classes &amp; formulas.</p>
+
+      <!-- Inputs -->
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px;">
+        <div>
+          <label for="scoreBodyweight">Bodyweight</label>
+          <input type="number" id="scoreBodyweight" step="0.1" placeholder="e.g. 83" oninput="calcStrengthScores()">
+        </div>
+        <div>
+          <label for="scoreUnit">Unit</label>
+          <select id="scoreUnit" onchange="calcStrengthScores()">
+            <option value="kg">kg</option>
+            <option value="lbs">lbs</option>
+          </select>
+        </div>
+        <div>
+          <label for="scoreSex">Sex</label>
+          <select id="scoreSex" onchange="calcStrengthScores()">
+            <option value="M">Male</option>
+            <option value="F">Female</option>
+          </select>
+        </div>
+        <div>
+          <label for="scoreEquipment">Equipment</label>
+          <select id="scoreEquipment" onchange="calcStrengthScores()">
+            <option value="raw">Raw</option>
+            <option value="equipped">Equipped</option>
+          </select>
+        </div>
+      </div>
+
+      <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-bottom:16px;">
+        <div>
+          <label for="scoreSquat">Squat</label>
+          <input type="number" id="scoreSquat" step="0.5" placeholder="0" oninput="calcStrengthScores()">
+        </div>
+        <div>
+          <label for="scoreBench">Bench</label>
+          <input type="number" id="scoreBench" step="0.5" placeholder="0" oninput="calcStrengthScores()">
+        </div>
+        <div>
+          <label for="scoreDeadlift">Deadlift</label>
+          <input type="number" id="scoreDeadlift" step="0.5" placeholder="0" oninput="calcStrengthScores()">
+        </div>
+      </div>
+
+      <!-- Results -->
+      <div id="scoreResults" style="display:none;">
+        <div style="background:var(--card-bg);border:1px solid var(--border-color);border-radius:14px;padding:14px 16px;margin-bottom:10px;">
+          <div style="font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);margin-bottom:10px;">
+            Total: <span id="scoreTotal" style="color:var(--text-color);font-size:1rem;"></span>
+          </div>
+          <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;">
+            <div style="text-align:center;background:var(--elevated-bg);border-radius:10px;padding:10px 6px;">
+              <div id="scoreWilks" style="font-size:1.4rem;font-weight:800;color:var(--primary);line-height:1;">—</div>
+              <div style="font-size:0.72rem;color:var(--text-muted);margin-top:3px;">Wilks</div>
+            </div>
+            <div style="text-align:center;background:var(--elevated-bg);border-radius:10px;padding:10px 6px;">
+              <div id="scoreDots" style="font-size:1.4rem;font-weight:800;color:#7c6ef0;line-height:1;">—</div>
+              <div style="font-size:0.72rem;color:var(--text-muted);margin-top:3px;">DOTS</div>
+            </div>
+            <div style="text-align:center;background:var(--elevated-bg);border-radius:10px;padding:10px 6px;">
+              <div id="scoreIpfgl" style="font-size:1.4rem;font-weight:800;color:#e07c30;line-height:1;">—</div>
+              <div style="font-size:0.72rem;color:var(--text-muted);margin-top:3px;">IPF GL</div>
+            </div>
+          </div>
+        </div>
+        <!-- Performance tier badge -->
+        <div id="scoreTier" style="text-align:center;padding:10px;border-radius:10px;font-size:0.88rem;font-weight:700;"></div>
+      </div>
+    </div>
+
     <div id="plSubMeet" class="pl-subview">
       <h3 style="margin-top:0;">Meet Prep Timeline</h3>
 
@@ -6949,6 +7063,46 @@ function renderHeroPhaseHeader(profile, username) {
   const statusPill = getHomeStatusPillClass(currentStatus);
   const todayLabel = formatExactDate(new Date().toISOString());
 
+  // Recreational hero: habit-centric, skip show-day / peak-week content
+  if (archetype === 'recreational') {
+    const stepsToday = (() => {
+      const userId2 = username || currentUser || localStorage.getItem('currentUser') || localStorage.getItem('username');
+      const todayKey = new Date().toISOString().slice(0,10);
+      const data = JSON.parse(localStorage.getItem('dailySteps') || '{}');
+      return parseInt(data[todayKey] || 0);
+    })();
+    const settings2 = (() => {
+      const userId2 = username || currentUser || localStorage.getItem('currentUser') || localStorage.getItem('username');
+      return JSON.parse(localStorage.getItem(`settings_${userId2}`) || '{}');
+    })();
+    const stepsGoal = settings2?.profile?.goals?.stepsTarget || 10000;
+    const stepsPct  = Math.round(Math.min(stepsToday / stepsGoal, 1) * 100);
+    const gamification = getHomeGamificationSummary(profile, username);
+    const streakCount  = gamification?.habitStreak || gamification?.currentStreak || 0;
+    return `
+      <section class="home-dashboard-card home-hero-card">
+        <div class="home-card-header">
+          <p class="home-hero-topline">Habit Command Center</p>
+          <span class="home-status-pill ${statusPill}">${currentStatus}</span>
+        </div>
+        <div class="home-split-grid">
+          <div>
+            <h2 class="home-hero-athlete">${athleteName}</h2>
+            <p class="home-hero-meta">📅 ${todayLabel}</p>
+            <p class="home-hero-meta">🔥 Habit Streak: <strong>${streakCount} day${streakCount !== 1 ? 's' : ''}</strong></p>
+            <p class="home-hero-meta">👟 Steps today: <strong>${stepsToday.toLocaleString()} / ${stepsGoal.toLocaleString()} (${stepsPct}%)</strong></p>
+          </div>
+          <div class="home-muted-panel">
+            <p class="home-stat-label">Daily Status</p>
+            <p class="home-stat-value" style="margin-bottom:8px;">${currentStatus}</p>
+            <p class="home-stat-label">Next Check-in</p>
+            <p class="home-stat-value">${nextReview}</p>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
   return `
     <section class="home-dashboard-card home-hero-card">
       <div class="home-card-header">
@@ -7602,7 +7756,8 @@ function getHomeDashboardCardOrder(archetype) {
     bodybuilder: ['hero', 'progression', 'mission', 'focus', 'macro', 'status', 'weekly', 'upcoming', 'insights'],
     powerlifter: ['hero', 'progression', 'mission', 'focus', 'macro', 'status', 'weekly', 'upcoming', 'insights'],
     hybrid: ['hero', 'progression', 'mission', 'focus', 'macro', 'status', 'weekly', 'upcoming', 'insights'],
-    recreational: ['hero', 'progression', 'mission', 'focus', 'macro', 'status', 'weekly', 'upcoming', 'insights']
+    // Recreational: habit-first, skip "Upcoming Prep Events" (show-day / peak week irrelevant)
+    recreational: ['hero', 'mission', 'status', 'progression', 'weekly', 'focus', 'macro', 'insights']
   };
   return orders[archetype] || baseOrder;
 }
@@ -8294,6 +8449,10 @@ function switchCheckInTab(panel) {
   if (panel === 'history') {
     generateCheckInSummary?.();
   }
+  // Populate photo compare picker when switching to photos
+  if (panel === 'photos') {
+    populatePhotoCompareSelect?.();
+  }
 }
 window.switchCheckInTab = switchCheckInTab;
 
@@ -8423,6 +8582,61 @@ function getCheckInPhaseState() {
   return window.prepModeApi?.getCurrentPhaseState?.(userId) || {};
 }
 
+/**
+ * Auto-fill the cardioAdherence slider (1–10) from this week's cardio log.
+ * Only sets a value if the slider hasn't already been manually adjusted.
+ * Mapping: sessions ≥ target → 10, 0 sessions → 1, proportional in between.
+ */
+function autoFillCardioAdherenceSlider(userId) {
+  const slider = document.getElementById('checkInField_cardioAdherence');
+  if (!slider) return; // field not shown for this archetype
+
+  // Don't overwrite if user already moved the slider away from the default (5)
+  if (slider.dataset.userEdited === 'true') return;
+
+  const log = JSON.parse(localStorage.getItem(`cardioLog_${userId}`)) || [];
+  if (!log.length) return;
+
+  // Determine "this week" window (Mon–Sun)
+  const today = new Date();
+  const dayOfWeek = (today.getDay() + 6) % 7; // 0 = Mon … 6 = Sun
+  const weekStart = new Date(today);
+  weekStart.setDate(today.getDate() - dayOfWeek);
+  weekStart.setHours(0, 0, 0, 0);
+  const weekStartStr = weekStart.toISOString().slice(0, 10);
+  const todayStr     = today.toISOString().slice(0, 10);
+
+  const sessionsThisWeek = log.filter(e => e.date >= weekStartStr && e.date <= todayStr).length;
+  if (sessionsThisWeek === 0) return; // leave slider at default
+
+  // Pull weekly cardio target from settings; default 3 sessions/week
+  const settings  = JSON.parse(localStorage.getItem(`settings_${userId}`) || '{}');
+  const target    = settings?.profile?.goals?.cardioSessionsPerWeek || 3;
+
+  const pct   = Math.min(sessionsThisWeek / target, 1);
+  const score = Math.max(1, Math.min(10, Math.round(1 + pct * 9)));
+
+  slider.value = score;
+  const display = document.getElementById('checkInFieldValue_cardioAdherence');
+  if (display) display.textContent = score;
+
+  // Apply colour coding that bindCheckInSliderDisplays normally handles
+  if (score >= 7) display?.setAttribute('data-score-high', '');
+  else if (score >= 4) display?.setAttribute('data-score-mid', '');
+  else display?.setAttribute('data-score-low', '');
+
+  // Tag with a hint so the UI can show "auto-filled"
+  slider.dataset.autoFilled = 'true';
+  const header = slider.closest('.checkin-slider-field')?.querySelector('.checkin-slider-title');
+  if (header && !header.querySelector('.ci-autofill-tag')) {
+    const tag = document.createElement('span');
+    tag.className = 'ci-autofill-tag';
+    tag.textContent = ` (${sessionsThisWeek}/${target} sessions)`;
+    tag.style.cssText = 'font-size:0.7rem;color:var(--text-muted);font-weight:400;';
+    header.appendChild(tag);
+  }
+}
+
 function renderCheckInTab() {
   const userId = currentUser || localStorage.getItem('currentUser') || localStorage.getItem('username');
   if (!userId || !window.checkinEngine) return;
@@ -8451,6 +8665,7 @@ function renderCheckInTab() {
   renderCheckInArchetypeFields(archetype, latestCheckIn);
   hydrateCheckInFormFromLatestEntry(checkIns);
   bindCheckInSliderDisplays();
+  autoFillCardioAdherenceSlider(userId);
 
   const timeline = document.getElementById('checkInTimeline');
   if (!timeline) return;
@@ -8590,7 +8805,7 @@ function bindCheckInSliderDisplays() {
       const percent = max > min ? ((current - min) / (max - min)) * 100 : 0;
       slider.style.setProperty('--checkin-slider-progress', `${Math.max(0, Math.min(100, percent))}%`);
     };
-    slider.oninput = updateValue;
+    slider.oninput = () => { slider.dataset.userEdited = 'true'; updateValue(); };
     updateValue();
   });
 }
@@ -8711,6 +8926,48 @@ function exportCheckInSummary(format = 'json') {
   link.click();
   link.remove();
   URL.revokeObjectURL(url);
+}
+
+/** Populate the comparison date picker from historical check-ins that have photos */
+function populatePhotoCompareSelect() {
+  const userId = currentUser || localStorage.getItem('currentUser') || localStorage.getItem('username');
+  if (!userId || !window.checkinEngine) return;
+  const sel = document.getElementById('photoCompareSelect');
+  if (!sel) return;
+  const checkIns = window.checkinEngine.loadCheckIns(userId) || [];
+  const withPhotos = checkIns.filter(e => e.frontPhoto || e.sidePhoto || e.backPhoto);
+  const current = sel.value;
+  sel.innerHTML = '<option value="">-- Select a previous check-in --</option>' +
+    withPhotos.map(e => `<option value="${e.date}">${e.date}</option>`).join('');
+  if (current) sel.value = current;
+  // Show empty state if no historical photos
+  const empty = document.getElementById('photoComparisonEmpty');
+  if (empty) empty.style.display = withPhotos.length ? 'none' : '';
+}
+
+function renderPhotoComparison() {
+  const sel = document.getElementById('photoCompareSelect');
+  const date = sel?.value;
+  const grid = document.getElementById('photoComparisonGrid');
+  const empty = document.getElementById('photoComparisonEmpty');
+  if (!date || !grid) { if(grid) grid.style.display='none'; return; }
+
+  const userId = currentUser || localStorage.getItem('currentUser') || localStorage.getItem('username');
+  const checkIns = window.checkinEngine?.loadCheckIns(userId) || [];
+  const entry = checkIns.find(e => e.date === date);
+  if (!entry) { grid.style.display = 'none'; return; }
+
+  // "now" = latest photo stored for current user
+  const nowFront = localStorage.getItem(`progressPhoto_${userId}_front`) || '';
+  const oldFront = entry.frontPhoto || '';
+
+  const imgOld = document.getElementById('photoCompare_front_old');
+  const imgNew = document.getElementById('photoCompare_front_new');
+  if (imgOld) { imgOld.src = oldFront; imgOld.style.opacity = oldFront ? '1' : '0.3'; }
+  if (imgNew) { imgNew.src = nowFront; imgNew.style.opacity = nowFront ? '1' : '0.3'; }
+
+  grid.style.display = '';
+  if (empty) empty.style.display = 'none';
 }
 
 function saveWeeklyCheckIn(actor = 'athlete') {
@@ -12609,6 +12866,89 @@ window.renderOneRMChart = renderOneRMChart;
 window.renderOneRMStats = renderOneRMStats;
 
 // ─────────────────────────────────────────────
+// STRENGTH SCORES  (Wilks 2020 · DOTS · IPF GL)
+// ─────────────────────────────────────────────
+function calcStrengthScores() {
+  const bwRaw   = parseFloat(document.getElementById('scoreBodyweight')?.value) || 0;
+  const unit    = document.getElementById('scoreUnit')?.value || 'kg';
+  const sex     = document.getElementById('scoreSex')?.value || 'M';
+  const equip   = document.getElementById('scoreEquipment')?.value || 'raw';
+  const squat   = parseFloat(document.getElementById('scoreSquat')?.value) || 0;
+  const bench   = parseFloat(document.getElementById('scoreBench')?.value) || 0;
+  const deadl   = parseFloat(document.getElementById('scoreDeadlift')?.value) || 0;
+
+  const toKg = v => unit === 'lbs' ? v * 0.453592 : v;
+  const bw   = toKg(bwRaw);
+  const total= toKg(squat + bench + deadl);
+
+  const resEl = document.getElementById('scoreResults');
+  if (!resEl) return;
+
+  if (bw <= 0 || total <= 0) { resEl.style.display = 'none'; return; }
+  resEl.style.display = '';
+
+  // ── Wilks 2020 coefficients ──
+  const WC = {
+    M: [-216.0475144, 16.2606339, -0.002388645, -0.00113732, 7.01863E-06, -1.291E-08],
+    F: [594.31747775582, -27.23842536447, 0.82112226871, -0.00930733913, 0.00004731582, -0.00000009054],
+  };
+  function wilks(bwKg, totalKg, s) {
+    const c = WC[s];
+    const denom = c[0] + c[1]*bwKg + c[2]*bwKg**2 + c[3]*bwKg**3 + c[4]*bwKg**4 + c[5]*bwKg**5;
+    return denom > 0 ? +(totalKg * (600 / denom)).toFixed(2) : 0;
+  }
+
+  // ── DOTS coefficients ──
+  const DC = {
+    M: [-307.75076, 24.0900756, -0.1918759221, 0.0007391293, -0.000001093],
+    F: [-57.96288, 13.6175032, -0.1126655495, 0.0005158568, -0.0000010706],
+  };
+  function dots(bwKg, totalKg, s) {
+    const c = DC[s];
+    const denom = c[0] + c[1]*bwKg + c[2]*bwKg**2 + c[3]*bwKg**3 + c[4]*bwKg**4;
+    return denom > 0 ? +(totalKg * (500 / denom)).toFixed(2) : 0;
+  }
+
+  // ── IPF GL (Good Lift Points) ──
+  // Coefficients: [a, b, c] for raw/equipped × M/F
+  const GL = {
+    M: { raw: [1236.25115, 1449.21864, 0.01644], equipped: [1734.7591, 1979.6376, 0.01644] },
+    F: { raw: [758.63878, 949.31382, 0.02435], equipped: [1056.01593, 1327.58983, 0.02435] },
+  };
+  function ipfgl(bwKg, totalKg, s, e) {
+    const [a, b, c] = GL[s][e];
+    const denom = a - b * Math.exp(-c * bwKg);
+    return denom > 0 ? +(100 * totalKg / denom).toFixed(2) : 0;
+  }
+
+  const w  = wilks(bw, total, sex);
+  const d  = dots(bw, total, sex);
+  const g  = ipfgl(bw, total, sex, equip);
+
+  document.getElementById('scoreTotal').textContent =
+    unit === 'lbs' ? `${(squat+bench+deadl).toFixed(1)} lbs (${total.toFixed(1)} kg)` : `${total.toFixed(1)} kg`;
+  document.getElementById('scoreWilks').textContent = w;
+  document.getElementById('scoreDots').textContent  = d;
+  document.getElementById('scoreIpfgl').textContent = g;
+
+  // Tier based on Wilks (rough community benchmarks, raw)
+  const tierEl = document.getElementById('scoreTier');
+  if (tierEl) {
+    const tiers = [
+      { min: 500, label: '🏆 Elite',       bg: 'rgba(255,215,0,0.15)',  color: '#f0c040' },
+      { min: 400, label: '⭐ Advanced',     bg: 'rgba(82,214,138,0.12)', color: '#52d68a' },
+      { min: 300, label: '📈 Intermediate', bg: 'rgba(82,148,224,0.12)', color: '#5294e0' },
+      { min: 200, label: '🌱 Novice',       bg: 'rgba(160,125,192,0.12)',color: '#a07dc0' },
+      { min:   0, label: '🔰 Beginner',     bg: 'rgba(99,110,114,0.1)',  color: '#9eabb0' },
+    ];
+    const tier = tiers.find(t => w >= t.min) || tiers[tiers.length - 1];
+    tierEl.textContent     = tier.label;
+    tierEl.style.background = tier.bg;
+    tierEl.style.color      = tier.color;
+    tierEl.style.border     = `1px solid ${tier.color}33`;
+  }
+}
+
 // MEET PREP TIMELINE
 // ─────────────────────────────────────────────
 function saveMeetDetails() {

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" sizes="32x32" href="/public/icons/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/public/icons/favicon-16.png">
+  <script src="src/js/native-ui.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
 </head>

--- a/index.html
+++ b/index.html
@@ -217,6 +217,31 @@
       <span class="notif-banner-text">Enable notifications to get rest timer alerts when your phone is locked.</span>
       <button class="notif-banner-btn" onclick="requestRestTimerNotifications()">Enable</button>
     </div>
+    <!-- Step tracking widget — JS in archetype-features.js (initStepWidget) -->
+    <div id="stepWidgetCard" style="margin:0 12px 8px; background:var(--card-bg); border:1px solid var(--border-color); border-radius:16px; padding:14px 16px;">
+      <div class="step-widget">
+        <div class="step-ring-wrap">
+          <svg class="step-ring-svg" viewBox="0 0 80 80">
+            <circle class="step-ring-track" cx="40" cy="40" r="34"/>
+            <circle id="stepRingFill" class="step-ring-fill" cx="40" cy="40" r="34"
+                    stroke-dasharray="213.6" stroke-dashoffset="213.6"/>
+          </svg>
+          <div class="step-ring-inner">
+            <span id="stepRingCount" class="step-ring-count">0</span>
+            <span class="step-ring-icon">👟</span>
+          </div>
+        </div>
+        <div class="step-widget-info">
+          <div id="stepGoalLabel" class="step-widget-goal">Goal: 10,000 steps</div>
+          <div class="step-input-row">
+            <input id="stepCountInput" type="number" class="step-count-input"
+                   placeholder="Steps today" min="0" inputmode="numeric"/>
+            <button id="stepSaveBtn" class="step-save-btn">Save</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div id="homeDashboardContent" class="home-dashboard"></div>
   </div>
 
@@ -12591,7 +12616,7 @@ function saveMeetDetails() {
   const name = document.getElementById('meetName')?.value || '';
   const fed = document.getElementById('meetFed')?.value || '';
   const weightClass = document.getElementById('meetWeightClass')?.value || '';
-  if (!date) { alert('Please enter a meet date.'); return; }
+  if (!date) { window.showToast?.('Please enter a meet date.', 'warn'); return; }
   localStorage.setItem('plMeetDetails', JSON.stringify({ date, name, fed, weightClass }));
   renderMeetPrep();
   if (typeof showToast === 'function') showToast('Meet saved!');

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <link rel="stylesheet" href="css/features.css">
   <link rel="stylesheet" href="css/cardio.css">
   <link rel="stylesheet" href="css/checkin.css">
+  <link rel="stylesheet" href="css/community-share.css">
   <link rel="manifest" href="/manifest.json">
   <!-- iOS PWA / Capacitor meta tags -->
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -1013,9 +1014,10 @@
 
 <div id="communityTab" class="tab-content">
   <nav class="community-nav">
-    <button class="comm-nav-btn" onclick="showCommunitySection('groups')" id="commNavGroups">👥 Groups</button>
-    <button class="comm-nav-btn" onclick="showCommunitySection('feed')"   id="commNavFeed">📣 Feed</button>
+    <button class="comm-nav-btn" onclick="showCommunitySection('groups')"      id="commNavGroups">👥 Groups</button>
+    <button class="comm-nav-btn" onclick="showCommunitySection('feed')"        id="commNavFeed">📣 Feed</button>
     <button class="comm-nav-btn" onclick="showCommunitySection('competition')" id="commNavCompetition">🏆 Leaderboard</button>
+    <button class="comm-nav-btn" onclick="showCommunitySection('share')"       id="commNavShare">🔗 Share<span id="commShareBadge" class="comm-nav-badge" style="display:none">0</span></button>
   </nav>
 
   <!-- ── Groups panel ── -->
@@ -1096,7 +1098,76 @@
 
   <!-- Legacy posts panel (kept for compatibility) -->
   <div id="postsPanel" class="panel" style="display:none;"></div>
-</div>
+
+  <!-- ── Share Panel ── -->
+  <div id="commSharePanel" class="panel" style="display:none;">
+
+    <!-- ① SEND section -->
+    <div class="comm-share-card">
+      <h3 class="comm-share-card-title">📤 Send Program or Template</h3>
+
+      <!-- Mode: user vs group -->
+      <div class="comm-share-mode-row">
+        <button class="comm-share-mode-btn active" data-mode="user"  onclick="commShareSetMode('user')">👤 To a User</button>
+        <button class="comm-share-mode-btn"        data-mode="group" onclick="commShareSetMode('group')">👥 To a Group</button>
+      </div>
+
+      <!-- User mode -->
+      <div id="commShareUserMode">
+        <div class="comm-share-field">
+          <label for="commShareRecipient">Recipient username</label>
+          <input type="text" id="commShareRecipient" placeholder="e.g. john_lifts" autocomplete="off">
+        </div>
+      </div>
+
+      <!-- Group mode (hidden by default) -->
+      <div id="commShareGroupMode" style="display:none">
+        <div class="comm-share-field">
+          <label for="commShareGroupSelect">Choose group</label>
+          <select id="commShareGroupSelect">
+            <option value="">— select a group —</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Type selector -->
+      <div class="comm-share-type-row">
+        <button class="comm-share-type-btn active" data-type="template" onclick="commShareSetType('template')">📋 Templates</button>
+        <button class="comm-share-type-btn"        data-type="program"  onclick="commShareSetType('program')">🗓 Programs</button>
+      </div>
+
+      <!-- Selectable item list -->
+      <div id="commShareItemList" class="comm-share-item-list">
+        <div class="comm-share-empty">Open the Share tab to load your library.</div>
+      </div>
+
+      <!-- Optional message -->
+      <div class="comm-share-field">
+        <label for="commShareMessage">Note <span style="font-weight:400;text-transform:none">(optional)</span></label>
+        <textarea id="commShareMessage" placeholder="e.g. This is the program I mentioned — give it a try!"></textarea>
+      </div>
+
+      <button class="comm-share-send-btn" onclick="commSendShare()">📤 Send</button>
+    </div>
+
+    <!-- ② INBOX section -->
+    <div class="comm-share-card">
+      <h3 class="comm-share-card-title">📥 Received</h3>
+      <div id="commShareInbox">
+        <div class="comm-share-empty">Loading…</div>
+      </div>
+    </div>
+
+    <!-- ③ SENT history -->
+    <div class="comm-share-card">
+      <h3 class="comm-share-card-title">📨 Sent</h3>
+      <div id="commShareOutbox">
+        <div class="comm-share-empty">Nothing sent yet.</div>
+      </div>
+    </div>
+
+  </div><!-- /commSharePanel -->
+</div><!-- /communityTab -->
 
 <div id="leaderboardTab" class="tab-content">
   <div class="lb-page">
@@ -2400,6 +2471,13 @@ function showTab(tabName) {
       break;
     case 'communityTab':
       if (window.showCommunitySection) showCommunitySection('groups');
+      // Refresh inbox badge whenever community tab is opened
+      if (currentUser) {
+        const _cInbox = (JSON.parse(localStorage.getItem(`communityInbox_${currentUser}`)) || [])
+          .filter(i => !i.accepted && !i.dismissed);
+        const _cBadge = document.getElementById('commShareBadge');
+        if (_cBadge) { _cBadge.style.display = _cInbox.length ? '' : 'none'; _cBadge.textContent = _cInbox.length; }
+      }
       break;
     case 'leaderboardTab':
       if (window.initLeaderboard) initLeaderboard();
@@ -11424,6 +11502,383 @@ window.completeCardioSession = completeCardioSession;
 window.loadSelectedTemplate = loadSelectedTemplate;
 window.loadSelectedResistanceTemplate = loadSelectedResistanceTemplate;
 window.sendTemplate = sendTemplate;
+
+/* ══════════════════════════════════════════════════════════════
+   COMMUNITY SHARE — peer-to-peer program & template sharing
+   localStorage keys:
+     communityInbox_${u}  — items received by user u
+     communityOutbox_${u} — items sent by user u
+   ═════════════════════════════════════════════════════════════ */
+
+let _commShareMode = 'user';       // 'user' | 'group'
+let _commShareType = 'template';   // 'template' | 'program'
+let _commShareSelectedId = null;
+
+/* Switch delivery mode (direct user vs community group) */
+function commShareSetMode(mode) {
+  _commShareMode = mode;
+  document.querySelectorAll('.comm-share-mode-btn').forEach(b =>
+    b.classList.toggle('active', b.dataset.mode === mode));
+  const userEl  = document.getElementById('commShareUserMode');
+  const groupEl = document.getElementById('commShareGroupMode');
+  if (userEl)  userEl.style.display  = mode === 'user'  ? '' : 'none';
+  if (groupEl) groupEl.style.display = mode === 'group' ? '' : 'none';
+  if (mode === 'group') _populateCommShareGroups();
+}
+
+/* Switch item type (templates vs programs) */
+function commShareSetType(type) {
+  _commShareType = type;
+  _commShareSelectedId = null;
+  document.querySelectorAll('.comm-share-type-btn').forEach(b =>
+    b.classList.toggle('active', b.dataset.type === type));
+  renderCommShareItemList();
+}
+
+/* Populate the group select with groups the user has joined */
+function _populateCommShareGroups() {
+  const sel = document.getElementById('commShareGroupSelect');
+  if (!sel) return;
+  const grps = (typeof groups !== 'undefined' ? groups : [])
+    .filter(g => g.members?.some(m => (m.userId || m) === currentUser));
+  if (!grps.length) {
+    sel.innerHTML = '<option value="">No groups joined yet</option>';
+    return;
+  }
+  sel.innerHTML = '<option value="">— select a group —</option>' +
+    grps.map(g => `<option value="${g.id}">${g.name}</option>`).join('');
+}
+
+/* Render the selectable list of user's own templates or programs */
+function renderCommShareItemList() {
+  const listEl = document.getElementById('commShareItemList');
+  if (!listEl || !currentUser) return;
+
+  let items = [];
+  if (_commShareType === 'template') {
+    const raw = JSON.parse(localStorage.getItem(`managedTemplates_${currentUser}`)) || [];
+    items = raw.map(t => ({
+      id: t.localId || t.id || `t_${Math.random()}`,
+      name: t.name || t.data?.title || 'Untitled Template',
+      desc: `${(t.data?.exercises || []).length} exercises`,
+    }));
+  } else {
+    const raw = JSON.parse(localStorage.getItem(`programs_${currentUser}`)) || [];
+    items = raw.map(p => ({
+      id: p.id,
+      name: p.name || 'Untitled Program',
+      desc: `${(p.days || []).length} days · ${p.wizard?.weeks || (p.generatedWeeks?.length) || '?'} weeks`,
+    }));
+  }
+
+  if (!items.length) {
+    listEl.innerHTML = `<div class="comm-share-empty">No ${_commShareType}s saved yet.<br>Save some first from the ${_commShareType === 'template' ? 'Logbook' : 'Programs'} tab.</div>`;
+    return;
+  }
+
+  listEl.innerHTML = items.map(item => `
+    <div class="comm-share-item" data-id="${item.id}" onclick="commShareSelectItem('${item.id}')">
+      <div class="comm-share-item-check">✓</div>
+      <div class="comm-share-item-info">
+        <div class="comm-share-item-name">${item.name}</div>
+        <div class="comm-share-item-desc">${item.desc}</div>
+      </div>
+    </div>`).join('');
+}
+
+/* Highlight a selected item in the list */
+function commShareSelectItem(id) {
+  _commShareSelectedId = id;
+  document.querySelectorAll('#commShareItemList .comm-share-item').forEach(el =>
+    el.classList.toggle('selected', el.dataset.id === id));
+}
+
+/* Main send handler — dispatches to user or group path */
+async function commSendShare() {
+  if (!_commShareSelectedId) {
+    window.showToast?.('Select a program or template first.', 'warn'); return;
+  }
+  const message = document.getElementById('commShareMessage')?.value.trim() || '';
+  if (_commShareMode === 'user') {
+    const recipient = document.getElementById('commShareRecipient')?.value.trim();
+    if (!recipient)                  { window.showToast?.('Enter a recipient username.', 'warn'); return; }
+    if (recipient === currentUser)   { window.showToast?.("You can't share with yourself.", 'warn'); return; }
+    await _commSendToUser(recipient, message);
+  } else {
+    const groupId = document.getElementById('commShareGroupSelect')?.value;
+    if (!groupId) { window.showToast?.('Select a group first.', 'warn'); return; }
+    await _commSendToGroup(groupId, message);
+  }
+}
+
+/* Resolve the selected item's data and name */
+function _commResolveItem() {
+  if (_commShareType === 'template') {
+    const raw = JSON.parse(localStorage.getItem(`managedTemplates_${currentUser}`)) || [];
+    const tpl = raw.find(t => (t.localId || t.id) === _commShareSelectedId);
+    if (!tpl) return null;
+    return { data: tpl.data, name: tpl.name || tpl.data?.title || 'Untitled Template', type: 'template' };
+  } else {
+    const raw = JSON.parse(localStorage.getItem(`programs_${currentUser}`)) || [];
+    const prog = raw.find(p => p.id === _commShareSelectedId);
+    if (!prog) return null;
+    return { data: prog, name: prog.name || 'Untitled Program', type: 'program' };
+  }
+}
+
+async function _commSendToUser(recipient, message) {
+  const item = _commResolveItem();
+  if (!item) { window.showToast?.('Could not find the selected item.', 'warn'); return; }
+
+  /* Try backend (best-effort; template endpoint already exists) */
+  if (item.type === 'template') {
+    try {
+      await fetch(`${window.SERVER_URL}/sendTemplate`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({
+          fromUser: currentUser,
+          toUser: recipient,
+          templateName: `${item.name} (from @${currentUser})`,
+          templateData: item.data,
+          message
+        }),
+        signal: AbortSignal.timeout(5000)
+      });
+    } catch (e) { console.warn('Community sendTemplate backend unavailable, using local', e); }
+  } else {
+    try {
+      await fetch(`${window.SERVER_URL}/shareProgram`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({
+          fromUser: currentUser,
+          toUser: recipient,
+          programData: item.data,
+          message
+        }),
+        signal: AbortSignal.timeout(5000)
+      });
+    } catch (e) { console.warn('Community shareProgram backend unavailable, using local', e); }
+  }
+
+  /* Always persist to recipient's local inbox (works same-device; server handles cross-device) */
+  const inboxKey = `communityInbox_${recipient}`;
+  const inbox = JSON.parse(localStorage.getItem(inboxKey)) || [];
+  inbox.unshift({
+    id: `share_${Date.now()}`,
+    type: item.type,
+    name: item.name,
+    from: currentUser,
+    data: item.data,
+    message,
+    date: new Date().toISOString().slice(0, 10),
+    accepted: false
+  });
+  localStorage.setItem(inboxKey, JSON.stringify(inbox));
+
+  /* Record in sender's outbox */
+  _commAddToOutbox({ type: item.type, name: item.name, to: `@${recipient}`, toType: 'user', date: new Date().toISOString().slice(0, 10) });
+
+  window.showToast?.(`📤 "${item.name}" sent to @${recipient}!`, 'success', 3500);
+  if (document.getElementById('commShareRecipient')) document.getElementById('commShareRecipient').value = '';
+  if (document.getElementById('commShareMessage'))   document.getElementById('commShareMessage').value   = '';
+  _commShareSelectedId = null;
+  renderCommShareItemList();
+  renderCommShareOutbox();
+}
+
+async function _commSendToGroup(groupId, message) {
+  const item = _commResolveItem();
+  if (!item) { window.showToast?.('Could not find the selected item.', 'warn'); return; }
+
+  const groupEl   = document.getElementById('commShareGroupSelect');
+  const groupName = groupEl?.options[groupEl?.selectedIndex]?.text || 'Group';
+
+  /* Piggyback on existing shareProgramToGroup from community.js */
+  if (typeof shareProgramToGroup === 'function') {
+    try {
+      await shareProgramToGroup(groupId, {
+        ...item.data,
+        _type: item.type,
+        _sharedBy: currentUser,
+        _itemName: item.name,
+        _message: message
+      });
+    } catch (e) { console.warn('shareProgramToGroup failed', e); }
+  }
+
+  _commAddToOutbox({ type: item.type, name: item.name, to: groupName, toType: 'group', date: new Date().toISOString().slice(0, 10) });
+
+  window.showToast?.(`📤 "${item.name}" shared to ${groupName}!`, 'success', 3500);
+  if (document.getElementById('commShareMessage')) document.getElementById('commShareMessage').value = '';
+  _commShareSelectedId = null;
+  renderCommShareItemList();
+  renderCommShareOutbox();
+}
+
+/* Append an entry to the sender's outbox (capped at 50) */
+function _commAddToOutbox(item) {
+  const key = `communityOutbox_${currentUser}`;
+  const outbox = JSON.parse(localStorage.getItem(key)) || [];
+  outbox.unshift({ id: `out_${Date.now()}`, ...item });
+  if (outbox.length > 50) outbox.length = 50;
+  localStorage.setItem(key, JSON.stringify(outbox));
+}
+
+/* Render inbox (received items) */
+function renderCommShareInbox() {
+  const el = document.getElementById('commShareInbox');
+  if (!el || !currentUser) return;
+
+  const inbox = (JSON.parse(localStorage.getItem(`communityInbox_${currentUser}`)) || [])
+    .filter(i => !i.accepted && !i.dismissed);
+
+  _renderCommInboxItems(el, inbox);
+
+  /* Also try backend non-blocking */
+  _fetchCommBackendInbox().then(backendItems => {
+    if (!backendItems?.length) return;
+    const existing = new Set(inbox.map(i => i.id));
+    backendItems.filter(b => !existing.has(b.id)).forEach(b => inbox.unshift(b));
+    _renderCommInboxItems(el, inbox);
+    _updateCommShareBadge(inbox.length);
+  });
+
+  _updateCommShareBadge(inbox.length);
+}
+
+async function _fetchCommBackendInbox() {
+  try {
+    const res = await fetch(
+      `${window.SERVER_URL}/shared-inbox?username=${encodeURIComponent(currentUser)}`,
+      { credentials: 'include', headers: getAuthHeaders(), signal: AbortSignal.timeout(5000) }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return Array.isArray(data?.items) ? data.items : null;
+  } catch { return null; }
+}
+
+function _renderCommInboxItems(el, items) {
+  if (!items?.length) {
+    el.innerHTML = `<div class="comm-share-empty">Nothing received yet.<br>When someone shares a program or template with you, it appears here. 📬</div>`;
+    return;
+  }
+  const typeColors = { template: '#5295e0', program: '#9070d8' };
+  const typeLabels = { template: '📋 Template', program: '🗓 Program' };
+  el.innerHTML = items.map(item => `
+    <div class="comm-inbox-item" id="commInboxItem_${item.id}">
+      <div class="comm-inbox-header">
+        <span class="comm-inbox-from">@${item.from || 'unknown'}</span>
+        <span class="comm-inbox-type-badge"
+              style="background:${typeColors[item.type] || '#888'}22;color:${typeColors[item.type] || '#aaa'};border:1px solid ${typeColors[item.type] || '#888'}44">
+          ${typeLabels[item.type] || item.type}
+        </span>
+        <span class="comm-inbox-date">${item.date || ''}</span>
+      </div>
+      <div class="comm-inbox-item-name">${item.name}</div>
+      ${item.message ? `<div class="comm-inbox-message">"${item.message}"</div>` : ''}
+      <div class="comm-inbox-actions">
+        <button class="comm-inbox-accept-btn"  onclick="commAcceptShare('${item.id}')">✅ Accept &amp; Save</button>
+        <button class="comm-inbox-dismiss-btn" onclick="commDismissShare('${item.id}')">Dismiss</button>
+      </div>
+    </div>`).join('');
+}
+
+/* Render outbox (sent history) */
+function renderCommShareOutbox() {
+  const el = document.getElementById('commShareOutbox');
+  if (!el || !currentUser) return;
+  const outbox = JSON.parse(localStorage.getItem(`communityOutbox_${currentUser}`)) || [];
+  if (!outbox.length) {
+    el.innerHTML = `<div class="comm-share-empty">Nothing sent yet.</div>`; return;
+  }
+  const icons = { user: '👤', group: '👥' };
+  el.innerHTML = outbox.slice(0, 15).map(item => `
+    <div class="comm-outbox-item">
+      <div class="comm-outbox-to">
+        <div class="comm-outbox-to-name">${icons[item.toType] || '👤'} ${item.to}</div>
+        <div class="comm-outbox-to-desc">${item.type === 'template' ? '📋' : '🗓'} ${item.name}</div>
+      </div>
+      <div class="comm-outbox-date">${item.date || ''}</div>
+    </div>`).join('');
+}
+
+/* Accept an inbox item → add to local library */
+function commAcceptShare(shareId) {
+  const key   = `communityInbox_${currentUser}`;
+  const inbox = JSON.parse(localStorage.getItem(key)) || [];
+  const item  = inbox.find(i => i.id === shareId);
+  if (!item) return;
+
+  if (item.type === 'template') {
+    const tplKey = `managedTemplates_${currentUser}`;
+    const tpls   = JSON.parse(localStorage.getItem(tplKey)) || [];
+    tpls.unshift({
+      localId: `local_${Date.now()}`,
+      name: `${item.name} (from @${item.from})`,
+      data: item.data,
+      source: 'community'
+    });
+    localStorage.setItem(tplKey, JSON.stringify(tpls));
+    window.showToast?.(`✅ "${item.name}" added to your Templates!`, 'success', 3500);
+  } else {
+    const progKey = `programs_${currentUser}`;
+    const progs   = JSON.parse(localStorage.getItem(progKey)) || [];
+    progs.unshift({
+      ...item.data,
+      id: `comm_${Date.now()}`,
+      name: `${item.name} (from @${item.from})`,
+      _sharedBy: item.from
+    });
+    localStorage.setItem(progKey, JSON.stringify(progs));
+    window.showToast?.(`✅ "${item.name}" added to your Programs!`, 'success', 3500);
+  }
+
+  item.accepted = true;
+  localStorage.setItem(key, JSON.stringify(inbox));
+  document.getElementById(`commInboxItem_${shareId}`)?.remove();
+  _updateCommShareBadge(
+    (JSON.parse(localStorage.getItem(key)) || []).filter(i => !i.accepted && !i.dismissed).length
+  );
+}
+
+/* Dismiss an inbox item */
+function commDismissShare(shareId) {
+  const key   = `communityInbox_${currentUser}`;
+  const inbox = JSON.parse(localStorage.getItem(key)) || [];
+  const item  = inbox.find(i => i.id === shareId);
+  if (item) { item.dismissed = true; localStorage.setItem(key, JSON.stringify(inbox)); }
+  document.getElementById(`commInboxItem_${shareId}`)?.remove();
+}
+
+/* Show/hide the red badge on the Share nav button */
+function _updateCommShareBadge(count) {
+  const badge = document.getElementById('commShareBadge');
+  if (!badge) return;
+  badge.style.display = count > 0 ? '' : 'none';
+  badge.textContent   = count;
+}
+
+/* Orchestrate the whole share panel on open */
+function renderSharePanel() {
+  renderCommShareItemList();
+  renderCommShareInbox();
+  renderCommShareOutbox();
+  if (_commShareMode === 'group') _populateCommShareGroups();
+}
+
+/* Expose all public API */
+window.commShareSetMode    = commShareSetMode;
+window.commShareSetType    = commShareSetType;
+window.commShareSelectItem = commShareSelectItem;
+window.commSendShare       = commSendShare;
+window.commAcceptShare     = commAcceptShare;
+window.commDismissShare    = commDismissShare;
+window.renderSharePanel    = renderSharePanel;
 window.renderWorkouts = renderWorkouts;
 window.toggleWorkoutDetails = toggleWorkoutDetails;
 window.removeWorkout = removeWorkout;               // ✅ Add this

--- a/index.html
+++ b/index.html
@@ -505,7 +505,7 @@
           <button class="measurements-metric-pill" data-metric="shoulders" onclick="renderMeasurementsChart('shoulders')">Shoulders</button>
         </div>
         <div class="measurements-chart-wrap">
-          <canvas id="measurementsCanvas"></canvas>
+          <canvas id="measurementsCanvas" height="220"></canvas>
         </div>
         <div id="measurementsHistory" style="margin-top:12px;"></div>
       </div>
@@ -1013,8 +1013,8 @@
     <!-- ⑤ Charts (collapsible) -->
     <details class="lb-charts-section">
       <summary class="lb-charts-summary">📊 Charts</summary>
-      <canvas id="lbBarChart"></canvas>
-      <canvas id="lbLineChart" style="margin-top:16px;"></canvas>
+      <canvas id="lbBarChart" height="220"></canvas>
+      <canvas id="lbLineChart" height="200" style="margin-top:16px;"></canvas>
     </details>
 
     <!-- ⑨ Exercise leaderboard inline (replaces hidden separate tab) -->
@@ -1460,7 +1460,7 @@
       <section class="progress-chart">
         <div id="progressGamificationCard" class="gamification-panel gamification-card-shell" style="margin-bottom:12px;"></div>
         <div id="progressArchetypeSpotlight" class="gamification-panel" style="margin-bottom:12px;"></div>
-        <canvas id="progressCanvas"></canvas>
+        <canvas id="progressCanvas" height="220"></canvas>
         <div id="exerciseProgress" style="display:none;"></div>
         <div id="trainingLoadPanel" style="margin-top:14px;">
           <h3 style="margin-bottom:6px;">Training Stress
@@ -1470,8 +1470,8 @@
             <strong title="Higher values indicate less day-to-day variation in training load.">Monotony</strong> and
             <strong title="Strain combines weekly work and monotony to estimate total stress.">Strain</strong> are calculated from weekly volume and intensity load.
           </p>
-          <canvas id="monotonyCanvas" style="max-height:180px; margin-bottom:10px;"></canvas>
-          <canvas id="strainCanvas" style="max-height:180px;"></canvas>
+          <canvas id="monotonyCanvas" height="180" style="max-height:180px; margin-bottom:10px;"></canvas>
+          <canvas id="strainCanvas" height="180" style="max-height:180px;"></canvas>
           <div id="loadAlerts" style="margin-top:8px;"></div>
         </div>
         <div id="bodybuildingProgressPanel"></div>

--- a/index.html
+++ b/index.html
@@ -193,8 +193,16 @@
 <div id="progressReminder"></div>
 
   <div id="homeTab" class="tab-content">
+    <!-- Vacation mode active banner -->
+    <div id="vacationModeBanner">
+      <span class="vm-banner-icon">🏖️</span>
+      <span>Vacation Mode — streak &amp; program tracking paused</span>
+      <span class="vm-since"></span>
+    </div>
     <!-- Today's program day + weekly split — populated by today-program.js -->
     <div id="todayProgramCard"></div>
+    <!-- Vacation mode card — populated by session-context.js -->
+    <div id="vacationModeCard"></div>
     <!-- Daily readiness card — populated by readiness-checkin.js -->
     <div id="readinessHomeCard"></div>
     <!-- Weekly summary card — populated by weekly-summary.js -->
@@ -223,6 +231,9 @@
     <!-- ══ Sub-view: Log ══════════════════════════════════════════ -->
     <div id="logSub_log" class="log-subview active">
       <h2 style="padding:0 10px;">Resistance Exercise Log</h2>
+
+      <!-- Session context flags: alt-machine / alt-gym -->
+      <div id="sessionContextBar"></div>
 
       <div id="workoutTimer" class="workout-timer" aria-live="polite">
         <span class="workout-timer-label">Workout Time:</span>
@@ -2005,6 +2016,7 @@ function _doLocalLogin(username) {
   loadTemplateDropdown?.();
   renderDailyMacroProgress?.();
   if (typeof window.renderTodayProgramCard === 'function') window.renderTodayProgramCard();
+  if (typeof window.initSessionContext === 'function') window.initSessionContext();
 }
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -2107,6 +2119,7 @@ async function startLogin() {
       saveDailyMacroProgress(0, 0, 0); // reset progress on login
       renderDailyMacroProgress();
       if (typeof window.renderTodayProgramCard === 'function') window.renderTodayProgramCard();
+      if (typeof window.initSessionContext === 'function') window.initSessionContext();
     }
   } catch (error) {
     console.error('Login error:', error);
@@ -11840,6 +11853,7 @@ window.renderMeetPrep = renderMeetPrep;
   <script src="src/js/progress-report.js"></script>
   <script src="src/js/community-feed.js"></script>
   <script src="src/js/today-program.js"></script>
+  <script src="src/js/session-context.js"></script>
   <script>
     // Render PR board whenever the Streaks sub-tab becomes active
     document.addEventListener('DOMContentLoaded', function() {

--- a/index.html
+++ b/index.html
@@ -66,22 +66,22 @@
       <h2>What's your training focus?</h2>
       <p class="ob-subtitle">We'll personalise the app for you</p>
       <div class="ob-archetype-grid">
-        <button class="ob-archetype-card" data-archetype="bodybuilder">
+        <button class="ob-archetype-card" data-archetype="bodybuilder" onclick="window._selectArchetype(this)">
           <span class="ob-arch-icon">💪</span>
           <strong>Bodybuilder</strong>
           <small>Physique &amp; hypertrophy</small>
         </button>
-        <button class="ob-archetype-card" data-archetype="powerlifter">
+        <button class="ob-archetype-card" data-archetype="powerlifter" onclick="window._selectArchetype(this)">
           <span class="ob-arch-icon">🏋️</span>
           <strong>Powerlifter</strong>
           <small>Squat, bench &amp; deadlift</small>
         </button>
-        <button class="ob-archetype-card" data-archetype="hybrid">
+        <button class="ob-archetype-card" data-archetype="hybrid" onclick="window._selectArchetype(this)">
           <span class="ob-arch-icon">⚡</span>
           <strong>Hybrid</strong>
           <small>Strength &amp; conditioning</small>
         </button>
-        <button class="ob-archetype-card" data-archetype="recreational">
+        <button class="ob-archetype-card" data-archetype="recreational" onclick="window._selectArchetype(this)">
           <span class="ob-arch-icon">🌱</span>
           <strong>Recreational</strong>
           <small>General fitness</small>
@@ -11241,6 +11241,7 @@ function showOnboarding() {
   const overlay = document.getElementById('onboardingOverlay');
   if (overlay) {
     overlay.removeAttribute('hidden');
+    _initOnboarding(); // ensure delegation is wired up before first interaction
     _obGoToStep(1);
   }
 }
@@ -11255,52 +11256,58 @@ function _obGoToStep(step) {
   });
 }
 
+// Global handler callable from inline onclick — works regardless of init order
+window._ob = _ob;
+window._selectArchetype = function(card) {
+  document.querySelectorAll('.ob-archetype-card').forEach(c => c.classList.remove('selected'));
+  card.classList.add('selected');
+  window._ob.archetype = card.dataset.archetype;
+  const btn = document.getElementById('obNext1');
+  if (btn) btn.disabled = false;
+};
+
 function _initOnboarding() {
-  // Step 1: archetype card selection
-  document.querySelectorAll('.ob-archetype-card').forEach(card => {
-    card.addEventListener('click', () => {
-      document.querySelectorAll('.ob-archetype-card').forEach(c => c.classList.remove('selected'));
-      card.classList.add('selected');
-      _ob.archetype = card.dataset.archetype;
-      const btn = document.getElementById('obNext1');
-      if (btn) btn.disabled = false;
-    });
+  const overlay = document.getElementById('onboardingOverlay');
+  if (!overlay || overlay._obDelegated) return;
+  overlay._obDelegated = true;
+
+  // Single delegated listener on the overlay — survives hidden/show cycles
+  // and fires even if direct card listeners were never attached.
+  overlay.addEventListener('click', (e) => {
+    // Archetype card
+    const card = e.target.closest('.ob-archetype-card');
+    if (card) { window._selectArchetype(card); return; }
+
+    if (e.target.closest('#obNext1')) { _obGoToStep(2); return; }
+    if (e.target.closest('#obBack2')) { _obGoToStep(1); return; }
+    if (e.target.closest('#obNext2')) { _obGoToStep(3); return; }
+    if (e.target.closest('#obBack3')) { _obGoToStep(2); return; }
+    if (e.target.closest('#obFinish')) { _finishOnboarding(); return; }
+
+    const unitBtn = e.target.closest('#obUnitToggle .ob-toggle-btn');
+    if (unitBtn) {
+      document.querySelectorAll('#obUnitToggle .ob-toggle-btn').forEach(b => b.classList.remove('ob-active'));
+      unitBtn.classList.add('ob-active');
+      window._ob.unit = unitBtn.dataset.unit;
+      return;
+    }
+    const themeBtn = e.target.closest('#obThemeToggle .ob-toggle-btn');
+    if (themeBtn) {
+      document.querySelectorAll('#obThemeToggle .ob-toggle-btn').forEach(b => b.classList.remove('ob-active'));
+      themeBtn.classList.add('ob-active');
+      window._ob.theme = themeBtn.dataset.theme;
+      return;
+    }
   });
 
-  document.getElementById('obNext1')?.addEventListener('click', () => _obGoToStep(2));
-  document.getElementById('obBack2')?.addEventListener('click', () => _obGoToStep(1));
-
-  // Step 2: experience radio
-  document.querySelectorAll('[name="obExperience"]').forEach(radio => {
-    radio.addEventListener('change', () => {
-      _ob.experience = radio.value;
+  // Experience level uses change (radio), not click
+  overlay.addEventListener('change', (e) => {
+    if (e.target.name === 'obExperience') {
+      window._ob.experience = e.target.value;
       const btn = document.getElementById('obNext2');
       if (btn) btn.disabled = false;
-    });
+    }
   });
-
-  document.getElementById('obNext2')?.addEventListener('click', () => _obGoToStep(3));
-  document.getElementById('obBack3')?.addEventListener('click', () => _obGoToStep(2));
-
-  // Step 3: unit toggle
-  document.querySelectorAll('#obUnitToggle .ob-toggle-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('#obUnitToggle .ob-toggle-btn').forEach(b => b.classList.remove('ob-active'));
-      btn.classList.add('ob-active');
-      _ob.unit = btn.dataset.unit;
-    });
-  });
-
-  // Step 3: theme toggle
-  document.querySelectorAll('#obThemeToggle .ob-toggle-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('#obThemeToggle .ob-toggle-btn').forEach(b => b.classList.remove('ob-active'));
-      btn.classList.add('ob-active');
-      _ob.theme = btn.dataset.theme;
-    });
-  });
-
-  document.getElementById('obFinish')?.addEventListener('click', _finishOnboarding);
 }
 
 function _finishOnboarding() {

--- a/index.html
+++ b/index.html
@@ -4001,7 +4001,7 @@ async function saveTemplate(username, templateName, templateData) {
     console.log('Template saved:', result);
   } catch (error) {
     console.error('Error saving template:', error);
-    alert('Failed to save template. Please try again.');
+    window.showToast('Failed to save template. Please try again.', 'error');
   }
 }
   
@@ -4188,37 +4188,39 @@ function buildTemplateFromWorkout(workout, metadata = {}) {
 
 // Save last workout as template
 function saveWorkoutAsTemplate() {
-  const name = prompt("Template name:");
-  if (!name) return;
-  const description = prompt('Template description (optional):') || '';
-  const tagsInput = prompt('Template tags (comma separated, optional):') || '';
-  const tags = tagsInput.split(',').map(tag => tag.trim()).filter(Boolean);
+  window.showPrompt('Template name:').then(name => {
+    if (!name || !name.trim()) return;
+    window.showPrompt('Description (optional):').then(description => {
+      window.showPrompt('Tags (comma separated, optional):').then(tagsInput => {
+        const tags = tagsInput ? tagsInput.split(',').map(t => t.trim()).filter(Boolean) : [];
 
-  const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
-  if (!workouts.length) return alert("No workout to save.");
-  const template = buildTemplateFromWorkout(workouts[workouts.length - 1], {
-    name,
-    description,
-    tags
-  });
-  const localTemplates = getLocalManagedTemplates();
-  localTemplates.push({
-    localId: `local_${Date.now()}`,
-    name,
-    data: template,
-    source: 'local'
-  });
-  saveLocalManagedTemplates(localTemplates);
+        const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
+        if (!workouts.length) { window.showToast('No workout to save.', 'warn'); return; }
+        const template = buildTemplateFromWorkout(workouts[workouts.length - 1], {
+          name: name.trim(), description: description || '', tags
+        });
+        const localTemplates = getLocalManagedTemplates();
+        localTemplates.push({
+          localId: `local_${Date.now()}`,
+          name: name.trim(),
+          data: template,
+          source: 'local'
+        });
+        saveLocalManagedTemplates(localTemplates);
 
-  saveTemplate(currentUser, name, template)
-    .then(() => {
-      alert("Template saved!");
-      loadTemplateDropdown(); // Refresh dropdown
-    })
-    .catch(err => {
-      console.error(err);
-      alert("Failed to save template.");
+        saveTemplate(currentUser, name.trim(), template)
+          .then(() => {
+            window.showToast('✅ Template saved!', 'success');
+            loadTemplateDropdown();
+          })
+          .catch(err => {
+            console.error(err);
+            window.showToast('Failed to save template to server — saved locally.', 'warn');
+            loadTemplateDropdown();
+          });
+      });
     });
+  });
 }
 
 
@@ -4238,7 +4240,7 @@ function loadSelectedResistanceTemplate() {
   const template = value;
 
   if (!template || typeof template !== 'object') {
-    alert('Invalid template format.');
+    window.showToast('Invalid template format.', 'warn');
     return;
   }
 
@@ -4273,7 +4275,7 @@ function loadSelectedResistanceTemplate() {
       : []);
 
   if (!templateLog.length) {
-    alert('Template has no exercises to load.');
+    window.showToast('Template has no exercises to load.', 'warn');
     return;
   }
 
@@ -4287,23 +4289,23 @@ function loadSelectedResistanceTemplate() {
   });
   localStorage.setItem(`workouts_${currentUser}`, JSON.stringify(workouts));
   renderWorkouts();
-  alert('Template loaded!');
+  window.showToast('✅ Template loaded!', 'success');
 }
 
 // SEND TEMPLATE TO ANOTHER USER
 async function sendTemplate() {
   const otherUser = document.getElementById("shareWithUser").value.trim();
-  if (!otherUser) return alert("Enter username to share with.");
+  if (!otherUser) { window.showToast('Enter a username to share with.', 'warn'); return; }
 
   const select = document.getElementById('resistanceTemplateSelect');
   if (!select || !select.value) {
-    alert('Select a template first.');
+    window.showToast('Select a template first.', 'warn');
     return;
   }
 
   const selected = resistanceTemplatesCache.find(tpl => tpl.id === select.value);
   const templateData = selected?.data;
-  if (!templateData) return alert('Failed to share template.');
+  if (!templateData) { window.showToast('Failed to share template.', 'warn'); return; }
 
   try {
     const response = await fetch(`${window.SERVER_URL}/sendTemplate`, {
@@ -4320,13 +4322,13 @@ async function sendTemplate() {
 
     const result = await response.json();
     if (result.success) {
-      alert("Template sent successfully!");
+      window.showToast('✅ Template sent!', 'success');
     } else {
-      alert(result.message || "Failed to send template.");
+      window.showToast(result.message || 'Failed to send template.', 'warn');
     }
   } catch (error) {
     console.error('Send template error:', error);
-    alert("Error sending template.");
+    window.showToast('Error sending template.', 'error');
   }
 }
 
@@ -4430,7 +4432,7 @@ function saveSimpleTemplate() {
     .split(',')
     .map(tag => tag.trim())
     .filter(Boolean);
-  if (!name || newTemplateExercises.length === 0) return alert('Template info missing');
+  if (!name || newTemplateExercises.length === 0) { window.showToast('Add a name and at least one exercise.', 'warn'); return; }
   const templateData = {
     title: name,
     date: new Date().toISOString().split('T')[0],

--- a/index.html
+++ b/index.html
@@ -193,6 +193,8 @@
 <div id="progressReminder"></div>
 
   <div id="homeTab" class="tab-content">
+    <!-- Today's program day + weekly split — populated by today-program.js -->
+    <div id="todayProgramCard"></div>
     <!-- Daily readiness card — populated by readiness-checkin.js -->
     <div id="readinessHomeCard"></div>
     <!-- Weekly summary card — populated by weekly-summary.js -->
@@ -2002,6 +2004,7 @@ function _doLocalLogin(username) {
   renderCardio?.();
   loadTemplateDropdown?.();
   renderDailyMacroProgress?.();
+  if (typeof window.renderTodayProgramCard === 'function') window.renderTodayProgramCard();
 }
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -2103,6 +2106,7 @@ async function startLogin() {
       loadUserExercises();
       saveDailyMacroProgress(0, 0, 0); // reset progress on login
       renderDailyMacroProgress();
+      if (typeof window.renderTodayProgramCard === 'function') window.renderTodayProgramCard();
     }
   } catch (error) {
     console.error('Login error:', error);
@@ -11835,6 +11839,7 @@ window.renderMeetPrep = renderMeetPrep;
   <script src="src/js/client-checkins.js"></script>
   <script src="src/js/progress-report.js"></script>
   <script src="src/js/community-feed.js"></script>
+  <script src="src/js/today-program.js"></script>
   <script>
     // Render PR board whenever the Streaks sub-tab becomes active
     document.addEventListener('DOMContentLoaded', function() {

--- a/index.html
+++ b/index.html
@@ -1965,6 +1965,46 @@ function setLoading(btn, state) {
 
   
 // LOGIN
+// ── Local credential cache (SHA-256 hash, stored in localStorage) ──────────
+// Lets the app log in offline / when the server is unreachable.
+async function _hashCredential(username, password) {
+  try {
+    const data = new TextEncoder().encode(username.toLowerCase() + ':' + password);
+    const buf  = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2,'0')).join('');
+  } catch { return null; }
+}
+async function _saveLocalCredentials(username, password) {
+  try {
+    const hash  = await _hashCredential(username, password);
+    if (!hash) return;
+    const store = JSON.parse(localStorage.getItem('_localAuth') || '{}');
+    store[username.toLowerCase()] = hash;
+    localStorage.setItem('_localAuth', JSON.stringify(store));
+  } catch { /* non-critical */ }
+}
+async function _checkLocalCredentials(username, password) {
+  try {
+    const hash  = await _hashCredential(username, password);
+    const store = JSON.parse(localStorage.getItem('_localAuth') || '{}');
+    return !!hash && store[username.toLowerCase()] === hash;
+  } catch { return false; }
+}
+function _doLocalLogin(username) {
+  setCurrentUser(username);
+  localStorage.setItem('fitnessAppUser', username);
+  const el = document.getElementById('loginContainer');
+  if (el) el.style.display = 'none';
+  openSection('pocketFit');
+  if (typeof window.renderWorkouts === 'function') window.renderWorkouts();
+  if (typeof syncLocalHistoryFromWorkouts === 'function') syncLocalHistoryFromWorkouts();
+  renderWeights?.();
+  renderCardio?.();
+  loadTemplateDropdown?.();
+  renderDailyMacroProgress?.();
+}
+// ────────────────────────────────────────────────────────────────────────────
+
 async function startLogin() {
   const btn = document.getElementById('loginButton');
   setLoading(btn, true);
@@ -2032,6 +2072,7 @@ async function startLogin() {
       setCurrentUser(username);
       localStorage.setItem("fitnessAppUser", username);
       persistLoginIdentity(username, result.token);
+      _saveLocalCredentials(username, password); // cache for offline login
 
       // BUGFIX: null-safe — #userDisplay may not exist in the current DOM
       const userDisplayEl = document.getElementById("userDisplay");
@@ -2065,13 +2106,18 @@ async function startLogin() {
     }
   } catch (error) {
     console.error('Login error:', error);
+    // Server unreachable — try cached local credentials
+    const localOk = await _checkLocalCredentials(username, password);
+    if (localOk) {
+      console.info('Server offline — using cached local credentials');
+      _doLocalLogin(username);
+      await loadTemplateDropdown();
+      return;
+    }
     if (errorEl) {
       errorEl.textContent = "Unable to connect to the server. Please try again later.";
-    } else {
-      console.error('Unable to connect to the server. Please try again later.');
     }
-
-    await loadTemplateDropdown(); // ✅ Load templates after login
+    await loadTemplateDropdown();
   } finally {
     setLoading(btn, false);
   }
@@ -2416,6 +2462,7 @@ async function startSignup() {
       if (loginResult.success || loginResult.token) {
         if (loginResult.token) localStorage.setItem('token', loginResult.token);
         setCurrentUser(username);
+        _saveLocalCredentials(username, password); // cache for offline login
         document.getElementById('loginContainer').style.display = 'none';
         showOnboarding();
       } else {
@@ -2426,7 +2473,7 @@ async function startSignup() {
     }
   } catch (error) {
     console.error('Signup error:', error);
-    alert("Error connecting to server.");
+    alert("Error connecting to server. If you already have an account, try logging in instead.");
   } finally {
     setLoading(btn, false);
   }

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
   <link rel="stylesheet" href="css/ui-declutter.css">
   <link rel="stylesheet" href="css/features.css">
   <link rel="stylesheet" href="css/cardio.css">
+  <link rel="stylesheet" href="css/checkin.css">
   <link rel="manifest" href="/manifest.json">
   <!-- iOS PWA / Capacitor meta tags -->
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -514,107 +515,229 @@
   </div>
 
   <div id="checkInTab" class="tab-content">
-    <div class="panel active">
-      <h2>Weekly Athlete Check-In</h2>
-      <p style="margin-top:-6px;">Track weekly readiness with prompts tailored to your athlete archetype.</p>
-      <div id="checkInNextDate" class="home-mission-progress"></div>
 
-      <section class="checkin-form-section">
-        <h3>Physical</h3>
-        <input type="date" id="checkInDateInput">
-        <input type="text" id="checkInPhaseInput" placeholder="Phase (contest prep, improvement, mini cut)">
-        <input type="text" id="checkInWeekLabelInput" placeholder="Week label (auto if blank)">
-        <input type="number" step="0.1" id="checkInBodyweightInput" placeholder="Bodyweight">
-        <input type="number" step="0.1" id="checkInWaistInput" placeholder="Waist">
-      </section>
+    <!-- ── Sub-tab navigation ── -->
+    <nav class="ci-nav" id="ciNav">
+      <button class="ci-nav-btn active" data-panel="log"     onclick="switchCheckInTab('log')">📋 Log</button>
+      <button class="ci-nav-btn"        data-panel="adjust"  onclick="switchCheckInTab('adjust')">⚙️ Adjust</button>
+      <button class="ci-nav-btn"        data-panel="photos"  onclick="switchCheckInTab('photos')">📷 Photos</button>
+      <button class="ci-nav-btn"        data-panel="history" onclick="switchCheckInTab('history')">📊 History</button>
+    </nav>
 
-      <section class="checkin-form-section">
-        <h3>Recovery</h3>
+    <!-- ════════════════════════════════════════════════════════
+         PANEL 1 · LOG
+    ═══════════════════════════════════════════════════════════ -->
+    <div id="ciPanel_log" class="ci-panel">
+
+      <!-- Phase banner -->
+      <div id="checkInNextDate" class="ci-phase-banner"></div>
+
+      <!-- Physical -->
+      <div class="ci-card">
+        <h3 class="ci-card-title">📏 Physical</h3>
+        <div class="ci-row-2">
+          <div class="ci-field">
+            <label for="checkInDateInput">Date</label>
+            <input type="date" id="checkInDateInput">
+          </div>
+          <div class="ci-field">
+            <label for="checkInBodyweightInput">Bodyweight (kg)</label>
+            <input type="number" step="0.1" id="checkInBodyweightInput" placeholder="e.g. 82.5">
+          </div>
+        </div>
+        <div class="ci-row-2">
+          <div class="ci-field">
+            <label for="checkInWaistInput">Waist (cm)</label>
+            <input type="number" step="0.1" id="checkInWaistInput" placeholder="e.g. 74">
+          </div>
+          <div class="ci-field">
+            <label for="checkInPhaseInput">Phase</label>
+            <input type="text" id="checkInPhaseInput" placeholder="e.g. contest prep">
+          </div>
+        </div>
+        <div class="ci-field ci-field-full">
+          <label for="checkInWeekLabelInput">Week label <span class="ci-opt">(auto if blank)</span></label>
+          <input type="text" id="checkInWeekLabelInput" placeholder="e.g. 8 Weeks Out">
+        </div>
+      </div>
+
+      <!-- Recovery -->
+      <div class="ci-card">
+        <h3 class="ci-card-title">😴 Recovery</h3>
         <div class="checkin-slider-field">
-          <div class="checkin-slider-header"><span class="checkin-slider-title">Energy</span><strong class="checkin-slider-value" id="checkInEnergyValue">5</strong></div>
+          <div class="checkin-slider-header">
+            <span class="checkin-slider-title">⚡ Energy</span>
+            <strong class="checkin-slider-value" id="checkInEnergyValue">5</strong>
+          </div>
           <input type="range" min="1" max="10" step="1" value="5" id="checkInEnergyInput" data-value-target="checkInEnergyValue">
           <div class="checkin-slider-labels"><span>Drained</span><span>High Energy</span></div>
         </div>
         <div class="checkin-slider-field">
-          <div class="checkin-slider-header"><span class="checkin-slider-title">Sleep Quality</span><strong class="checkin-slider-value" id="checkInSleepValue">5</strong></div>
+          <div class="checkin-slider-header">
+            <span class="checkin-slider-title">🌙 Sleep Quality</span>
+            <strong class="checkin-slider-value" id="checkInSleepValue">5</strong>
+          </div>
           <input type="range" min="1" max="10" step="1" value="5" id="checkInSleepInput" data-value-target="checkInSleepValue">
           <div class="checkin-slider-labels"><span>Poor Sleep</span><span>Excellent Sleep</span></div>
         </div>
         <div class="checkin-slider-field">
-          <div class="checkin-slider-header"><span class="checkin-slider-title">Stress</span><strong class="checkin-slider-value" id="checkInStressValue">5</strong></div>
+          <div class="checkin-slider-header">
+            <span class="checkin-slider-title">🧠 Stress</span>
+            <strong class="checkin-slider-value" id="checkInStressValue">5</strong>
+          </div>
           <input type="range" min="1" max="10" step="1" value="5" id="checkInStressInput" data-value-target="checkInStressValue">
           <div class="checkin-slider-labels"><span>Low Stress</span><span>High Stress</span></div>
         </div>
-      </section>
+      </div>
 
-      <section class="checkin-form-section">
-        <h3 id="checkInArchetypeSectionTitle">Archetype Focus</h3>
-        <p id="checkInArchetypeSectionDescription" class="home-mission-progress">Loading archetype-specific prompts…</p>
+      <!-- Archetype focus -->
+      <div class="ci-card">
+        <h3 class="ci-card-title" id="checkInArchetypeSectionTitle">🎯 Archetype Focus</h3>
+        <p class="ci-card-desc" id="checkInArchetypeSectionDescription">Loading archetype-specific prompts…</p>
         <div id="checkInArchetypeFields"></div>
-      </section>
+      </div>
 
-      <section class="checkin-form-section">
-        <h3>Notes</h3>
-        <textarea id="checkInNotesInput" placeholder="Notes"></textarea>
-      </section>
-      <section class="checkin-form-section">
-        <h3>Weekly Adjustments</h3>
-        <label><input type="checkbox" id="checkInAdjustmentMacrosChanged"> Macros changed</label>
-        <input type="text" id="checkInAdjustmentMacrosNotes" placeholder="Macro adjustment details">
-        <label><input type="checkbox" id="checkInAdjustmentCardioChanged"> Cardio changed</label>
-        <input type="text" id="checkInAdjustmentCardioNotes" placeholder="Cardio adjustment details">
-        <label><input type="checkbox" id="checkInAdjustmentStepsChanged"> Steps changed</label>
-        <input type="text" id="checkInAdjustmentStepsNotes" placeholder="Step target adjustment details">
-        <label><input type="checkbox" id="checkInAdjustmentRefeedAdded"> Refeed added</label>
-        <input type="text" id="checkInAdjustmentRefeedNotes" placeholder="Refeed details">
-      </section>
-      <section class="checkin-form-section">
-        <h3>Coach Review</h3>
-        <select id="checkInReviewStatusInput">
-          <option value="pending">Pending coach review</option>
-          <option value="reviewed">Reviewed</option>
-          <option value="approved">Approved</option>
-          <option value="needs_changes">Needs changes</option>
-        </select>
-        <textarea id="checkInCoachNotesInput" placeholder="Coach notes"></textarea>
-        <textarea id="checkInCoachActionItemsInput" placeholder="Coach action items for next week"></textarea>
-      </section>
-      <section class="checkin-form-section">
-        <h3>Summary & Export</h3>
-        <div id="checkInSummaryOutput" class="home-mission-progress">Save or select a check-in to generate a prep summary.</div>
-        <button type="button" onclick="generateCheckInSummary()">Generate Summary</button>
-        <button type="button" onclick="exportCheckInSummary('json')">Export Summary JSON</button>
-        <button type="button" onclick="exportCheckInSummary('txt')">Export Summary TXT</button>
-      </section>
-      <!-- Progress photo upload grid -->
-      <div class="photo-upload-grid">
-        <div class="photo-upload-slot">
-          <label>Front</label>
-          <div class="photo-upload-preview" id="photoSlot_front" onclick="document.getElementById('photoFile_front').click()">📷</div>
-          <input type="file" class="photo-upload-input" id="photoFile_front" accept="image/*">
-        </div>
-        <div class="photo-upload-slot">
-          <label>Side</label>
-          <div class="photo-upload-preview" id="photoSlot_side" onclick="document.getElementById('photoFile_side').click()">📷</div>
-          <input type="file" class="photo-upload-input" id="photoFile_side" accept="image/*">
-        </div>
-        <div class="photo-upload-slot">
-          <label>Back</label>
-          <div class="photo-upload-preview" id="photoSlot_back" onclick="document.getElementById('photoFile_back').click()">📷</div>
-          <input type="file" class="photo-upload-input" id="photoFile_back" accept="image/*">
+      <!-- Notes -->
+      <div class="ci-card">
+        <h3 class="ci-card-title">📝 Notes</h3>
+        <div class="ci-field ci-field-full">
+          <textarea id="checkInNotesInput" placeholder="How did the week go? Any key observations…"></textarea>
         </div>
       </div>
-      <!-- Hidden legacy inputs kept for saveWeeklyCheckIn() compatibility -->
-      <input type="text" id="checkInFrontPhotoInput" style="display:none">
-      <input type="text" id="checkInSidePhotoInput" style="display:none">
-      <input type="text" id="checkInBackPhotoInput" style="display:none">
-      <button onclick="saveWeeklyCheckIn('athlete')">Save Athlete Check-In</button>
-      <button type="button" onclick="saveWeeklyCheckIn('coach')">Save Coach Review</button>
 
-      <h3>Check-In Timeline</h3>
+      <button class="ci-save-btn" onclick="saveWeeklyCheckIn('athlete')">Save Check-In ✓</button>
+    </div><!-- /ciPanel_log -->
+
+    <!-- ════════════════════════════════════════════════════════
+         PANEL 2 · ADJUSTMENTS + COACH REVIEW
+    ═══════════════════════════════════════════════════════════ -->
+    <div id="ciPanel_adjust" class="ci-panel" style="display:none">
+
+      <!-- Weekly adjustments -->
+      <div class="ci-card">
+        <h3 class="ci-card-title">📐 Weekly Adjustments</h3>
+
+        <div class="ci-adjust-row">
+          <label class="ci-toggle-label">
+            <input type="checkbox" class="ci-toggle-input" id="checkInAdjustmentMacrosChanged">
+            <span class="ci-toggle-track"></span>
+            <span class="ci-toggle-text">🥗 Macros Changed</span>
+          </label>
+          <input type="text" class="ci-adjust-notes" id="checkInAdjustmentMacrosNotes" placeholder="e.g. +10g carbs on training days">
+        </div>
+
+        <div class="ci-adjust-row">
+          <label class="ci-toggle-label">
+            <input type="checkbox" class="ci-toggle-input" id="checkInAdjustmentCardioChanged">
+            <span class="ci-toggle-track"></span>
+            <span class="ci-toggle-text">🏃 Cardio Changed</span>
+          </label>
+          <input type="text" class="ci-adjust-notes" id="checkInAdjustmentCardioNotes" placeholder="e.g. added 20 min LISS morning">
+        </div>
+
+        <div class="ci-adjust-row">
+          <label class="ci-toggle-label">
+            <input type="checkbox" class="ci-toggle-input" id="checkInAdjustmentStepsChanged">
+            <span class="ci-toggle-track"></span>
+            <span class="ci-toggle-text">👟 Steps Target Changed</span>
+          </label>
+          <input type="text" class="ci-adjust-notes" id="checkInAdjustmentStepsNotes" placeholder="e.g. 12,000 → 10,000/day">
+        </div>
+
+        <div class="ci-adjust-row">
+          <label class="ci-toggle-label">
+            <input type="checkbox" class="ci-toggle-input" id="checkInAdjustmentRefeedAdded">
+            <span class="ci-toggle-track"></span>
+            <span class="ci-toggle-text">🍚 Refeed Added</span>
+          </label>
+          <input type="text" class="ci-adjust-notes" id="checkInAdjustmentRefeedNotes" placeholder="e.g. Saturday 2,600 kcal refeed">
+        </div>
+      </div>
+
+      <!-- Coach review -->
+      <div class="ci-card">
+        <h3 class="ci-card-title">👨‍💼 Coach Review</h3>
+        <div class="ci-field ci-field-full" style="margin-bottom:10px">
+          <label for="checkInReviewStatusInput">Review Status</label>
+          <select id="checkInReviewStatusInput">
+            <option value="pending">⏳ Pending review</option>
+            <option value="reviewed">👁 Reviewed</option>
+            <option value="approved">✅ Approved</option>
+            <option value="needs_changes">✏️ Needs changes</option>
+          </select>
+        </div>
+        <div class="ci-field ci-field-full" style="margin-bottom:10px">
+          <label for="checkInCoachNotesInput">Coach Notes</label>
+          <textarea id="checkInCoachNotesInput" placeholder="Feedback for the athlete…"></textarea>
+        </div>
+        <div class="ci-field ci-field-full">
+          <label for="checkInCoachActionItemsInput">Action Items (next week)</label>
+          <textarea id="checkInCoachActionItemsInput" placeholder="e.g. Increase cardio to 5× this week…"></textarea>
+        </div>
+      </div>
+
+      <button class="ci-save-btn" onclick="saveWeeklyCheckIn('coach')">Save Coach Review ✓</button>
+    </div><!-- /ciPanel_adjust -->
+
+    <!-- ════════════════════════════════════════════════════════
+         PANEL 3 · PROGRESS PHOTOS
+    ═══════════════════════════════════════════════════════════ -->
+    <div id="ciPanel_photos" class="ci-panel" style="display:none">
+      <div class="ci-card">
+        <h3 class="ci-card-title">📷 Progress Photos</h3>
+        <p class="ci-card-desc">Tap a slot to upload. Photos are stored locally on your device.</p>
+        <div class="ci-photo-grid">
+          <div class="ci-photo-slot">
+            <label>Front</label>
+            <div class="ci-photo-preview photo-upload-preview" id="photoSlot_front"
+                 onclick="document.getElementById('photoFile_front').click()">📷</div>
+            <input type="file" class="photo-upload-input" id="photoFile_front" accept="image/*">
+          </div>
+          <div class="ci-photo-slot">
+            <label>Side</label>
+            <div class="ci-photo-preview photo-upload-preview" id="photoSlot_side"
+                 onclick="document.getElementById('photoFile_side').click()">📷</div>
+            <input type="file" class="photo-upload-input" id="photoFile_side" accept="image/*">
+          </div>
+          <div class="ci-photo-slot">
+            <label>Back</label>
+            <div class="ci-photo-preview photo-upload-preview" id="photoSlot_back"
+                 onclick="document.getElementById('photoFile_back').click()">📷</div>
+            <input type="file" class="photo-upload-input" id="photoFile_back" accept="image/*">
+          </div>
+        </div>
+      </div>
+      <button class="ci-save-btn" onclick="saveWeeklyCheckIn('athlete')">Save with Photos ✓</button>
+    </div><!-- /ciPanel_photos -->
+
+    <!-- ════════════════════════════════════════════════════════
+         PANEL 4 · HISTORY + SUMMARY
+    ═══════════════════════════════════════════════════════════ -->
+    <div id="ciPanel_history" class="ci-panel" style="display:none">
+
+      <!-- Summary card -->
+      <div class="ci-card">
+        <h3 class="ci-card-title">📊 Latest Summary</h3>
+        <div id="checkInSummaryOutput" class="ci-summary-output">
+          Save your first check-in to generate a prep summary.
+        </div>
+        <div class="ci-btn-row">
+          <button class="ci-sec-btn" onclick="generateCheckInSummary()">🔄 Refresh</button>
+          <button class="ci-sec-btn" onclick="exportCheckInSummary('txt')">📄 Export TXT</button>
+          <button class="ci-sec-btn" onclick="exportCheckInSummary('json')">⬇️ Export JSON</button>
+        </div>
+      </div>
+
+      <!-- Timeline (rendered by renderCheckInTab) -->
       <div id="checkInTimeline"></div>
-    </div>
-  </div>
+    </div><!-- /ciPanel_history -->
+
+    <!-- Legacy hidden inputs kept for saveWeeklyCheckIn() compatibility -->
+    <input type="text" id="checkInFrontPhotoInput" style="display:none">
+    <input type="text" id="checkInSidePhotoInput"  style="display:none">
+    <input type="text" id="checkInBackPhotoInput"  style="display:none">
+
+  </div><!-- /checkInTab -->
   
 <div id="crossfitTab" class="tab-content">
   <div id="cfEntryPanel" class="panel active">
@@ -8055,6 +8178,22 @@ window.renderCoachClientRoster = renderCoachClientRoster;
 window.renderCoachClientCard = renderCoachClientCard;
 window.renderCoachClientDetail = renderCoachClientDetail;
 
+/* ── Check-in sub-tab switcher ──────────────────────────────── */
+function switchCheckInTab(panel) {
+  ['log', 'adjust', 'photos', 'history'].forEach(p => {
+    const el = document.getElementById(`ciPanel_${p}`);
+    if (el) el.style.display = p === panel ? '' : 'none';
+  });
+  document.querySelectorAll('#ciNav .ci-nav-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.panel === panel);
+  });
+  // Refresh history when switching to it
+  if (panel === 'history') {
+    generateCheckInSummary?.();
+  }
+}
+window.switchCheckInTab = switchCheckInTab;
+
 const CHECKIN_ARCHETYPE_SCHEMAS = Object.freeze({
   bodybuilder: {
     label: 'Bodybuilder Check-In',
@@ -8212,53 +8351,73 @@ function renderCheckInTab() {
 
   const timeline = document.getElementById('checkInTimeline');
   if (!timeline) return;
-  timeline.innerHTML = '<p class="home-mission-progress">Loading weekly check-ins…</p>';
 
   const entriesWithInsights = window.checkinEngine.getCheckInInsightTimeline?.(checkIns) || checkIns;
   const groupedTimeline = window.checkinEngine.groupCheckInsForTimeline?.(entriesWithInsights) || [];
   if (!groupedTimeline.length) {
-    timeline.innerHTML = '<p class="home-mission-progress">No weekly ritual logged yet. Save your first check-in to build your prep timeline.</p>';
+    timeline.innerHTML = `<div class="ci-timeline-empty">No check-ins logged yet.<br><span style="font-size:1.6rem;display:block;margin-top:8px">📋</span></div>`;
     return;
   }
 
-  timeline.innerHTML = groupedTimeline.map((weeksOutGroup) => {
-    const phaseWeekBlocks = weeksOutGroup.phaseWeeks.map((phaseWeekGroup) => {
-      const entries = phaseWeekGroup.entries.map((entry) => `
-        <li style="margin-bottom:10px;">
-          <strong>${entry.date}</strong> · Phase: ${entry.phase || '—'}<br />
-          Archetype: ${entry.archetype || 'legacy'}<br />
-          BW: ${entry.bodyweight || '—'} · Waist: ${entry.waist || '—'} · Recovery (E/S/St): ${entry.recoveryRatings?.energy || entry.energy || '—'}/${entry.recoveryRatings?.sleep || entry.sleep || '—'}/${entry.recoveryRatings?.stress || entry.stress || '—'}<br />
-          ${formatCheckInArchetypeMetricSummary(entry)}
-          <div style="font-size:0.9rem; opacity:0.85;">${entry.notes || 'No notes logged.'}</div>
-          <div style="font-size:0.88rem; margin-top:4px;">
-            <strong>Weekly adjustments:</strong> ${formatAdjustmentSummary(entry.adjustments)}
-          </div>
-          <div style="font-size:0.88rem; margin-top:4px;">
-            <strong>Coach review:</strong> ${(entry.review?.status || 'pending').replace('_', ' ')}
-            ${entry.review?.coachActionItems ? ` · Action items: ${entry.review.coachActionItems}` : ''}
-          </div>
-          <div style="font-size:0.88rem; opacity:0.9;">${entry.coachNotes ? `Coach notes: ${entry.coachNotes}` : 'Coach notes pending.'}</div>
-          <div style="font-size:0.86rem; opacity:0.95; margin-top:6px; border-left:3px solid rgba(47,128,237,0.45); padding-left:8px;">
-            <strong>Coach insight:</strong> ${(entry.insights?.summaryShort) || 'More check-ins needed for trend feedback.'}
-            ${entry.insights?.summaryFull?.length ? `<div style="margin-top:4px;">${entry.insights.summaryFull.map(line => `<div>• ${line}</div>`).join('')}</div>` : ''}
-          </div>
-        </li>
-      `).join('');
+  function _scoreClass(val, invert) {
+    const n = Number(val);
+    if (!Number.isFinite(n)) return '';
+    if (invert) return n >= 7 ? 'poor' : n >= 4 ? 'mid' : 'good'; // stress: high = bad
+    return n >= 7 ? 'good' : n >= 4 ? 'mid' : 'poor';
+  }
 
-      return `
-        <article class="checkin-timeline-subgroup">
-          <h5>${phaseWeekGroup.phaseWeekLabel}</h5>
-          <ul>${entries}</ul>
-        </article>
-      `;
-    }).join('');
+  function _statusLabel(status) {
+    return { approved: '✅ Approved', reviewed: '👁 Reviewed', needs_changes: '✏️ Needs changes', pending: '⏳ Pending' }[status] || '⏳ Pending';
+  }
+
+  timeline.innerHTML = groupedTimeline.map((weeksOutGroup) => {
+    const cards = weeksOutGroup.phaseWeeks.flatMap((phaseWeekGroup) =>
+      phaseWeekGroup.entries.map((entry) => {
+        const status  = entry.review?.status || 'pending';
+        const energy  = entry.recoveryRatings?.energy || entry.energy || '';
+        const sleep   = entry.recoveryRatings?.sleep  || entry.sleep  || '';
+        const stress  = entry.recoveryRatings?.stress || entry.stress || '';
+        const adjText = formatAdjustmentSummary(entry.adjustments);
+        const insight = entry.insights?.summaryShort || '';
+        const insightFull = (entry.insights?.summaryFull || []).join(' · ');
+        const archetypeMetrics = formatCheckInArchetypeMetricSummary(entry);
+        const dateLabel = (() => {
+          try { return new Date(entry.date + 'T00:00:00').toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' }); } catch { return entry.date; }
+        })();
+
+        return `
+          <div class="ci-tc" data-status="${status}">
+            <div class="ci-tc-header">
+              <span class="ci-tc-date">${dateLabel}</span>
+              ${entry.phase ? `<span class="ci-tc-badge">${entry.phase}</span>` : ''}
+              ${phaseWeekGroup.phaseWeekLabel ? `<span class="ci-tc-badge">${phaseWeekGroup.phaseWeekLabel}</span>` : ''}
+              <span class="ci-tc-status-badge ${status}">${_statusLabel(status)}</span>
+            </div>
+            <div class="ci-tc-stats">
+              ${entry.bodyweight ? `<span class="ci-tc-stat">⚖️ ${entry.bodyweight} kg</span>` : ''}
+              ${entry.waist      ? `<span class="ci-tc-stat">📏 ${entry.waist} cm</span>`  : ''}
+              ${energy !== ''    ? `<span class="ci-tc-stat ${_scoreClass(energy, false)}">⚡ E:${energy}</span>` : ''}
+              ${sleep  !== ''    ? `<span class="ci-tc-stat ${_scoreClass(sleep, false)}">🌙 S:${sleep}</span>`  : ''}
+              ${stress !== ''    ? `<span class="ci-tc-stat ${_scoreClass(stress, true)}">🧠 St:${stress}</span>` : ''}
+            </div>
+            ${archetypeMetrics ? `<div class="ci-tc-archetype">${archetypeMetrics}</div>` : ''}
+            ${(insight || insightFull) ? `<div class="ci-tc-insight">💡 ${insight}${insightFull ? '<br><span style="opacity:0.8">'+insightFull+'</span>' : ''}</div>` : ''}
+            ${adjText && adjText !== 'No weekly adjustments logged.' ? `<div class="ci-tc-adjust">⚙️ ${adjText}</div>` : ''}
+            ${entry.notes     ? `<div class="ci-tc-notes">"${entry.notes}"</div>` : ''}
+            ${(entry.coachNotes || entry.review?.coachActionItems) ? `
+              <div class="ci-tc-coach">
+                ${entry.coachNotes ? `<div>📝 ${entry.coachNotes}</div>` : ''}
+                ${entry.review?.coachActionItems ? `<div>→ ${entry.review.coachActionItems}</div>` : ''}
+              </div>` : ''}
+          </div>`;
+      })
+    ).join('');
 
     return `
-      <section class="home-dashboard-card checkin-timeline-group">
-        <h4>${weeksOutGroup.weeksOutLabel}</h4>
-        ${phaseWeekBlocks}
-      </section>
-    `;
+      <div class="ci-timeline-group">
+        <div class="ci-timeline-group-label">${weeksOutGroup.weeksOutLabel}</div>
+        ${cards}
+      </div>`;
   }).join('');
   generateCheckInSummary();
 }
@@ -8515,8 +8674,14 @@ function saveWeeklyCheckIn(actor = 'athlete') {
 
   const weekLabelInput = document.getElementById('checkInWeekLabelInput');
   if (weekLabelInput) weekLabelInput.value = draft.weekLabel;
+
+  const saveLabel = actor === 'coach' ? 'Coach review saved ✓' : `Check-in saved — ${draft.weekLabel || draft.date} ✓`;
+  window.showToast?.(saveLabel, 'success', 3500);
+
   renderCheckInTab();
   generateCheckInSummary();
+  // Auto-navigate to history so the user sees their new entry
+  switchCheckInTab('history');
 }
 
 window.saveWeeklyCheckIn = saveWeeklyCheckIn;

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -338,7 +338,7 @@ async function fetchLeaderboard() {
   if (spinner) spinner.style.display = 'flex';
   if (empty)   empty.style.display   = 'none';
   try {
-    const res = await fetch(`${window.SERVER_URL}/leaderboard`, { headers: getAuthHeaders() });
+    const res = await fetch(`${window.SERVER_URL}/leaderboard`, { headers: getAuthHeaders(), signal: AbortSignal.timeout(5000) });
     leaderboardData = await res.json();
   } catch (e) {
     console.warn('fetch leaderboard failed', e);

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -42,15 +42,21 @@ function buildLocalStats(username) {
   const weightLog   = _parse(`weightLog_${username}`) || _parse('weightEntries') || [];
   const readiness   = _parse('dailyReadiness_v1') || {};
 
-  // Workout streak
-  const workedDates = new Set(workouts.map(w => w.date).filter(Boolean));
+  // Workout streak (vacation days count as "kept" so they don't break the streak)
+  const workedDates   = new Set(workouts.map(w => w.date).filter(Boolean));
+  const _isVacation   = typeof window.isVacationDate === 'function' ? window.isVacationDate : () => false;
   let streak = 0;
   const today = new Date();
   const check = new Date(today);
   check.setHours(0, 0, 0, 0);
-  while (workedDates.has(check.toISOString().slice(0, 10))) {
-    streak++;
-    check.setDate(check.getDate() - 1);
+  while (true) {
+    const ds = check.toISOString().slice(0, 10);
+    if (workedDates.has(ds) || _isVacation(ds)) {
+      streak++;
+      check.setDate(check.getDate() - 1);
+    } else {
+      break;
+    }
   }
 
   // Workouts this month

--- a/lifestyle.js
+++ b/lifestyle.js
@@ -12,7 +12,8 @@ function initLifestyle(){
     btn.addEventListener('click',()=>showLifestyleTab(btn.dataset.ltab));
   });
   showLifestyleTab('dailyTab');
-  document.getElementById('scheduleDate').value = new Date().toISOString().split('T')[0];
+  const _sd = document.getElementById('scheduleDate');
+  if (_sd) _sd.value = new Date().toISOString().split('T')[0];
   renderSchedule();
   renderStudy();
   renderTodos();
@@ -28,7 +29,7 @@ function showLifestyleTab(id){
 function renderSchedule(){
   const list=document.getElementById('scheduleList');
   if(!list) return;
-  const date=document.getElementById('scheduleDate').value;
+  const date=document.getElementById('scheduleDate')?.value;
   const items=load('schedule').filter(i=>i.date===date);
   list.innerHTML='';
   items.forEach(item=>{
@@ -42,7 +43,7 @@ function renderSchedule(){
 function openScheduleForm(){
   const text=prompt('Schedule item');
   if(!text) return;
-  const date=document.getElementById('scheduleDate').value;
+  const date=document.getElementById('scheduleDate')?.value;
   const data=load('schedule');
   data.push({id:Date.now(),date,text,done:false});
   save('schedule',data);
@@ -79,8 +80,8 @@ function addSubject(){
   if(!sub) return;
   const opt=document.createElement('option');
   opt.textContent=sub; opt.value=sub;
-  document.getElementById('subjectFilter').appendChild(opt);
-  document.getElementById('subjectFilter').value=sub;
+  const sf=document.getElementById('subjectFilter');
+  if(sf){ sf.appendChild(opt); sf.value=sub; }
 }
 function startStudySession(){
   const btn=document.getElementById('studyTimerBtn');
@@ -88,7 +89,7 @@ function startStudySession(){
   if(studyTimer){
     clearInterval(studyTimer); studyTimer=null;
     const mins=Math.round((Date.now()-studyStart)/60000);
-    const subject=document.getElementById('subjectFilter').value || 'General';
+    const subject=document.getElementById('subjectFilter')?.value || 'General';
     const date=new Date().toISOString().split('T')[0];
     const data=load('study');
     data.push({id:Date.now(),date,subject,duration:mins});
@@ -148,13 +149,13 @@ function addTodoCategory(){
   const c=prompt('New category');
   if(!c) return;
   const opt=document.createElement('option'); opt.textContent=c; opt.value=c;
-  document.getElementById('todoCategoryFilter').appendChild(opt);
-  document.getElementById('todoCategoryFilter').value=c;
+  const cf=document.getElementById('todoCategoryFilter');
+  if(cf){ cf.appendChild(opt); cf.value=c; }
 }
 function openTodoForm(){
   const text=prompt('Task');
   if(!text) return;
-  const cat=document.getElementById('todoCategoryFilter').value||'General';
+  const cat=document.getElementById('todoCategoryFilter')?.value||'General';
   const todos=load('todo');
   todos.push({id:Date.now(),text,category:cat,done:false});
   save('todo',todos); renderTodos();

--- a/macrosFeatures.js
+++ b/macrosFeatures.js
@@ -24,7 +24,7 @@ export async function scanBarcode() {
 
 export async function importRecipe(url) {
   try {
-    const res = await fetch(url, { credentials: "include" });
+    const res = await fetch(url, { credentials: "include", signal: AbortSignal.timeout(5000) });
     const text = await res.text();
     const m = text.match(/(protein|fat|carb)s?\s*:?\s*(\d+)/gi);
     if (!m) return null;

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,100 @@
 {
   "name": "Pocket Coach",
-  "short_name": "PocketCoach",
+  "short_name": "Pocket Coach",
   "description": "Your personal fitness training log and coach.",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#0b130d",
   "theme_color": "#5fa87e",
   "orientation": "portrait-primary",
+  "lang": "en",
+  "categories": ["fitness", "health", "sports"],
   "icons": [
     {
-      "src": "/favicon.ico",
-      "sizes": "any",
-      "type": "image/x-icon",
-      "purpose": "any maskable"
+      "src": "/public/icons/icon-72.png",
+      "sizes": "72x72",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/public/icons/icon-96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/public/icons/icon-128.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/public/icons/icon-144.png",
+      "sizes": "144x144",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/public/icons/icon-152.png",
+      "sizes": "152x152",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/public/icons/icon-180.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/public/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/public/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/public/icons/icon-512-maskable.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/public/icons/icon-1024.png",
+      "sizes": "1024x1024",
+      "type": "image/png",
+      "purpose": "any"
     }
   ],
-  "categories": ["fitness", "health", "sports"],
-  "screenshots": []
+  "screenshots": [
+    {
+      "src": "/public/screenshots/home.png",
+      "sizes": "390x844",
+      "type": "image/png",
+      "form_factor": "narrow",
+      "label": "Home dashboard"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Log Workout",
+      "short_name": "Log",
+      "description": "Quickly log a workout",
+      "url": "/?tab=logTab",
+      "icons": [{ "src": "/public/icons/icon-96.png", "sizes": "96x96" }]
+    },
+    {
+      "name": "Check Progress",
+      "short_name": "Progress",
+      "description": "View your progress",
+      "url": "/?tab=progressTab",
+      "icons": [{ "src": "/public/icons/icon-96.png", "sizes": "96x96" }]
+    }
+  ]
 }

--- a/offline.js
+++ b/offline.js
@@ -14,7 +14,7 @@ export async function processQueue() {
   for (let i = 0; i < pendingActions.length; i++) {
     const { url, options } = pendingActions[i];
     try {
-      await fetch(url, { ...options, credentials: "include" });
+      await fetch(url, { ...options, credentials: "include", signal: AbortSignal.timeout(5000) });
       pendingActions.splice(i, 1);
       i--;
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@capacitor/android": "^6.0.0",
+    "@capacitor/core": "^6.0.0",
+    "@capacitor/ios": "^6.0.0",
     "chart.js": "^4.5.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
@@ -19,7 +22,9 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",
+    "@capacitor/cli": "^6.0.0",
     "jest": "^29.6.1",
-    "jsdom": "^26.1.0"
+    "jsdom": "^26.1.0",
+    "sharp": "^0.33.0"
   }
 }

--- a/prepMode.js
+++ b/prepMode.js
@@ -274,7 +274,8 @@
       return globalScope.fetch(`/api/bodybuilding/phase-state/${encodeURIComponent(resolvedUser)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(5000)
       }).then(() => true).catch(() => false);
     } catch (_error) {
       return false;
@@ -285,7 +286,7 @@
   let _apiBackendConfirmed = false;
   function _hasApiBackend() { return _apiBackendConfirmed; }
   if (typeof globalScope.fetch === 'function') {
-    globalScope.fetch('/api/ping', { method: 'HEAD' })
+    globalScope.fetch('/api/ping', { method: 'HEAD', signal: AbortSignal.timeout(5000) })
       .then(r => { if (r.ok) _apiBackendConfirmed = true; })
       .catch(() => {});
   }

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * generate-icons.js
+ * Resizes public/icons/icon-source.png into every size needed for
+ * iOS, Android, PWA manifest, and the App Store submission.
+ *
+ * Usage:
+ *   1. Save your 1024×1024 (or larger) app icon as:
+ *        public/icons/icon-source.png
+ *   2. Install sharp:
+ *        npm install sharp --save-dev
+ *   3. Run:
+ *        node scripts/generate-icons.js
+ */
+
+const sharp  = require('sharp');
+const path   = require('path');
+const fs     = require('fs');
+
+const SRC  = path.join(__dirname, '..', 'public', 'icons', 'icon-source.png');
+const DEST = path.join(__dirname, '..', 'public', 'icons');
+
+// Sizes needed
+const SIZES = [
+  // PWA manifest
+  { size: 72,   name: 'icon-72.png' },
+  { size: 96,   name: 'icon-96.png' },
+  { size: 128,  name: 'icon-128.png' },
+  { size: 144,  name: 'icon-144.png' },
+  { size: 152,  name: 'icon-152.png' },
+  { size: 180,  name: 'icon-180.png' },   // apple-touch-icon
+  { size: 192,  name: 'icon-192.png' },
+  { size: 512,  name: 'icon-512.png' },
+  { size: 512,  name: 'icon-512-maskable.png' },
+  { size: 1024, name: 'icon-1024.png' },  // App Store
+
+  // Favicon sizes
+  { size: 16,   name: 'favicon-16.png' },
+  { size: 32,   name: 'favicon-32.png' },
+
+  // iOS-specific (Xcode asset catalog)
+  { size: 20,   name: 'ios/AppIcon-20@1x.png' },
+  { size: 40,   name: 'ios/AppIcon-20@2x.png' },
+  { size: 60,   name: 'ios/AppIcon-20@3x.png' },
+  { size: 29,   name: 'ios/AppIcon-29@1x.png' },
+  { size: 58,   name: 'ios/AppIcon-29@2x.png' },
+  { size: 87,   name: 'ios/AppIcon-29@3x.png' },
+  { size: 40,   name: 'ios/AppIcon-40@1x.png' },
+  { size: 80,   name: 'ios/AppIcon-40@2x.png' },
+  { size: 120,  name: 'ios/AppIcon-40@3x.png' },
+  { size: 120,  name: 'ios/AppIcon-60@2x.png' },
+  { size: 180,  name: 'ios/AppIcon-60@3x.png' },
+  { size: 76,   name: 'ios/AppIcon-76@1x.png' },
+  { size: 152,  name: 'ios/AppIcon-76@2x.png' },
+  { size: 167,  name: 'ios/AppIcon-83.5@2x.png' },
+  { size: 1024, name: 'ios/AppIcon-1024.png' },   // App Store submission
+
+  // Android-specific (Capacitor default locations)
+  { size: 36,   name: 'android/mipmap-ldpi/ic_launcher.png' },
+  { size: 48,   name: 'android/mipmap-mdpi/ic_launcher.png' },
+  { size: 72,   name: 'android/mipmap-hdpi/ic_launcher.png' },
+  { size: 96,   name: 'android/mipmap-xhdpi/ic_launcher.png' },
+  { size: 144,  name: 'android/mipmap-xxhdpi/ic_launcher.png' },
+  { size: 192,  name: 'android/mipmap-xxxhdpi/ic_launcher.png' },
+];
+
+async function main() {
+  if (!fs.existsSync(SRC)) {
+    console.error(`\n❌  Source icon not found: ${SRC}`);
+    console.error('    Save your 1024×1024 PNG as public/icons/icon-source.png and re-run.\n');
+    process.exit(1);
+  }
+
+  // Ensure all sub-directories exist
+  const dirs = new Set(SIZES.map(s => path.join(DEST, path.dirname(s.name))));
+  dirs.forEach(d => fs.mkdirSync(d, { recursive: true }));
+
+  let ok = 0;
+  for (const { size, name } of SIZES) {
+    const out = path.join(DEST, name);
+    try {
+      await sharp(SRC).resize(size, size).png().toFile(out);
+      console.log(`✅  ${size}×${size}  →  public/icons/${name}`);
+      ok++;
+    } catch (err) {
+      console.error(`❌  Failed ${name}: ${err.message}`);
+    }
+  }
+
+  console.log(`\n✨  Done — ${ok}/${SIZES.length} icons generated in public/icons/\n`);
+  console.log('Next steps:');
+  console.log('  npx cap sync          (copy web assets into ios/ and android/)');
+  console.log('  npx cap open ios      (open Xcode)');
+  console.log('  npx cap open android  (open Android Studio)\n');
+}
+
+main();

--- a/src/config/loadConfig.js
+++ b/src/config/loadConfig.js
@@ -30,7 +30,7 @@ function resolveServerUrl() {
 
 async function loadConfig() {
   const serverUrl = resolveServerUrl();
-  const res = await fetch(`${serverUrl}/config`);
+  const res = await fetch(`${serverUrl}/config`, { signal: AbortSignal.timeout(5000) });
   const config = await res.json();
 
   if (typeof window !== 'undefined') {

--- a/src/html/programs.html
+++ b/src/html/programs.html
@@ -15,7 +15,7 @@
       --ok: #0f9d58;
       --warn: #b45309;
     }
-    body { font-family: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; justify-content: center; padding: 40px 16px; }
+    body { font-family: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; background: var(--bg); color: var(--text); min-height: 100vh; min-height: 100dvh; display: flex; justify-content: center; padding: 40px 16px; }
     .page { width: min(960px, 100%); display: grid; gap: 24px; }
     header { display: flex; justify-content: space-between; align-items: center; }
     h1 { font-size: clamp(1.8rem, 3vw, 2.4rem); margin: 0; }

--- a/src/js/ProgramTabV2.js
+++ b/src/js/ProgramTabV2.js
@@ -557,6 +557,71 @@
       host.appendChild(addBtn);
     }
 
+    /* ── Template helpers ─────────────────────────────────────── */
+
+    /** Pull all workout templates the user has saved. */
+    function _getAvailableTemplates() {
+      // Prefer the in-memory cache populated when the Logbook Templates tab loads
+      if (Array.isArray(window.resistanceTemplatesCache) && window.resistanceTemplatesCache.length) {
+        return window.resistanceTemplatesCache;
+      }
+      // Fallback: read directly from localStorage
+      const user = window.currentUser || localStorage.getItem('fitnessAppUser') || '';
+      if (!user) return [];
+      try {
+        const raw = JSON.parse(localStorage.getItem(`managedTemplates_${user}`)) || [];
+        return raw
+          .map(t => ({
+            id:   t.localId || t.id || String(Date.now()),
+            name: t.name || 'Untitled',
+            data: typeof t.data === 'string' ? JSON.parse(t.data) : t.data
+          }))
+          .filter(t => t.data && typeof t.data === 'object');
+      } catch { return []; }
+    }
+
+    /** Load all exercises from a template into the currently selected day. */
+    function _loadTemplateIntoDay(dayId, templateId) {
+      if (!dayId) return;
+      const tpl = _getAvailableTemplates().find(t => t.id === templateId);
+      if (!tpl) return;
+
+      const day = (draft.days || []).find(d => d.dayId === dayId);
+      if (!day) return;
+
+      const tplExercises = Array.isArray(tpl.data?.exercises) ? tpl.data.exercises : [];
+      if (!tplExercises.length) {
+        window.showToast('This template has no exercises.', 'warn');
+        return;
+      }
+
+      // Map template exercise format → program-builder exercise format
+      const mapped = tplExercises.map(ex => ({
+        exerciseId: uuid(),
+        name:       ex.name || 'Exercise',
+        notes:      ex.notes || '',
+        rirNote: '', rpeNote: '', progressionNotes: '',
+        archetypeTags: [draft.archetype || 'general'],
+        sets: (Array.isArray(ex.sets) && ex.sets.length
+          ? ex.sets.map(s => ({
+              setType: s.setType || 'straight',
+              reps:    Number(s.targetReps)  || 8,
+              weight:  Number(s.targetWeight) || null,
+              rpe: null, rir: null, restSec: 120
+            }))
+          : [{ setType: 'straight', reps: 8, weight: null, rpe: null, rir: null, restSec: 120 }]
+        )
+      }));
+
+      day.exercises = [...(day.exercises || []), ...mapped];
+      persistDraft();
+      renderExercisesPane();
+      window.showToast(
+        `✅ "${tpl.name}" loaded — ${mapped.length} exercise${mapped.length !== 1 ? 's' : ''} added`,
+        'success', 4000
+      );
+    }
+
     function _renderExercisePane(host) {
       host.innerHTML = '';
 
@@ -567,6 +632,37 @@
       if (!day) {
         host.innerHTML = '<div class="pbv2-no-exercises">Add a day first →</div>';
         return;
+      }
+
+      /* ── Template loader strip ──────────────────────────────── */
+      const availableTpls = _getAvailableTemplates();
+      if (availableTpls.length) {
+        const strip = document.createElement('div');
+        strip.className = 'pbv2-template-strip';
+        strip.title = 'Load a saved workout template into this day';
+
+        const sel = document.createElement('select');
+        sel.className = 'pbv2-template-select';
+        sel.innerHTML =
+          '<option value="">📋 Load from template…</option>' +
+          availableTpls.map(t =>
+            `<option value="${esc(t.id)}">${esc(t.name)}</option>`
+          ).join('');
+
+        const loadBtn = document.createElement('button');
+        loadBtn.type = 'button';
+        loadBtn.className = 'pbv2-template-load-btn';
+        loadBtn.textContent = 'Load';
+        loadBtn.addEventListener('click', () => {
+          const id = sel.value;
+          if (!id) { window.showToast('Choose a template first.', 'warn'); return; }
+          _loadTemplateIntoDay(selectedDayId, id);
+          sel.value = '';
+        });
+
+        strip.appendChild(sel);
+        strip.appendChild(loadBtn);
+        host.appendChild(strip);
       }
 
       /* Exercise picker */

--- a/src/js/ProgramTabV2.js
+++ b/src/js/ProgramTabV2.js
@@ -218,20 +218,23 @@
     function renameDay(dayId) {
       const day = draft.days.find(d => d.dayId === dayId);
       if (!day) return;
-      const name = prompt('Rename day:', day.name);
-      if (!name || !name.trim()) return;
-      day.name = name.trim();
-      persistDraft();
-      render();
+      window.showPrompt('Rename day:', { defaultValue: day.name }).then(name => {
+        if (!name || !name.trim()) return;
+        day.name = name.trim();
+        persistDraft();
+        render();
+      });
     }
 
     function deleteDay(dayId) {
-      if (!confirm('Delete this day and all its exercises?')) return;
-      draft.days = (draft.days || []).filter(d => d.dayId !== dayId);
-      if (selectedDayId === dayId) selectedDayId = draft.days[0]?.dayId || null;
-      if (draft.split) draft.split.daysPerWeek = draft.days.length;
-      persistDraft();
-      render();
+      window.showConfirm('Delete this day and all its exercises?', { danger: true }).then(ok => {
+        if (!ok) return;
+        draft.days = (draft.days || []).filter(d => d.dayId !== dayId);
+        if (selectedDayId === dayId) selectedDayId = draft.days[0]?.dayId || null;
+        if (draft.split) draft.split.daysPerWeek = draft.days.length;
+        persistDraft();
+        render();
+      });
     }
 
     function selectDay(dayId) {
@@ -322,14 +325,16 @@
     }
 
     function startFresh() {
-      if (!confirm('Clear the current draft and start a new program?')) return;
-      draft = core.normalizeDraft(core.createEmptyDraft(userId));
-      selectedDayId = null;
-      pickerQuery = '';
-      pickerCategory = 'All';
-      step = 'goal';
-      persistDraft();
-      render();
+      window.showConfirm('Clear the current draft and start a new program?').then(ok => {
+        if (!ok) return;
+        draft = core.normalizeDraft(core.createEmptyDraft(userId));
+        selectedDayId = null;
+        pickerQuery = '';
+        pickerCategory = 'All';
+        step = 'goal';
+        persistDraft();
+        render();
+      });
     }
 
     /* ── Picker helpers ─ */
@@ -921,13 +926,15 @@
 
       card.querySelector('.prog-card-del').addEventListener('click', () => {
         const name = prog.name || prog.title || 'this program';
-        if (!confirm(`Delete "${name}"?`)) return;
-        const core = window.programBuilderV2Core;
-        if (!core) return;
-        const all = core.loadPrograms(window);
-        all.splice(origIdx, 1);
-        core.savePrograms(window, all);
-        renderProgramList(); // refresh
+        window.showConfirm(`Delete "${name}"?`, { danger: true }).then(ok => {
+          if (!ok) return;
+          const core = window.programBuilderV2Core;
+          if (!core) return;
+          const all = core.loadPrograms(window);
+          all.splice(origIdx, 1);
+          core.savePrograms(window, all);
+          renderProgramList();
+        });
       });
 
       container.appendChild(card);

--- a/src/js/archetype-features.js
+++ b/src/js/archetype-features.js
@@ -57,11 +57,25 @@ function _fmt(totalSeconds) {
 
   function syncAll() { RING_CONFIGS.forEach(syncRing); }
 
-  // Poll at 300 ms so we don't need to touch every JS call that sets bar values
+  // Poll at 300 ms so we don't need to touch every JS call that sets bar values.
+  // Interval is paused when the app is backgrounded to avoid draining battery.
   document.addEventListener('DOMContentLoaded', () => {
-    setInterval(syncAll, 300);
+    let _pollId = setInterval(syncAll, 300);
     syncAll();
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        clearInterval(_pollId);
+        _pollId = 0;
+      } else if (!_pollId) {
+        _pollId = setInterval(syncAll, 300);
+        syncAll(); // immediate sync on resume
+      }
+    });
   });
+
+  // Expose for callers that update bar values programmatically
+  window.syncMacroRings = syncAll;
 })();
 
 // ── Progress photo upload ─────────────────────────────────────

--- a/src/js/client-checkins.js
+++ b/src/js/client-checkins.js
@@ -210,14 +210,16 @@
   };
 
   window.ccSetRating = function (n) {
-    document.getElementById('ccRating').value = n;
+    const ratingEl = document.getElementById('ccRating');
+    if (ratingEl) ratingEl.value = n;
     document.querySelectorAll('.cc-star').forEach((s, i) => {
       s.classList.toggle('active', i < n);
     });
   };
 
   window.ccSetMood = function (val, emoji) {
-    document.getElementById('ccMood').value = emoji;
+    const moodEl = document.getElementById('ccMood');
+    if (moodEl) moodEl.value = emoji;
     document.querySelectorAll('.cc-mood-btn').forEach((b, i) => {
       b.classList.toggle('active', i + 1 === val);
     });
@@ -243,7 +245,8 @@
     if (document.getElementById('ccNotes'))   document.getElementById('ccNotes').value = '';
     if (document.getElementById('ccActions')) document.getElementById('ccActions').value = '';
     ccSetRating(0);
-    document.getElementById('ccMood').value = '';
+    const ccMoodEl = document.getElementById('ccMood');
+    if (ccMoodEl) ccMoodEl.value = '';
     document.querySelectorAll('.cc-mood-btn').forEach(b => b.classList.remove('active'));
 
     _showMsg('✅ Check-in saved!', 'ok');

--- a/src/js/client-checkins.js
+++ b/src/js/client-checkins.js
@@ -255,9 +255,11 @@
   };
 
   window.ccDeleteCheckin = function (clientId, idx) {
-    if (!confirm('Delete this check-in?')) return;
-    deleteCheckin(clientId, idx);
-    _renderHistory(document.getElementById('ccHistoryFilter')?.value || '');
+    window.showConfirm('Delete this check-in?', { danger: true }).then(ok => {
+      if (!ok) return;
+      deleteCheckin(clientId, idx);
+      _renderHistory(document.getElementById('ccHistoryFilter')?.value || '');
+    });
   };
 
   function _showMsg(msg, type) {

--- a/src/js/coaching-enhanced.js
+++ b/src/js/coaching-enhanced.js
@@ -125,7 +125,7 @@ function _updateBulkToolbar() {
 function bulkAssignProgram() {
   if (!_bulkSelected.size) return;
   const programs = _coachStore('coachPrograms_v1') || [];
-  if (!programs.length) { alert('No saved programs. Create one in the Programs tab first.'); return; }
+  if (!programs.length) { window.showToast('No saved programs. Create one in the Programs tab first.', 'warn'); return; }
 
   const opts = programs.map((p,i) => `<option value="${i}">${p.name}</option>`).join('');
   const modal = document.createElement('div');
@@ -531,12 +531,14 @@ window.filterExLib = function(q) {
 window.applyProgTemplate = function(key) {
   const tmpl = PROGRAM_TEMPLATES[key];
   if (!tmpl) return;
-  if (!confirm(`Load "${tmpl.name}" template? This will replace the current week.`)) return;
-  _progState.name = tmpl.name;
-  _progState.days = Object.fromEntries(DAYS.map(d => [d, [...(tmpl.days[d] || [])]]));
-  const nameInput = document.getElementById('progNameInput');
-  if (nameInput) nameInput.value = _progState.name;
-  DAYS.forEach(d => _refreshDayCol(d));
+  window.showConfirm(`Load "${tmpl.name}" template? This will replace the current week.`).then(ok => {
+    if (!ok) return;
+    _progState.name = tmpl.name;
+    _progState.days = Object.fromEntries(DAYS.map(d => [d, [...(tmpl.days[d] || [])]]));
+    const nameInput = document.getElementById('progNameInput');
+    if (nameInput) nameInput.value = _progState.name;
+    DAYS.forEach(d => _refreshDayCol(d));
+  });
 };
 
 window.clearProgram = function() {
@@ -559,7 +561,7 @@ window.saveCoachProgram = function() {
 
 window.loadCoachProgramList = function() {
   const programs = _coachStore('coachPrograms_v1') || [];
-  if (!programs.length) { alert('No saved programs yet.'); return; }
+  if (!programs.length) { window.showToast('No saved programs yet.', 'warn'); return; }
   const opts = programs.map((p,i) => `<option value="${i}">${p.name} (${p.savedAt?.slice(0,10)})</option>`).join('');
   const modal = document.createElement('div');
   modal.className = 'gdpr-modal-overlay';
@@ -589,10 +591,10 @@ window._confirmLoadProgram = function() {
 
 window.assignProgramToClient = function() {
   const clientId = document.getElementById('progAssignClient')?.value;
-  if (!clientId) { alert('Select a client first.'); return; }
+  if (!clientId) { window.showToast('Select a client first.', 'warn'); return; }
   const programs = _coachStore('coachPrograms_v1') || [];
   const prog = programs.find(p => p.id === _progState.id);
-  if (!prog) { alert('Save the program before assigning.'); return; }
+  if (!prog) { window.showToast('Save the program before assigning.', 'warn'); return; }
   const assignments = _coachStore('coachProgramAssignments_v1') || {};
   assignments[clientId] = { programId: prog.id, programName: prog.name, assignedAt: new Date().toISOString() };
   _coachStore('coachProgramAssignments_v1', assignments);
@@ -634,10 +636,12 @@ window._loadProgIdx = function(i) {
 
 window._deleteProgIdx = function(i) {
   const programs = _coachStore('coachPrograms_v1') || [];
-  if (!confirm(`Delete "${programs[i]?.name}"?`)) return;
-  programs.splice(i, 1);
-  _coachStore('coachPrograms_v1', programs);
-  renderSavedProgramsList();
+  window.showConfirm(`Delete "${programs[i]?.name}"?`, { danger: true }).then(ok => {
+    if (!ok) return;
+    programs.splice(i, 1);
+    _coachStore('coachPrograms_v1', programs);
+    renderSavedProgramsList();
+  });
 };
 
 /* ══════════════════════════════════════════════════════════════
@@ -1033,10 +1037,12 @@ window.sendConsentRequest = function(clientId) {
   const store   = _getGdprStore();
   const consent = store[clientId] || {};
   if (consent.status === 'consented') {
-    if (!confirm('Revoke consent for this client? This will stop data collection.')) return;
-    store[clientId] = { ...consent, status: 'withdrawn', revokedAt: new Date().toISOString() };
-    _saveGdprStore(store);
-    renderCoachGdpr();
+    window.showConfirm('Revoke consent for this client? This will stop data collection.', { danger: true }).then(ok => {
+      if (!ok) return;
+      store[clientId] = { ...consent, status: 'withdrawn', revokedAt: new Date().toISOString() };
+      _saveGdprStore(store);
+      renderCoachGdpr();
+    });
     return;
   }
   // Show consent request modal
@@ -1097,16 +1103,15 @@ window.exportClientData = function(clientId) {
 window.deleteClientData = function(clientId) {
   const clients = (window.coachDashboardState?.clients) || [];
   const client  = clients.find(c => c.id === clientId);
-  if (!confirm(`Permanently delete all data for ${client?.name || clientId}? This cannot be undone.`)) return;
-
-  // Remove from all stores
-  const msgStore = _getMsgStore();         delete msgStore[clientId];         _saveMsgStore(msgStore);
-  const asnStore = _coachStore('coachProgramAssignments_v1') || {}; delete asnStore[clientId]; _coachStore('coachProgramAssignments_v1', asnStore);
-  const nutStore = _coachStore('coachNutritionAssignments_v1') || {}; delete nutStore[clientId]; _coachStore('coachNutritionAssignments_v1', nutStore);
-  const gdprStore = _getGdprStore(); delete gdprStore[clientId]; _saveGdprStore(gdprStore);
-
-  renderCoachGdpr();
-  _showExportToast(`Data for ${client?.name || clientId} deleted`);
+  window.showConfirm(`Permanently delete all data for ${client?.name || clientId}? This cannot be undone.`, { danger: true }).then(ok => {
+    if (!ok) return;
+    const msgStore = _getMsgStore();         delete msgStore[clientId];         _saveMsgStore(msgStore);
+    const asnStore = _coachStore('coachProgramAssignments_v1') || {}; delete asnStore[clientId]; _coachStore('coachProgramAssignments_v1', asnStore);
+    const nutStore = _coachStore('coachNutritionAssignments_v1') || {}; delete nutStore[clientId]; _coachStore('coachNutritionAssignments_v1', nutStore);
+    const gdprStore = _getGdprStore(); delete gdprStore[clientId]; _saveGdprStore(gdprStore);
+    renderCoachGdpr();
+    _showExportToast(`Data for ${client?.name || clientId} deleted`);
+  });
 };
 
 window.exportAllCoachData = function() {
@@ -1129,12 +1134,14 @@ window.exportAllCoachData = function() {
 };
 
 window.deleteAllCoachData = function() {
-  if (!confirm('Delete ALL coaching data (programs, messages, assignments)? This cannot be undone.')) return;
-  ['coachPrograms_v1','coachMessages_v1','coachProgramAssignments_v1',
-   'coachNutritionAssignments_v1','coachGdprConsents_v1',
-   'coachDataSettings_v1','coachNotifSettings_v1'].forEach(k => localStorage.removeItem(k));
-  renderCoachGdpr();
-  _showExportToast('All coach data deleted');
+  window.showConfirm('Delete ALL coaching data (programs, messages, assignments)? This cannot be undone.', { danger: true, confirmText: 'Delete All' }).then(ok => {
+    if (!ok) return;
+    ['coachPrograms_v1','coachMessages_v1','coachProgramAssignments_v1',
+     'coachNutritionAssignments_v1','coachGdprConsents_v1',
+     'coachDataSettings_v1','coachNotifSettings_v1'].forEach(k => localStorage.removeItem(k));
+    renderCoachGdpr();
+    _showExportToast('All coach data deleted');
+  });
 };
 
 /* ── Utility: export toast ───────────────────────────────────── */

--- a/src/js/coaching-enhanced.js
+++ b/src/js/coaching-enhanced.js
@@ -785,7 +785,8 @@ window.sendCoachMessage = function() {
   const type = document.getElementById('msgType')?.value || 'note';
   if (!text || !_activeThreadClientId) return;
   _addMessage(_activeThreadClientId, text, type, true);
-  document.getElementById('msgText').value = '';
+  const msgTextEl = document.getElementById('msgText');
+  if (msgTextEl) msgTextEl.value = '';
   const threadContainer = document.getElementById('coachThreadContainer');
   if (threadContainer) threadContainer.innerHTML = _buildThreadHTML(_activeThreadClientId);
   // Scroll to bottom

--- a/src/js/coaching-enhanced.js
+++ b/src/js/coaching-enhanced.js
@@ -263,8 +263,7 @@ function bulkExportPDF() {
     <script>window.onload=()=>window.print()<\/script>
     </body></html>`;
 
-  const blob = new Blob([html], { type: 'text/html' });
-  window.open(URL.createObjectURL(blob), '_blank');
+  window.openReportWindow(html, { title: 'Coach Progress Report', filename: 'coach-report.html' });
   _showExportToast('PDF report opened for printing');
 }
 

--- a/src/js/native-ui.js
+++ b/src/js/native-ui.js
@@ -1,0 +1,164 @@
+/**
+ * native-ui.js
+ * Mobile-safe replacements for alert(), confirm(), prompt().
+ *
+ * Globals exposed:
+ *   window.showToast(msg, type, duration)  → void
+ *   window.showConfirm(msg, opts)          → Promise<boolean>
+ *   window.showPrompt(msg, opts)           → Promise<string|null>
+ *
+ * window.alert is overridden → showToast
+ * window.confirm / window.prompt are NOT overridden (they're sync; callers
+ * must migrate to the async versions explicitly).
+ */
+(function () {
+  'use strict';
+
+  // ── Toast ──────────────────────────────────────────────────────────────────
+
+  let _toastTimer = null;
+
+  /**
+   * @param {string} msg
+   * @param {'info'|'success'|'error'|'warn'} [type='info']
+   * @param {number} [duration=3000]
+   */
+  function showToast(msg, type, duration) {
+    type     = type     || 'info';
+    duration = duration || 3000;
+
+    let el = document.getElementById('nativeToast');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'nativeToast';
+      document.body.appendChild(el);
+    }
+
+    const icons = { info: 'ℹ️', success: '✅', error: '❌', warn: '⚠️' };
+    el.className = `native-toast native-toast--${type} native-toast--show`;
+    el.innerHTML = `<span class="nt-icon">${icons[type] || icons.info}</span><span class="nt-msg">${_esc(msg)}</span>`;
+
+    if (_toastTimer) clearTimeout(_toastTimer);
+    _toastTimer = setTimeout(() => {
+      el.classList.remove('native-toast--show');
+    }, duration);
+  }
+
+  // ── Confirm modal ──────────────────────────────────────────────────────────
+
+  /**
+   * @param {string} msg
+   * @param {{ confirmText?: string, cancelText?: string, danger?: boolean }} [opts]
+   * @returns {Promise<boolean>}
+   */
+  function showConfirm(msg, opts) {
+    opts = opts || {};
+    return new Promise(function (resolve) {
+      const overlay = _getOrCreateOverlay();
+      overlay.innerHTML = `
+        <div class="nm-dialog" role="dialog" aria-modal="true">
+          <p class="nm-body">${_esc(msg)}</p>
+          <div class="nm-actions">
+            <button class="nm-btn nm-btn--cancel" id="nmCancel">
+              ${_esc(opts.cancelText || 'Cancel')}
+            </button>
+            <button class="nm-btn ${opts.danger ? 'nm-btn--danger' : 'nm-btn--confirm'}" id="nmConfirm">
+              ${_esc(opts.confirmText || 'OK')}
+            </button>
+          </div>
+        </div>`;
+      overlay.style.display = 'flex';
+
+      function cleanup(val) {
+        overlay.style.display = 'none';
+        overlay.innerHTML = '';
+        resolve(val);
+      }
+
+      overlay.querySelector('#nmConfirm').addEventListener('click', () => cleanup(true),  { once: true });
+      overlay.querySelector('#nmCancel').addEventListener('click',  () => cleanup(false), { once: true });
+      // tap outside = cancel
+      overlay.addEventListener('click', function handler(e) {
+        if (e.target === overlay) { overlay.removeEventListener('click', handler); cleanup(false); }
+      });
+    });
+  }
+
+  // ── Prompt modal ───────────────────────────────────────────────────────────
+
+  /**
+   * @param {string} msg
+   * @param {{ placeholder?: string, defaultValue?: string, confirmText?: string }} [opts]
+   * @returns {Promise<string|null>}  null = cancelled
+   */
+  function showPrompt(msg, opts) {
+    opts = opts || {};
+    return new Promise(function (resolve) {
+      const overlay = _getOrCreateOverlay();
+      overlay.innerHTML = `
+        <div class="nm-dialog" role="dialog" aria-modal="true">
+          <p class="nm-body">${_esc(msg)}</p>
+          <input class="nm-input" id="nmInput"
+                 type="text"
+                 placeholder="${_esc(opts.placeholder || '')}"
+                 value="${_esc(opts.defaultValue || '')}" />
+          <div class="nm-actions">
+            <button class="nm-btn nm-btn--cancel"  id="nmCancel">Cancel</button>
+            <button class="nm-btn nm-btn--confirm" id="nmConfirm">
+              ${_esc(opts.confirmText || 'OK')}
+            </button>
+          </div>
+        </div>`;
+      overlay.style.display = 'flex';
+
+      const input = overlay.querySelector('#nmInput');
+      input.focus();
+      input.select();
+
+      function cleanup(val) {
+        overlay.style.display = 'none';
+        overlay.innerHTML = '';
+        resolve(val);
+      }
+
+      overlay.querySelector('#nmConfirm').addEventListener('click', () => cleanup(input.value), { once: true });
+      overlay.querySelector('#nmCancel').addEventListener('click',  () => cleanup(null),         { once: true });
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter')  cleanup(input.value);
+        if (e.key === 'Escape') cleanup(null);
+      }, { once: true });
+    });
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  function _getOrCreateOverlay() {
+    let el = document.getElementById('nativeModalOverlay');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'nativeModalOverlay';
+      el.className = 'nm-overlay';
+      document.body.appendChild(el);
+    }
+    return el;
+  }
+
+  function _esc(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  // ── Override window.alert ─────────────────────────────────────────────────
+  // confirm/prompt are synchronous by spec; callers must migrate explicitly.
+
+  window.alert = function (msg) { showToast(String(msg), 'info'); };
+
+  // ── Exports ───────────────────────────────────────────────────────────────
+
+  window.showToast    = showToast;
+  window.showConfirm  = showConfirm;
+  window.showPrompt   = showPrompt;
+})();

--- a/src/js/native-ui.js
+++ b/src/js/native-ui.js
@@ -156,9 +156,77 @@
 
   window.alert = function (msg) { showToast(String(msg), 'info'); };
 
+  // ── openReportWindow ──────────────────────────────────────────────────────
+  /**
+   * Open an HTML report document for viewing / printing / sharing.
+   *
+   * • Native Capacitor  → Web Share API (native share sheet).
+   *                       Falls back to a data: URI if Share is unavailable.
+   * • Web browser       → window.open() with HTML written in (existing behaviour).
+   *
+   * @param {string} html          Full HTML document string
+   * @param {{ title?: string, filename?: string }} [opts]
+   */
+  async function openReportWindow(html, opts) {
+    const title    = (opts && opts.title)    || 'Report';
+    const filename = (opts && opts.filename) || 'report.html';
+    const isNative = !!(
+      window.Capacitor &&
+      typeof window.Capacitor.isNativePlatform === 'function' &&
+      window.Capacitor.isNativePlatform()
+    );
+
+    if (isNative) {
+      // ── Native path: Web Share API ───────────────────────────────────────
+      if (typeof navigator.share === 'function') {
+        const blob = new Blob([html], { type: 'text/html' });
+        const file = new File([blob], filename, { type: 'text/html' });
+        try {
+          if (navigator.canShare && navigator.canShare({ files: [file] })) {
+            await navigator.share({ files: [file], title });
+          } else {
+            // Fallback: share plain-text summary (strips HTML tags)
+            const text = html
+              .replace(/<style[\s\S]*?<\/style>/gi, '')
+              .replace(/<[^>]+>/g, ' ')
+              .replace(/\s{2,}/g, ' ')
+              .trim()
+              .substring(0, 3000);
+            await navigator.share({ title, text });
+          }
+          return;
+        } catch (e) {
+          if (e.name === 'AbortError') return; // user cancelled — not an error
+          console.warn('[openReportWindow] Share API failed, trying data URI', e);
+        }
+      }
+
+      // ── Native fallback: data URI in a new window ────────────────────────
+      try {
+        const dataUrl = 'data:text/html;charset=utf-8,' + encodeURIComponent(html);
+        const w = window.open(dataUrl, '_blank');
+        if (w) return;
+      } catch (_) {}
+
+      showToast('Could not open report on this device.', 'warn');
+      return;
+    }
+
+    // ── Web path: open new window and write HTML into it ──────────────────
+    const win = window.open('', '_blank', 'width=960,height=800,scrollbars=yes');
+    if (!win) {
+      showToast('Pop-up blocked — allow pop-ups for this site and try again.', 'warn');
+      return;
+    }
+    win.document.write(html);
+    win.document.close();
+    win.focus();
+  }
+
   // ── Exports ───────────────────────────────────────────────────────────────
 
-  window.showToast    = showToast;
-  window.showConfirm  = showConfirm;
-  window.showPrompt   = showPrompt;
+  window.showToast        = showToast;
+  window.showConfirm      = showConfirm;
+  window.showPrompt       = showPrompt;
+  window.openReportWindow = openReportWindow;
 })();

--- a/src/js/programs.js
+++ b/src/js/programs.js
@@ -416,12 +416,14 @@
         method: "POST",
         headers,
         body: JSON.stringify({ draft: payload }),
+        signal: AbortSignal.timeout(5000)
       });
       if (first.ok) return;
       await fetch(endpoint, {
         method: "POST",
         headers,
         body: JSON.stringify({ program: payload }),
+        signal: AbortSignal.timeout(5000)
       });
     }
 

--- a/src/js/progress-report.js
+++ b/src/js/progress-report.js
@@ -267,20 +267,12 @@
 
   window.generateProgressReport = function () {
     const username = _user();
-    if (!username) { alert('Please log in first.'); return; }
+    if (!username) { window.showToast('Please log in first.', 'warn'); return; }
 
     const data = _gatherData(username);
     const html = _buildReportHTML(data);
-
-    const win = window.open('', '_blank', 'width=960,height=800,scrollbars=yes');
-    if (!win) {
-      alert('Pop-up blocked. Please allow pop-ups for this site and try again.');
-      return;
-    }
-    win.document.write(html);
-    win.document.close();
-    // Auto-focus so user can immediately press print or Ctrl+P
-    win.focus();
+    // openReportWindow handles native (Web Share API) vs web (new window) automatically
+    window.openReportWindow(html, { title: 'Progress Report', filename: 'progress-report.html' });
   };
 
 })();

--- a/src/js/readiness-checkin.js
+++ b/src/js/readiness-checkin.js
@@ -130,17 +130,17 @@
   window.submitReadiness = function () {
     const { sleep, soreness, motivation } = _ratings;
     if (!sleep || !soreness || !motivation) {
-      alert('Please answer all 3 questions.');
+      window.showToast('Please answer all 3 questions.', 'warn');
       return;
     }
     const score = saveEntry(sleep, soreness, motivation);
     dismissReadiness();
     renderReadinessHomeCard();
 
-    // Show inline tip if low
+    // Show tip if low readiness
     const tier = _tier(score);
     if (tier.cls !== 'high') {
-      setTimeout(() => alert('ℹ️ ' + tier.tip), 300);
+      setTimeout(() => window.showToast('ℹ️ ' + tier.tip, 'info', 5000), 300);
     }
   };
 

--- a/src/js/session-context.js
+++ b/src/js/session-context.js
@@ -1,0 +1,219 @@
+/**
+ * session-context.js
+ * Three niche quality-of-life features:
+ *
+ * 1. Vacation Mode   – pauses streak & program tracking, shows banner on home.
+ * 2. Alt-Machine flag – per-workout marker that equipment differs from usual.
+ * 3. Alt-Gym flag     – per-workout marker for a different gym location.
+ *
+ * All state lives in localStorage so it survives page reloads.
+ */
+(function () {
+  'use strict';
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  function _user() {
+    return window.currentUser || localStorage.getItem('fitnessAppUser') || '';
+  }
+
+  function _get(key) {
+    try { return JSON.parse(localStorage.getItem(`${key}_${_user()}`)); } catch { return null; }
+  }
+  function _set(key, val) {
+    localStorage.setItem(`${key}_${_user()}`, JSON.stringify(val));
+  }
+
+  // ── 1. VACATION MODE ────────────────────────────────────────────────────────
+
+  const VACATION_KEY = 'vacationMode';
+
+  function getVacationMode() {
+    return _get(VACATION_KEY) || { active: false, since: null };
+  }
+
+  function setVacationMode(active) {
+    const prev = getVacationMode();
+    const now  = new Date().toISOString().slice(0, 10);
+    _set(VACATION_KEY, {
+      active,
+      since: active ? (prev.since || now) : null,
+      resumedOn: active ? null : now,
+    });
+    renderVacationBanner();
+    // Refresh streak display if leaderboard helpers are loaded
+    if (typeof window.renderPersonalStats === 'function') window.renderPersonalStats();
+    if (typeof window.renderTodayProgramCard === 'function') window.renderTodayProgramCard();
+  }
+
+  /**
+   * Returns true if a given ISO date string falls inside a vacation window.
+   * Used by streak calculators to skip vacation days.
+   */
+  function isVacationDate(dateStr) {
+    const v = getVacationMode();
+    if (!v.since) return false;
+    const d       = dateStr;
+    const since   = v.since;
+    const resumed = v.resumedOn || new Date().toISOString().slice(0, 10);
+    return d >= since && d <= resumed;
+  }
+
+  function renderVacationBanner() {
+    const el = document.getElementById('vacationModeBanner');
+    if (!el) return;
+    const v = getVacationMode();
+    if (v.active) {
+      el.style.display = 'flex';
+      el.querySelector('.vm-since').textContent = `Since ${v.since}`;
+    } else {
+      el.style.display = 'none';
+    }
+  }
+
+  function renderVacationCard() {
+    const el = document.getElementById('vacationModeCard');
+    if (!el) return;
+    const v = getVacationMode();
+    el.innerHTML = `
+      <div class="vm-card ${v.active ? 'vm-card--active' : ''}">
+        <div class="vm-card-left">
+          <span class="vm-icon">${v.active ? '🏖️' : '🏋️'}</span>
+          <div>
+            <span class="vm-title">${v.active ? 'Vacation Mode On' : 'Vacation Mode'}</span>
+            ${v.active
+              ? `<span class="vm-sub">Streak &amp; program paused since ${v.since}</span>`
+              : `<span class="vm-sub">Pause streak &amp; program tracking</span>`}
+          </div>
+        </div>
+        <button class="vm-toggle ${v.active ? 'vm-toggle--on' : ''}"
+                onclick="window.toggleVacationMode()">
+          ${v.active ? 'Resume' : 'Go on vacation'}
+        </button>
+      </div>`;
+  }
+
+  function toggleVacationMode() {
+    const v = getVacationMode();
+    setVacationMode(!v.active);
+    renderVacationCard();
+  }
+
+  // ── 2 & 3. ALT-MACHINE / ALT-GYM (per-session flags) ──────────────────────
+
+  const SESSION_CTX_KEY = 'sessionContext';
+
+  function getSessionContext() {
+    return _get(SESSION_CTX_KEY) || { altMachine: false, altGym: false, gymName: '' };
+  }
+
+  function setSessionContext(patch) {
+    const ctx = { ...getSessionContext(), ...patch };
+    _set(SESSION_CTX_KEY, ctx);
+    renderSessionContextBar();
+  }
+
+  /** Attach session context metadata to a workout before saving. */
+  function applySessionContext(workoutObj) {
+    const ctx = getSessionContext();
+    if (ctx.altMachine || ctx.altGym) {
+      workoutObj._sessionCtx = {
+        altMachine: ctx.altMachine || false,
+        altGym:     ctx.altGym    || false,
+        gymName:    ctx.gymName   || '',
+      };
+    }
+    return workoutObj;
+  }
+
+  function renderSessionContextBar() {
+    const bar = document.getElementById('sessionContextBar');
+    if (!bar) return;
+    const ctx = getSessionContext();
+
+    bar.innerHTML = `
+      <div class="scb-wrap">
+        <!-- Alt Machine toggle -->
+        <button class="scb-chip ${ctx.altMachine ? 'scb-chip--on' : ''}"
+                onclick="window.toggleAltMachine()"
+                title="Mark this session as using different equipment than usual">
+          <span class="scb-chip-icon">🔧</span>
+          <span class="scb-chip-label">Alt&nbsp;Machine</span>
+          ${ctx.altMachine ? '<span class="scb-chip-badge">ON</span>' : ''}
+        </button>
+
+        <!-- Alt Gym toggle + name input -->
+        <button class="scb-chip ${ctx.altGym ? 'scb-chip--on' : ''}"
+                onclick="window.toggleAltGym()"
+                title="Mark this session as being at a different gym">
+          <span class="scb-chip-icon">📍</span>
+          <span class="scb-chip-label">Alt&nbsp;Gym</span>
+          ${ctx.altGym ? '<span class="scb-chip-badge">ON</span>' : ''}
+        </button>
+
+        ${ctx.altGym ? `
+          <input class="scb-gym-input"
+                 id="altGymNameInput"
+                 type="text"
+                 placeholder="Gym name (optional)"
+                 value="${ctx.gymName || ''}"
+                 oninput="window.setAltGymName(this.value)"
+                 maxlength="40" />
+        ` : ''}
+      </div>
+      ${ctx.altMachine || ctx.altGym ? `
+        <p class="scb-note">
+          ⚠️ This session will be tagged
+          ${[ctx.altMachine ? 'alt machine' : '', ctx.altGym ? `alt gym${ctx.gymName ? ' (' + ctx.gymName + ')' : ''}` : ''].filter(Boolean).join(' + ')}.
+          Progression comparisons will exclude it.
+        </p>` : ''}`;
+  }
+
+  function toggleAltMachine() {
+    const ctx = getSessionContext();
+    setSessionContext({ altMachine: !ctx.altMachine });
+  }
+
+  function toggleAltGym() {
+    const ctx = getSessionContext();
+    setSessionContext({ altGym: !ctx.altGym });
+  }
+
+  function setAltGymName(name) {
+    setSessionContext({ gymName: name });
+  }
+
+  /** Call after a workout is successfully saved to reset single-use flags. */
+  function clearSessionContextAfterSave() {
+    setSessionContext({ altMachine: false, altGym: false, gymName: '' });
+  }
+
+  // ── Init ────────────────────────────────────────────────────────────────────
+
+  function initSessionContext() {
+    renderVacationBanner();
+    renderVacationCard();
+    renderSessionContextBar();
+  }
+
+  // Re-init whenever the user changes (e.g. after login)
+  document.addEventListener('userChanged', initSessionContext);
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  window.getVacationMode          = getVacationMode;
+  window.setVacationMode          = setVacationMode;
+  window.toggleVacationMode       = toggleVacationMode;
+  window.isVacationDate           = isVacationDate;
+  window.renderVacationCard       = renderVacationCard;
+  window.renderVacationBanner     = renderVacationBanner;
+
+  window.getSessionContext        = getSessionContext;
+  window.applySessionContext      = applySessionContext;
+  window.toggleAltMachine         = toggleAltMachine;
+  window.toggleAltGym             = toggleAltGym;
+  window.setAltGymName            = setAltGymName;
+  window.clearSessionContextAfterSave = clearSessionContextAfterSave;
+  window.renderSessionContextBar  = renderSessionContextBar;
+  window.initSessionContext        = initSessionContext;
+})();

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -838,7 +838,7 @@ function injectSettingsMarkup() {
 
   container.dataset.loaded = 'loading';
 
-  fetch('src/html/settings.html')
+  fetch('src/html/settings.html', { signal: AbortSignal.timeout(5000) })
     .then(response => {
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       return response.text();

--- a/src/js/today-program.js
+++ b/src/js/today-program.js
@@ -1,0 +1,193 @@
+/**
+ * today-program.js
+ * Renders a "Today's Session" card on the home tab showing:
+ *  - Today's program day name (e.g. "Upper B") or Rest Day
+ *  - Current week number in the program
+ *  - Weekly split strip: Mon–Sun with day labels & today indicator
+ */
+(function () {
+  'use strict';
+
+  const WEEKDAY_ABBR  = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const WEEKDAY_MAP   = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+
+  // ── Data helpers ───────────────────────────────────────────────────────────
+
+  function _user() {
+    return window.currentUser || localStorage.getItem('fitnessAppUser');
+  }
+
+  function _getActiveRecord() {
+    const u = _user();
+    if (!u) return null;
+    return JSON.parse(
+      localStorage.getItem(`activeProgram_${u}`) ||
+      localStorage.getItem('activeProgram') ||
+      'null'
+    );
+  }
+
+  function _getPrograms() {
+    const u = _user();
+    if (!u) return [];
+    return (
+      JSON.parse(localStorage.getItem(`programs_${u}`)) ||
+      JSON.parse(localStorage.getItem('programs') || '[]')
+    );
+  }
+
+  /** Parse "YYYY-MM-DD" as local midnight (avoids UTC-offset day-off-by-one). */
+  function _parseLocalDate(str) {
+    if (!str) return null;
+    const [y, m, d] = str.split('-').map(Number);
+    if (!y) return null;
+    return new Date(y, m - 1, d);
+  }
+
+  /** Count training days from `from` (inclusive) up to but NOT including `until`. */
+  function _countTrainingDaysBetween(from, until, trainingDayNums) {
+    let count = 0;
+    const cur = new Date(from);
+    while (cur < until) {
+      if (trainingDayNums.includes(cur.getDay())) count++;
+      cur.setDate(cur.getDate() + 1);
+    }
+    return count;
+  }
+
+  // ── Core logic ─────────────────────────────────────────────────────────────
+
+  function _buildInfo() {
+    const active = _getActiveRecord();
+    if (!active) return null;
+
+    const programs = _getPrograms();
+    const program  = programs.find(p => p.id === active.programId);
+    if (!program || !Array.isArray(program.days) || !program.days.length) return null;
+
+    // Normalise training weekday list → JS getDay() numbers
+    const rawFreq = program.frequency || program.weekdays || ['Mon', 'Wed', 'Fri'];
+    const trainingNums = rawFreq
+      .map(d => WEEKDAY_MAP[d])
+      .filter(n => n !== undefined);
+
+    if (!trainingNums.length) return null;
+
+    const startDate = _parseLocalDate(active.startDate || program.startDate);
+    if (!startDate) return null;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // Training days completed before today
+    const tdBefore  = _countTrainingDaysBetween(startDate, today, trainingNums);
+    const nDays     = program.days.length;
+    const todayIdx  = tdBefore % nDays;
+    const isTrain   = trainingNums.includes(today.getDay()) && today >= startDate;
+
+    // Week number (1-based)
+    const weekNum = Math.floor((today - startDate) / (7 * 86400000)) + 1;
+
+    // Monday of the current week
+    const dow       = today.getDay();
+    const toMon     = dow === 0 ? -6 : 1 - dow;
+    const weekStart = new Date(today);
+    weekStart.setDate(today.getDate() + toMon);
+
+    // Training days before the start of this week
+    const tdBeforeWeek = _countTrainingDaysBetween(startDate, weekStart, trainingNums);
+
+    // Build 7-day strip
+    let weekTrainCount = 0;
+    const weekDays = [];
+    for (let i = 0; i < 7; i++) {
+      const d    = new Date(weekStart);
+      d.setDate(weekStart.getDate() + i);
+      const dNum = d.getDay();
+      const active_day = trainingNums.includes(dNum) && d >= startDate;
+
+      let dayName = null;
+      if (active_day) {
+        const idx = (tdBeforeWeek + weekTrainCount) % nDays;
+        dayName = program.days[idx]?.name || `Day ${idx + 1}`;
+        weekTrainCount++;
+      }
+
+      weekDays.push({
+        date:        d,
+        abbr:        WEEKDAY_ABBR[dNum],
+        isTraining:  active_day,
+        dayName,
+        isToday:     d.getTime() === today.getTime(),
+        isPast:      d < today,
+      });
+    }
+
+    return {
+      program,
+      isTodayTraining: isTrain,
+      todayDayName:    program.days[todayIdx]?.name || `Day ${todayIdx + 1}`,
+      weekNum:         Math.max(1, weekNum),
+      weekDays,
+      totalCompleted:  tdBefore,
+    };
+  }
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  /** Shorten long day names for the narrow split strip cells. */
+  function _short(name) {
+    if (!name) return '';
+    // "Upper Body A" → "Upper A"  |  "Push Day 1" → "Push 1"  |  short names untouched
+    return name
+      .replace(/\b(body|day)\b/gi, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim()
+      .slice(0, 10);
+  }
+
+  function renderTodayProgramCard() {
+    const el = document.getElementById('todayProgramCard');
+    if (!el) return;
+
+    const info = _buildInfo();
+    if (!info) { el.innerHTML = ''; return; }
+
+    const { program, isTodayTraining, todayDayName, weekNum, weekDays } = info;
+
+    // Weekly split strip
+    const strip = weekDays.map(d => {
+      const cls = ['tpc-split-cell'];
+      if (d.isToday)                 cls.push('tpc-split-cell--today');
+      if (d.isPast && d.isTraining)  cls.push('tpc-split-cell--done');
+      if (!d.isTraining)             cls.push('tpc-split-cell--rest');
+
+      return `
+        <div class="${cls.join(' ')}">
+          <span class="tpc-split-abbr">${d.abbr}</span>
+          <span class="tpc-split-name">${d.isTraining ? _short(d.dayName) : '–'}</span>
+          ${d.isToday ? '<span class="tpc-split-dot"></span>' : ''}
+        </div>`;
+    }).join('');
+
+    el.innerHTML = `
+      <div class="tpc-card">
+        <div class="tpc-header">
+          <span class="tpc-eyebrow">📅 Today's Session</span>
+          <span class="tpc-week-badge">Week ${weekNum}</span>
+        </div>
+
+        <div class="tpc-main">
+          ${isTodayTraining
+            ? `<span class="tpc-day-name">${todayDayName}</span>`
+            : `<span class="tpc-day-name tpc-day-name--rest">Rest Day 💤</span>`
+          }
+          <span class="tpc-program-name">${program.name}</span>
+        </div>
+
+        <div class="tpc-strip">${strip}</div>
+      </div>`;
+  }
+
+  window.renderTodayProgramCard = renderTodayProgramCard;
+})();

--- a/src/js/workout-archiver.js
+++ b/src/js/workout-archiver.js
@@ -109,6 +109,7 @@
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ records }),
+      signal: AbortSignal.timeout(5000)
     });
 
     if (!response.ok) {

--- a/stats.js
+++ b/stats.js
@@ -75,7 +75,7 @@ function showUserStats(name) {
     <table><tr><th>Date</th><th>Exercise</th><th>Sets</th><th>Reps</th><th>Weight</th></tr>${workouts}</table>
     <h4>Exercise Summary</h4>
     <table><tr><th>Exercise</th><th>Total Volume</th></tr>${volumes}</table>
-    <canvas id="userVolumeChart"></canvas>
+    <canvas id="userVolumeChart" height="200"></canvas>
     <div style="margin-top:10px;"><button onclick="showTab('leaderboardTab')">Back to Leaderboard</button></div>
   `;
   showTab('userStatsTab');
@@ -119,7 +119,7 @@ function showGroupStats(id) {
     <ul>${contributors}</ul>
     <h4>Exercise Totals</h4>
     <table><tr><th>Exercise</th><th>Total Volume</th></tr>${volumes}</table>
-    <canvas id="groupVolumeChart"></canvas>
+    <canvas id="groupVolumeChart" height="200"></canvas>
     <div style="margin-top:10px;"><button onclick="showTab('communityTab'); if(window.showCommunitySection) showCommunitySection('competition');">Back to Leaderboard</button></div>
   `;
   showTab('groupStatsTab');

--- a/style.css
+++ b/style.css
@@ -153,6 +153,7 @@
   position: sticky;
   top: 12px;
   max-height: calc(100vh - 24px);
+  max-height: calc(100dvh - 24px); /* dynamic viewport */
   overflow: auto;
 }
 

--- a/workoutTimer.js
+++ b/workoutTimer.js
@@ -253,7 +253,7 @@ async function _syncDayRemote(day) {
   };
 
   try {
-    const res = await fetch(action.url, { ...action.options, credentials: 'include' });
+    const res = await fetch(action.url, { ...action.options, credentials: 'include', signal: AbortSignal.timeout(5000) });
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }


### PR DESCRIPTION
## Summary

This PR brings together all the UI and feature work from this session:

### 🎨 Cardio Tracker (full redesign)
- Icon-prefix input wrappers — emoji icon on the left, unit badge on the right (min / km / kcal / bpm)
- Effort level pill row: 😌 Easy · 💪 Moderate · 🔥 Hard · ⚡ Max — colour-coded active states
- "More options" accordion for HR, calories override, custom date, and notes
- Today's date chip in the form header; submit icon changes per selected activity type
- Avg heart rate and intensity badge now saved and shown in history cards

### 📋 Check-In Tab (4 sub-tabs)
- **Log** · **Adjust** · **Photos** · **History** sub-tab nav with sticky underline indicator
- CSS toggle switches replacing native checkboxes
- Timeline history cards with status-based left border (approved / reviewed / needs changes / pending)
- Cardio adherence slider auto-fills from this week's actual cardio log data
- Photo comparison card: pick a past check-in and see front view side-by-side

### 🤝 Community — Peer Sharing
- New **Share** panel: send programs or workout templates to a specific user or group
- Inbox panel shows received items with Accept / Dismiss actions
- Sent history panel; red badge count on the nav button

### 🏋️ Powerlifting Improvements
- **Scores sub-tab**: live Wilks 2020, DOTS, and IPF GL calculator — inputs for bodyweight, sex, equipment, S/B/D lifts (kg or lbs); performance tier badge (Beginner → Elite)

### 🏠 Recreational Profile — Simplified Home
- Hero card shows habit streak + today's step count vs goal instead of show-day countdown
- Card order reordered: mission/status first; "Upcoming Prep Events" removed

### 🐛 Bug Fixes
- Attempt sheet buttons/inputs too small for iOS tap targets → bumped to 9px/12px padding, 0.9 rem
- Step tracking widget HTML was entirely missing — `initStepWidget()` had no DOM to mount to
- `saveMeetDetails()` used raw `alert()` → replaced with `window.showToast?()`
- `attempt-weight-input` font-size was 0.88 rem (triggers iOS auto-zoom) → 1 rem

## Test plan
- [ ] Log a cardio session — verify icon changes per activity, effort pills colour correctly, accordion opens/closes, HR and intensity appear on history card
- [ ] Open Check-In tab → verify all 4 sub-tabs switch correctly; log and save a check-in → redirects to History
- [ ] Community → Share panel → send a template; switch to Inbox
- [ ] Powerlifting → Scores tab → enter lifts, verify three scores update live
- [ ] Recreational profile → home hero card shows steps and streak, not show-day countdown
- [ ] Meet Day sheet → tap attempt status buttons on a phone; verify tap targets are comfortable

🤖 Generated with [Claude Code](https://claude.com/claude-code)