### PR TITLE
fix: settings tab crash and GitHub Pages asset 404s

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
   <link rel="stylesheet" href="css/cardio.css">
   <link rel="stylesheet" href="css/checkin.css">
   <link rel="stylesheet" href="css/community-share.css">
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="manifest.json">
   <!-- iOS PWA / Capacitor meta tags -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -12942,7 +12942,7 @@ window.renderHeroPhaseHeader = renderHeroPhaseHeader;
 window.renderStatusSummary = renderStatusSummary;
 window.renderTodaysMission = renderTodaysMission;
 window.renderUpcomingPrepEvents = renderUpcomingPrepEvents;
-window.renderRewardSummary = renderRewardSummary;
+window.renderRewardSummary = typeof renderRewardSummary === 'function' ? renderRewardSummary : function() {};
 
   function showToast(msg) {
     const toast = document.createElement('div');
@@ -13854,7 +13854,7 @@ window.renderMeetPrep = renderMeetPrep;
   // ── Service Worker registration ──────────────────────────
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function () {
-        navigator.serviceWorker.register('/sw.js').then(function (reg) {
+        navigator.serviceWorker.register('sw.js').then(function (reg) {
           console.log('[SW] Registered:', reg.scope);
           // Listen for SYNC_READY messages from the SW
           navigator.serviceWorker.addEventListener('message', function (e) {

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -859,12 +859,23 @@ function injectSettingsMarkup() {
       renderProfileGamificationSummary(container);
       if (typeof initSmartGoalForm === 'function') initSmartGoalForm();
       if (typeof applyTrainingModeClasses === 'function') applyTrainingModeClasses(localStorage.getItem('trainingMode') || 'bodybuilding');
+      // Wire up appModeSelect and coachModeToggle here — settings.html is
+      // fetched async so these elements don't exist at DOMContentLoaded.
       const appModeSel = container.querySelector('#appModeSelect');
-      if (appModeSel && typeof getCurrentAppMode === 'function') appModeSel.value = getCurrentAppMode();
-      // Wire up coach mode toggle — must be done here because settings.html
-      // is fetched async, so the element doesn't exist at DOMContentLoaded
-      // when index.html tries to bind it.
       const coachToggle = container.querySelector('#coachModeToggle');
+
+      if (appModeSel && typeof getCurrentAppMode === 'function') {
+        appModeSel.value = getCurrentAppMode();
+        appModeSel.addEventListener('change', (e) => {
+          if (typeof setCurrentAppMode === 'function') setCurrentAppMode(e.target.value);
+          if (typeof applyAppModeToNavigation === 'function') applyAppModeToNavigation();
+          if (coachToggle) {
+            coachToggle.checked = typeof isCoachModeEnabled === 'function' && isCoachModeEnabled();
+            coachToggle.disabled = e.target.value !== 'both';
+          }
+        });
+      }
+
       if (coachToggle && typeof isCoachModeEnabled === 'function') {
         coachToggle.checked = isCoachModeEnabled();
         coachToggle.disabled = getCurrentAppMode() !== 'both';
@@ -883,20 +894,6 @@ function injectSettingsMarkup() {
           }
           if (typeof showToast === 'function') {
             showToast(isEnabled ? '🏆 Coach Mode enabled' : 'Coach Mode disabled');
-          }
-        });
-      }
-
-      // Also wire appModeSelect if it isn't already bound by index.html
-      const appModeSel = container.querySelector('#appModeSelect');
-      if (appModeSel && typeof getCurrentAppMode === 'function') {
-        appModeSel.value = getCurrentAppMode();
-        appModeSel.addEventListener('change', (e) => {
-          if (typeof setCurrentAppMode === 'function') setCurrentAppMode(e.target.value);
-          if (typeof applyAppModeToNavigation === 'function') applyAppModeToNavigation();
-          if (coachToggle) {
-            coachToggle.checked = typeof isCoachModeEnabled === 'function' && isCoachModeEnabled();
-            coachToggle.disabled = e.target.value !== 'both';
           }
         });
       }


### PR DESCRIPTION
## Summary

Three bugs introduced by the previous session that broke the settings tab on the live site:

**1. `SyntaxError: 'appModeSel' already declared` — settings tab showed nothing**
The coach-mode wiring code I added declared `const appModeSel` twice in the same function scope in `settings.js`. A `SyntaxError` causes the entire script to fail parsing, so `injectSettingsMarkup`, `renderProfileTab`, `saveSettings` and every other settings function were unavailable. Fixed by merging the two blocks into one.

**2. `ReferenceError: renderRewardSummary is not defined`**
`window.renderRewardSummary = renderRewardSummary` referenced a function that doesn't exist anywhere. Guarded with `typeof` so it assigns a no-op instead of crashing.

**3. `manifest.json` and `sw.js` 404 on GitHub Pages**
Both were referenced with absolute paths (`/manifest.json`, `/sw.js`) which resolve to `https://butterszzz-art.github.io/` — the domain root. The app lives at `/TrainingLog-mobile/` so the files were never found. Changed to relative paths.

## Test plan

- [ ] Merge → open https://butterszzz-art.github.io/TrainingLog-mobile/
- [ ] Open Settings tab — form fields, sub-tabs, and Save button should all appear
- [ ] No `SyntaxError` or `ReferenceError` in the console
- [ ] No 404 for `manifest.json` or `sw.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)