### PR TITLE
feat: visual polish, AI features, workout timer fix, log form redesign

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -95,19 +95,24 @@ button {
   margin: 12px 0;
   box-sizing: border-box;
   border-radius: 999px;
-  background-color: var(--primary);
+  background: linear-gradient(135deg, #38a870 0%, var(--primary) 55%, #245f47 100%);
   color: var(--text-color);
   border: none;
   cursor: pointer;
   font-size: 15px;
   box-shadow: var(--shadow);
-  transition: background-color 0.25s ease, transform 0.2s ease, box-shadow 0.25s ease;
+  transition: background 0.25s ease, transform 0.2s ease, box-shadow 0.25s ease;
 }
 
 button:hover {
-  background-color: var(--primary-dark);
+  background: linear-gradient(135deg, #42bf80 0%, #35956b 55%, #2d7d5b 100%);
   transform: translateY(-2px);
-  box-shadow: 0 0 0 3px rgba(45, 125, 91, 0.28), 0 6px 20px rgba(45, 125, 91, 0.35);
+  box-shadow: 0 0 0 3px rgba(45, 125, 91, 0.28), 0 6px 20px rgba(45, 125, 91, 0.38);
+}
+
+button:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow);
 }
 
 /* Add-to-log button disabled state */

--- a/css/home.css
+++ b/css/home.css
@@ -837,3 +837,26 @@
   align-self: flex-start;
 }
 .plateau-alert-dismiss:hover { color: var(--text-color, #222); }
+
+/* ── Global card polish ─────────────────────────────────────────
+   Adds a subtle green-tinted top accent to all generic article
+   cards across every tab, giving depth without per-card overrides.
+   ─────────────────────────────────────────────────────────────── */
+
+.tab-content article,
+.tab-content .card {
+  border-top: 1px solid rgba(45, 125, 91, 0.28);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+/* Key stat numbers — glow on the primary green values */
+.stat-value,
+.big-stat,
+.readiness-score {
+  text-shadow: 0 0 18px rgba(45, 125, 91, 0.45);
+}
+
+/* Focus bar label — tighten up the glow for the timer */
+.wfb-timer {
+  text-shadow: 0 0 10px rgba(95, 168, 126, 0.5);
+}

--- a/css/log.css
+++ b/css/log.css
@@ -5,60 +5,128 @@
    Depends on: tokens.css
    ============================================================= */
 
-/* ── Narrower log-form inputs ───────────────────────────────── */
+/* ── Log sub-view padding ───────────────────────────────────── */
 
-/*
- * Constrain the main log inputs to 60% width so they don't stretch
- * the full card on wide viewports.
- */
+#logSub_log {
+  padding-bottom: 20px;
+}
+
+/* ── Workout session timer banner ───────────────────────────── */
+
+.workout-timer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 8px 12px 12px;
+  padding: 10px 14px;
+  background: rgba(45, 125, 91, 0.08);
+  border: 1px solid rgba(45, 125, 91, 0.22);
+  border-left: 3px solid var(--primary);
+  border-radius: 0 10px 10px 0;
+}
+
+.workout-timer-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.workout-timer-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--secondary-text);
+  font-weight: 600;
+}
+
+.workout-timer-value {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--primary);
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+.workout-timer-end {
+  padding: 8px 18px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  background: #c05060;
+  border-radius: 8px;
+  color: #fff;
+  border: none;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+/* ── Resistance section ─────────────────────────────────────── */
+
+#resistance-section {
+  display: block;
+  margin-bottom: 20px;
+  padding: 0 12px;
+}
+
+/* ── Form card ──────────────────────────────────────────────── */
+
+.log-form-card {
+  background: var(--card-bg);
+  border: 1px solid rgba(96, 126, 113, 0.36);
+  border-radius: 16px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.log-form-card input,
+.log-form-card select {
+  width: 100%;
+  margin: 0 0 8px;
+}
+
+/* Sets + unit side-by-side */
+.sets-unit-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 8px;
+}
+
+.sets-unit-row input,
+.sets-unit-row select {
+  margin: 0 0 8px;
+}
+
+/* Template select — secondary visual weight */
+.log-template-select {
+  color: var(--secondary-text);
+  font-size: 0.88rem;
+  margin-bottom: 8px !important;
+}
+
+/* Full-width Add to Log button */
+.log-add-btn {
+  width: 100%;
+  margin: 6px 0 0;
+  padding: 13px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  border-radius: 12px;
+  letter-spacing: 0.02em;
+}
+
+/* Inputs inside resistance inputs don't need the 60% centring */
 #exercise,
 #sets,
 #goal,
 #repGoal,
 #weightUnit,
 #entryDate {
-  width: 60%;
-  margin-left: auto;
-  margin-right: auto;
-  display: block;
-}
-
-/* ── Resistance section grid ────────────────────────────────── */
-
-#resistance-section {
-  display: grid;
-  grid-template-columns: 1fr 1.2fr;
-  column-gap: 24px;
-  align-items: start;
-  margin-bottom: 80px;
-}
-
-#resistance-inputs {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-#resistance-inputs input,
-#resistance-inputs select {
   width: 100%;
-  max-width: 100%;
-}
-
-/* ── Workout session timer strip ────────────────────────────── */
-
-.workout-timer {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  font-weight: 600;
-  margin: 12px 0 24px;
-  color: var(--text-color);
-}
-
-.workout-timer-value {
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 1.25rem;
+  margin-left: 0;
+  margin-right: 0;
+  display: block;
 }
 
 /* ── Training calendar ──────────────────────────────────────── */
@@ -147,34 +215,6 @@
 /* ── Responsive: single-column below 600 px ─────────────────── */
 
 @media (max-width: 600px) {
-  #resistance-section {
-    display: block;
-  }
-
-  #resistance-section .inputs-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  .workout-timer {
-    justify-content: center;
-  }
-
-  #resistance-inputs {
-    flex-direction: column;
-    align-items: stretch;
-    overflow: visible;
-    gap: 8px;
-    padding-bottom: 0;
-  }
-
-  #resistance-inputs input,
-  #resistance-inputs select {
-    flex: none;
-    width: 100%;
-  }
-
   #restTimerSection {
     display: flex;
     gap: 8px;

--- a/css/nav.css
+++ b/css/nav.css
@@ -60,14 +60,47 @@
   color: var(--primary);
 }
 
+.bn-item {
+  position: relative; /* anchor the ::before indicator */
+}
+
+/* Top indicator pill — scales in when active */
+.bn-item::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%) scaleX(0);
+  width: 28px;
+  height: 3px;
+  background: var(--primary);
+  border-radius: 0 0 4px 4px;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.bn-item.active::before {
+  transform: translateX(-50%) scaleX(1);
+}
+
 .bn-item .bn-icon {
   font-size: 20px;
   line-height: 1;
-  transition: transform 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+/* SVG icon sizing */
+.bn-icon svg {
+  width: 22px;
+  height: 22px;
+  display: block;
 }
 
 .bn-item.active .bn-icon {
   transform: translateY(-2px);
+  filter: drop-shadow(0 0 7px rgba(45, 125, 91, 0.7));
 }
 
 .bn-item .bn-label {

--- a/index.html
+++ b/index.html
@@ -159,46 +159,46 @@
   <!-- Simplified Navigation Bar: 5 core tabs + archetype specialty + More -->
   <nav id="bottomNav" aria-label="Main navigation">
     <button class="bn-item active" data-tab="homeTab" aria-label="Home">
-      <span class="bn-icon">🏠</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg></span>
       <span class="bn-label">Home</span>
     </button>
     <button class="bn-item" data-tab="logTab" aria-label="Log">
-      <span class="bn-icon">📝</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></span>
       <span class="bn-label">Log</span>
     </button>
     <button class="bn-item" data-tab="progressTab" aria-label="Progress">
-      <span class="bn-icon">📈</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
       <span class="bn-label">Progress</span>
     </button>
     <button class="bn-item" data-tab="programTab" aria-label="Programs">
-      <span class="bn-icon">🗓️</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
       <span class="bn-label">Programs</span>
     </button>
     <!-- Archetype-specific specialty tab (only one is visible at a time via mode classes) -->
     <button class="bn-item bb-only" data-tab="posingTab" aria-label="Posing">
-      <span class="bn-icon">🎭</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></span>
       <span class="bn-label">Posing</span>
     </button>
     <button class="bn-item pl-only" data-tab="powerliftingTab" aria-label="Powerlifting">
-      <span class="bn-icon">🏋️</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="6.5" y1="12" x2="17.5" y2="12"/><line x1="2" y1="10" x2="2" y2="14"/><line x1="4" y1="8.5" x2="4" y2="15.5"/><line x1="20" y1="8.5" x2="20" y2="15.5"/><line x1="22" y1="10" x2="22" y2="14"/></svg></span>
       <span class="bn-label">Lifting</span>
     </button>
     <button class="bn-item athlete-only" data-tab="crossfitTab" aria-label="CrossFit">
-      <span class="bn-icon">💪</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
       <span class="bn-label">CrossFit</span>
     </button>
     <!-- Coach-mode tabs — hidden until coach mode is enabled -->
     <button class="bn-item coach-only" data-tab="clientsTab" aria-label="Clients" style="display:none;">
-      <span class="bn-icon">👥</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
       <span class="bn-label">Clients</span>
     </button>
     <button class="bn-item coach-only" data-tab="coachOpsTab" aria-label="Coach" style="display:none;">
-      <span class="bn-icon">🏆</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
       <span class="bn-label">Coach</span>
     </button>
     <!-- More button opens the secondary-tabs drawer -->
     <button class="bn-item bn-more" id="moreNavBtn" onclick="openMoreDrawer()" aria-label="More" aria-expanded="false" aria-controls="moreDrawer">
-      <span class="bn-icon">⋯</span>
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg></span>
       <span class="bn-label">More</span>
     </button>
   </nav>

--- a/index.html
+++ b/index.html
@@ -270,45 +270,50 @@
 
     <!-- ══ Sub-view: Log ══════════════════════════════════════════ -->
     <div id="logSub_log" class="log-subview active">
-      <h2 style="padding:0 10px;">Resistance Exercise Log</h2>
 
       <!-- Session context flags: alt-machine / alt-gym -->
-      <div id="sessionContextBar"></div>
+      <div id="sessionContextBar" style="padding:0 12px;"></div>
 
+      <!-- Workout session timer — styled as a full-width banner -->
       <div id="workoutTimer" class="workout-timer" aria-live="polite">
-        <span class="workout-timer-label">Workout Time:</span>
-        <span id="workoutElapsed" class="workout-timer-value">00:00:00</span>
-        <button id="endWorkoutBtn" type="button" class="workout-timer-end">End Workout</button>
+        <div class="workout-timer-info">
+          <span class="workout-timer-label">Workout in progress</span>
+          <span id="workoutElapsed" class="workout-timer-value">00:00:00</span>
+        </div>
+        <button id="endWorkoutBtn" type="button" class="workout-timer-end">End</button>
       </div>
 
+      <!-- Main entry form card -->
       <div id="resistance-section">
-        <div id="resistance-inputs">
-          <div class="inputs-grid">
-            <input type="text" id="exercise" placeholder="Exercise" list="exerciseSuggestions" oninput="updateAddButtonState()" />
-            <datalist id="exerciseSuggestions"></datalist>
-            <input type="number" id="sets" placeholder="Sets" oninput="generateSetInputs(this.value); updateAddButtonState();" />
-            <!-- Progressive overload hint — populated by workout-intelligence.js -->
-            <div id="overloadHint" class="overload-hint" style="grid-column:1/-1;"></div>
+        <div id="resistance-inputs" class="log-form-card">
 
-            <!-- Unit selector -->
+          <input type="text" id="exercise" placeholder="Exercise name…" list="exerciseSuggestions" oninput="updateAddButtonState()" />
+          <datalist id="exerciseSuggestions"></datalist>
+
+          <!-- Progressive overload hint -->
+          <div id="overloadHint" class="overload-hint"></div>
+
+          <!-- Sets + unit on one row -->
+          <div class="sets-unit-row">
+            <input type="number" id="sets" placeholder="Sets" oninput="generateSetInputs(this.value); updateAddButtonState();" />
             <select id="weightUnit">
               <option value="kg">kg</option>
               <option value="lbs">lbs</option>
             </select>
-
-            <!-- Dynamically generated inputs -->
-            <div id="setInputsContainer" style="grid-column: 1 / -1;"></div>
           </div>
 
+          <!-- Dynamically generated set inputs -->
+          <div id="setInputsContainer"></div>
+
           <!-- Template quick-load -->
-          <select id="resistanceTemplateSelect" onchange="loadSelectedResistanceTemplate()" style="margin-top: 10px;">
-            <option value="">Select Template...</option>
+          <select id="resistanceTemplateSelect" class="log-template-select" onchange="loadSelectedResistanceTemplate()">
+            <option value="">Load a template…</option>
           </select>
-          <div id="templateLoadMessage" style="margin-top:6px; color:#b00020; display:none;"></div>
+          <div id="templateLoadMessage" style="margin-top:4px; color:#b00020; display:none;"></div>
 
           <!-- Advanced accordion: goals + date -->
-          <details class="log-advanced" style="margin-top:10px;">
-            <summary>⚙️ Advanced options</summary>
+          <details class="log-advanced">
+            <summary>Advanced options</summary>
             <div class="log-advanced-body">
               <input type="number" id="goal" placeholder="Target Weight Goal (kg/lbs)" />
               <input type="number" id="repGoal" placeholder="Target Rep Goal (optional)" />
@@ -316,11 +321,12 @@
             </div>
           </details>
 
-          <button id="addLogBtn" onclick="addLogEntry()" disabled style="margin-top:12px;">Add to Log</button>
+          <button id="addLogBtn" onclick="addLogEntry()" disabled class="log-add-btn">+ Add to Log</button>
 
-          <!-- Logs render here -->
-          <div id="workoutsContainer" style="margin-top: 20px;"></div>
-        </div>
+        </div><!-- /log-form-card -->
+
+        <!-- Logs render here -->
+        <div id="workoutsContainer" style="margin-top:16px;"></div>
       </div>
     </div><!-- /logSub_log -->
 


### PR DESCRIPTION
## Summary

This PR bundles several sessions of work across AI features, visual polish, and UX improvements.

### AI Features
- **Check-in summary** — `POST /api/ai/checkin-summary` backend + home tab card
- **Macro advisor** — `POST /api/ai/macro-advice` + slide-up panel in Macros tab
- **Program analyser** — `POST /api/ai/program-analysis` + toggle panel per program card
- **Plateau detector** — `POST /api/ai/plateau-check` runs silently on Progress tab, surfaces amber card when a stall is detected, dismissable per-week
- **AI draft message generator** — `POST /api/ai/coach-draft-message` + button in coach client detail view with copy/clear controls
- **AI program generator** — `POST /api/ai/generate-program` + slide-up panel in Programs tab with 7-field form, preview step, and save to builder

All AI routes use `claude-haiku-4-5-20251001` and return `404 { error: 'AI_NOT_CONFIGURED' }` without `ANTHROPIC_API_KEY`.

### Visual Polish
- **SVG nav icons** — replaced all 10 bottom-nav emojis with clean inline Lucide-style SVGs (22px, 2px stroke); consistent across Android and iOS
- **Active tab indicator** — 28×3px green pill that spring-animates in above the active tab; drop-shadow glow on the active icon
- **Gradient buttons** — primary buttons now use a three-stop green gradient instead of flat colour, with press-down `:active` state
- **Card depth** — subtle green-tinted `border-top` + deeper `box-shadow` on all `article`/`.card` elements

### Bug Fixes
- **Workout focus bar overlap** — bumped `bottom: 64px → 65px` on `#workoutFocusBar` to account for the nav's 1px `border-top`; gap between bar and nav is now exactly 0px

### Resistance Log Redesign
- Removed the oversized `h2` title
- **Session banner** — full-width green left-bordered timer bar replacing the old inline "Workout Time:" strip; compact "End" button right-aligned
- **Form card** — all inputs unified in a dark rounded card (16px radius)
- **Sets + Unit** — now side-by-side in a 2:1 grid row
- **Add to Log** — full-width gradient CTA button

## Test plan

- [ ] Verify bottom nav icons render correctly on both Android and iOS (no emoji fallback)
- [ ] Switch tabs and confirm active indicator animates in; inactive tabs show no indicator
- [ ] Start a workout and confirm focus bar sits flush above the nav with no overlap
- [ ] Open Log tab — confirm timer banner, form card layout, and sets/unit row look correct
- [ ] `POST /api/ai/*` endpoints return `404` without API key, correct JSON with key set
- [ ] Add `ANTHROPIC_API_KEY` to Render environment variables to enable all AI endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)