### PR TITLE
ci: fix Codemagic triggers + session bug fixes and coach tab redesign

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -10,6 +10,15 @@ workflows:
     max_build_duration: 60
     instance_type: mac_mini_m2
 
+    triggering:
+      events:
+        - push
+        - pull_request
+      branch_patterns:
+        - pattern: main
+          include: true
+          source: true
+
     environment:
       # ── Uncomment + fill in once you have an Apple Developer account ──
       # ios_signing:
@@ -134,6 +143,15 @@ workflows:
     name: Pocket Coach – Android
     max_build_duration: 60
     instance_type: linux_x2
+
+    triggering:
+      events:
+        - push
+        - pull_request
+      branch_patterns:
+        - pattern: main
+          include: true
+          source: true
 
     environment:
       vars:


### PR DESCRIPTION
## Summary

- **Fix Codemagic not deploying** — `codemagic.yaml` had no `triggering` section so Codemagic only fired on PR events from its dashboard. Direct pushes to `main` produced no build. Added `triggering` blocks to both `ios-capacitor` and `android-capacitor` workflows so any push to `main` now kicks off a build automatically.

This PR also captures all session work that was committed directly to `main` (no diff shown for those, they are already in `main`):

- **3 bug fixes** — `workouts_null` key before auth initialises; duplicate workout sessions after API sync; onboarding writing wrong `weightUnit` key
- **Login security** — JWT signing, bcrypt password verify, rate limiting, helmet headers, post-login UI renders immediately from localStorage
- **`/templates` routes** — GET/POST/DELETE added to server; `fetchTemplates()` fails gracefully on 401
- **Coach mode toggle fixed** — event listener now bound after `settings.html` loads async
- **Profile save fixed** — `#profileTabContent` added to `settings.html` so `renderProfileTab()` can render
- **Coach + Clients tabs** — single dense coaching tab split into `clientsTab` (roster) and `coachOpsTab` (programs/messages/analytics/privacy) with bottom nav buttons that appear when coach mode is on

## Test plan

- [ ] Merge this PR → Codemagic build triggers automatically
- [ ] Toggle Coach Mode in Settings → Clients and Coach nav buttons appear
- [ ] Open Clients tab → roster loads; open Coach tab → sub-tabs work
- [ ] Edit profile in Settings → Save → values persist on reload
- [ ] Log a workout exercise → saves under correct username key

🤖 Generated with [Claude Code](https://claude.com/claude-code)