### PR TITLE
fix: close unclosed brace in startSignup (resolves startLogin ReferenceError)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2935,12 +2935,6 @@ async function startSignup() {
       } else {
         alert("Account created! Please log in to continue.");
       }
-
-    if (result.success && result.token) {
-      persistLoginIdentity(result.username || username, result.token);
-      setCurrentUser(result.username || username);
-      document.getElementById('loginContainer').style.display = 'none';
-      showOnboarding();
     } else {
       const message = result.error?.message || result.message || "Signup failed. Please try again.";
       if (errorEl) errorEl.textContent = message;


### PR DESCRIPTION
## Root Cause

PR #255 accidentally merged two different versions of `startSignup`, leaving `if (result.success) {` opened at line 2920 but never closed. The parser therefore saw `} catch (error)` as trying to attach to something other than a `try` block, and threw:

> **SyntaxError: Unexpected token 'catch'**

Because the entire inline `<script>` block failed to parse, **every function in it was undefined** — including `startLogin`. Clicking the login button then threw:

> **Uncaught ReferenceError: startLogin is not defined**

## Fix

Collapsed the duplicate signup-flow block. `if (result.success) { … }` now closes properly (with an `else` branch for failure messages) before the `} catch (error) {` clause.

## Test plan
- [ ] Open the app — login page loads without console errors
- [ ] Click **Login** — no "startLogin is not defined" error
- [ ] Signup flow completes without JS exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)