### PR TITLE
feat: dark theme fixes, app tutorial, archetype personalization

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -182,7 +182,8 @@ td {
 }
 
 th {
-  background-color: #f0f0f0;
+  background-color: var(--surface-bg);
+  color: var(--secondary-text);
 }
 
 /* ── Layout containers ──────────────────────────────────────── */

--- a/css/tutorial.css
+++ b/css/tutorial.css
@@ -1,0 +1,199 @@
+/* =============================================================
+   APP TUTORIAL
+   Swipeable feature-tour overlay shown once after first signup.
+   Depends on: tokens.css
+   ============================================================= */
+
+/* ── Overlay ───────────────────────────────────────────────── */
+
+.tutorial-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2100;
+  background: var(--bg-color, #080b0a);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.tutorial-overlay[hidden] { display: none; }
+
+/* ── Skip button (top-right) ───────────────────────────────── */
+
+.tutorial-skip {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 2;
+  padding: 6px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--secondary-text);
+  font-size: 0.82rem;
+  cursor: pointer;
+  box-shadow: none;
+  margin: 0;
+}
+
+/* ── Slide track (horizontal scroll-snap) ──────────────────── */
+
+.tutorial-track {
+  flex: 1;
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.tutorial-track::-webkit-scrollbar { display: none; }
+
+/* ── Individual slide ──────────────────────────────────────── */
+
+.tutorial-slide {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 28px 32px;
+  text-align: center;
+  gap: 12px;
+}
+
+/* Icon container */
+.tutorial-icon {
+  width: 96px;
+  height: 96px;
+  border-radius: 28px;
+  background: rgba(45, 125, 91, 0.12);
+  border: 1px solid rgba(45, 125, 91, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+
+.tutorial-icon svg {
+  width: 44px;
+  height: 44px;
+  stroke: var(--primary, #2d7d5b);
+  fill: none;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.tutorial-icon--highlight {
+  background: linear-gradient(135deg, rgba(45,125,91,0.18), rgba(198,148,79,0.12));
+  border-color: rgba(198, 148, 79, 0.3);
+}
+
+.tutorial-icon--highlight svg {
+  stroke: var(--highlight, #c6944f);
+}
+
+/* Text */
+.tutorial-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-color);
+  margin: 0;
+  line-height: 1.3;
+}
+
+.tutorial-desc {
+  font-size: 0.95rem;
+  color: var(--secondary-text);
+  margin: 0;
+  line-height: 1.55;
+  max-width: 320px;
+}
+
+/* Feature chips shown on some slides */
+.tutorial-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.tutorial-chip {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(45,125,91,0.3);
+  background: rgba(45,125,91,0.08);
+  color: var(--secondary-text);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: default;
+  box-shadow: none;
+  margin: 0;
+}
+
+/* ── Bottom controls ───────────────────────────────────────── */
+
+.tutorial-controls {
+  padding: 20px 28px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+/* Dot indicators */
+.tutorial-dots {
+  display: flex;
+  gap: 8px;
+}
+
+.tutorial-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border-color);
+  transition: background 0.25s, transform 0.25s;
+}
+
+.tutorial-dot.active {
+  background: var(--primary, #2d7d5b);
+  transform: scale(1.3);
+}
+
+/* CTA button */
+.tutorial-cta {
+  width: 100%;
+  max-width: 320px;
+  padding: 14px;
+  border-radius: 14px;
+  border: none;
+  background: linear-gradient(135deg, #38a870 0%, var(--primary) 55%, #245f47 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+  box-shadow: 0 4px 16px rgba(45,125,91,0.35);
+  margin: 0;
+}
+
+/* ── Swipe hint animation ──────────────────────────────────── */
+
+@keyframes tutorial-nudge {
+  0%, 100% { transform: translateX(0); }
+  50%      { transform: translateX(-8px); }
+}
+
+.tutorial-slide:first-child::after {
+  content: '';
+  display: block;
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border-color);
+  margin-top: 20px;
+  animation: tutorial-nudge 2s ease-in-out infinite;
+}

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="css/base.css">
   <link rel="stylesheet" href="css/nav.css">
   <link rel="stylesheet" href="css/onboarding.css">
+  <link rel="stylesheet" href="css/tutorial.css">
   <link rel="stylesheet" href="css/tabs.css">
   <link rel="stylesheet" href="css/home.css">
   <link rel="stylesheet" href="css/log.css">
@@ -148,6 +149,94 @@
   </div>
 </div>
 
+<!-- ── App Tutorial (feature tour, shown once after onboarding) ────── -->
+<div id="tutorialOverlay" class="tutorial-overlay" hidden>
+  <button class="tutorial-skip" id="tutorialSkip">Skip</button>
+
+  <div class="tutorial-track" id="tutorialTrack">
+    <!-- Slide 1: Welcome -->
+    <div class="tutorial-slide">
+      <div class="tutorial-icon tutorial-icon--highlight">
+        <svg viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+      </div>
+      <h2 class="tutorial-title">Welcome to Pocket Coach</h2>
+      <p class="tutorial-desc">Your all-in-one training companion. Let's take a quick look at what you can do.</p>
+    </div>
+
+    <!-- Slide 2: Log -->
+    <div class="tutorial-slide">
+      <div class="tutorial-icon">
+        <svg viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+      </div>
+      <h2 class="tutorial-title">Log Your Workouts</h2>
+      <p class="tutorial-desc">Track every set, rep, and weight. The app remembers your history and suggests progressive overload.</p>
+      <div class="tutorial-chips">
+        <span class="tutorial-chip">Resistance</span>
+        <span class="tutorial-chip">Cardio</span>
+        <span class="tutorial-chip">Templates</span>
+        <span class="tutorial-chip">Rest Timer</span>
+      </div>
+    </div>
+
+    <!-- Slide 3: Progress -->
+    <div class="tutorial-slide">
+      <div class="tutorial-icon">
+        <svg viewBox="0 0 24 24"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+      </div>
+      <h2 class="tutorial-title">Track Your Progress</h2>
+      <p class="tutorial-desc">Visualise strength trends, personal records, and workout consistency over time.</p>
+      <div class="tutorial-chips">
+        <span class="tutorial-chip">Strength Charts</span>
+        <span class="tutorial-chip">PRs</span>
+        <span class="tutorial-chip">Streaks</span>
+      </div>
+    </div>
+
+    <!-- Slide 4: Weight -->
+    <div class="tutorial-slide">
+      <div class="tutorial-icon">
+        <svg viewBox="0 0 24 24"><rect x="2" y="9" width="20" height="12" rx="2"/><path d="M8 9a4 4 0 0 1 8 0"/><line x1="12" y1="14" x2="12" y2="17"/><line x1="10" y1="17" x2="14" y2="17"/></svg>
+      </div>
+      <h2 class="tutorial-title">Bodyweight Tracking</h2>
+      <p class="tutorial-desc">Log daily weigh-ins and see your trend line. Great for cuts, bulks, or maintaining.</p>
+    </div>
+
+    <!-- Slide 5: Macros -->
+    <div class="tutorial-slide">
+      <div class="tutorial-icon">
+        <svg viewBox="0 0 24 24"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg>
+      </div>
+      <h2 class="tutorial-title">Nutrition & Macros</h2>
+      <p class="tutorial-desc">Set calorie and macro targets, then track your daily intake with a simple tap interface.</p>
+      <div class="tutorial-chips">
+        <span class="tutorial-chip">Protein</span>
+        <span class="tutorial-chip">Carbs</span>
+        <span class="tutorial-chip">Fat</span>
+        <span class="tutorial-chip">Calories</span>
+      </div>
+    </div>
+
+    <!-- Slide 6: More features -->
+    <div class="tutorial-slide">
+      <div class="tutorial-icon tutorial-icon--highlight">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </div>
+      <h2 class="tutorial-title">And Much More</h2>
+      <p class="tutorial-desc">Explore AI-generated programs, posing guides, training calendars, and gamification — all in the More tab.</p>
+      <div class="tutorial-chips">
+        <span class="tutorial-chip">AI Programs</span>
+        <span class="tutorial-chip">Posing</span>
+        <span class="tutorial-chip">XP & Badges</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="tutorial-controls">
+    <div class="tutorial-dots" id="tutorialDots"></div>
+    <button class="tutorial-cta" id="tutorialCta">Next</button>
+  </div>
+</div>
+
 <div id="dashboardContainer" class="section" style="display:none; text-align:center;">
   <h2>Welcome to Pocket Coach</h2>
   <button onclick="openSection('pocketFit')">PocketFit</button>
@@ -156,13 +245,9 @@
 
 <div id="pocketFitContainer" class="section" style="display:none;">
   
-  <!-- Simplified Navigation Bar: 5 core tabs + archetype specialty + More -->
+  <!-- Bottom Navigation: Log, Progress, Weight, Macro + More -->
   <nav id="bottomNav" aria-label="Main navigation">
-    <button class="bn-item active" data-tab="homeTab" aria-label="Home">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg></span>
-      <span class="bn-label">Home</span>
-    </button>
-    <button class="bn-item" data-tab="logTab" aria-label="Log">
+    <button class="bn-item active" data-tab="logTab" aria-label="Log">
       <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></span>
       <span class="bn-label">Log</span>
     </button>
@@ -170,31 +255,13 @@
       <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
       <span class="bn-label">Progress</span>
     </button>
-    <button class="bn-item" data-tab="programTab" aria-label="Programs">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
-      <span class="bn-label">Programs</span>
+    <button class="bn-item" data-tab="weightTab" aria-label="Weight">
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="9" width="20" height="12" rx="2"/><path d="M8 9a4 4 0 0 1 8 0"/><line x1="12" y1="14" x2="12" y2="17"/><line x1="10" y1="17" x2="14" y2="17"/></svg></span>
+      <span class="bn-label">Weight</span>
     </button>
-    <!-- Archetype-specific specialty tab (only one is visible at a time via mode classes) -->
-    <button class="bn-item bb-only" data-tab="posingTab" aria-label="Posing">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></span>
-      <span class="bn-label">Posing</span>
-    </button>
-    <button class="bn-item pl-only" data-tab="powerliftingTab" aria-label="Powerlifting">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="6.5" y1="12" x2="17.5" y2="12"/><line x1="2" y1="10" x2="2" y2="14"/><line x1="4" y1="8.5" x2="4" y2="15.5"/><line x1="20" y1="8.5" x2="20" y2="15.5"/><line x1="22" y1="10" x2="22" y2="14"/></svg></span>
-      <span class="bn-label">Lifting</span>
-    </button>
-    <button class="bn-item athlete-only" data-tab="crossfitTab" aria-label="CrossFit">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
-      <span class="bn-label">CrossFit</span>
-    </button>
-    <!-- Coach-mode tabs — hidden until coach mode is enabled -->
-    <button class="bn-item coach-only" data-tab="clientsTab" aria-label="Clients" style="display:none;">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
-      <span class="bn-label">Clients</span>
-    </button>
-    <button class="bn-item coach-only" data-tab="coachOpsTab" aria-label="Coach" style="display:none;">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
-      <span class="bn-label">Coach</span>
+    <button class="bn-item" data-tab="macroTab" aria-label="Macros">
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg></span>
+      <span class="bn-label">Macros</span>
     </button>
     <!-- More button opens the secondary-tabs drawer -->
     <button class="bn-item bn-more" id="moreNavBtn" onclick="openMoreDrawer()" aria-label="More" aria-expanded="false" aria-controls="moreDrawer">
@@ -220,6 +287,8 @@
     <div id="vacationModeCard"></div>
     <!-- Daily readiness card — populated by readiness-checkin.js -->
     <div id="readinessHomeCard"></div>
+    <!-- AI Profile summary card -->
+    <div id="archetypeProfileCard"></div>
     <!-- Weekly summary card — populated by weekly-summary.js -->
     <div id="weeklySummaryCard"></div>
     <!-- Notification permission banner — shown if permission not yet granted -->
@@ -282,6 +351,9 @@
         </div>
         <button id="endWorkoutBtn" type="button" class="workout-timer-end">End</button>
       </div>
+
+      <!-- Archetype smart tip -->
+      <div id="logSmartTip" class="apc-cue" style="margin:0 12px 10px;display:none;"></div>
 
       <!-- Main entry form card -->
       <div id="resistance-section">
@@ -2100,20 +2172,20 @@
   <div class="more-drawer-panel">
     <div class="more-drawer-handle"></div>
     <div class="more-drawer-grid">
-      <button class="more-drawer-item" data-tab="macroTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('macroTab'), 220)">
-        <span class="more-drawer-icon">🍽️</span>
-        <span>Macros</span>
+      <button class="more-drawer-item" data-tab="homeTab"
+              onclick="closeMoreDrawer(); setTimeout(()=>showTab('homeTab'), 220)">
+        <span class="more-drawer-icon">🏠</span>
+        <span>Home</span>
+      </button>
+      <button class="more-drawer-item" data-tab="programTab"
+              onclick="closeMoreDrawer(); setTimeout(()=>showTab('programTab'), 220)">
+        <span class="more-drawer-icon">📅</span>
+        <span>Programs</span>
       </button>
       <button class="more-drawer-item" data-tab="checkInTab"
               onclick="closeMoreDrawer(); setTimeout(()=>showTab('checkInTab'), 220)">
         <span class="more-drawer-icon">🧾</span>
         <span>Check-In</span>
-      </button>
-      <button class="more-drawer-item" data-tab="weightTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('weightTab'), 220)">
-        <span class="more-drawer-icon">⚖️</span>
-        <span>Weight</span>
       </button>
       <button class="more-drawer-item" data-tab="cardioTab"
               onclick="closeMoreDrawer(); setTimeout(()=>showTab('cardioTab'), 220)">
@@ -2134,6 +2206,21 @@
               onclick="closeMoreDrawer(); setTimeout(()=>showTab('logHistoryTab'), 220)">
         <span class="more-drawer-icon">📜</span>
         <span>History</span>
+      </button>
+      <button class="more-drawer-item bb-only" data-tab="posingTab"
+              onclick="closeMoreDrawer(); setTimeout(()=>showTab('posingTab'), 220)">
+        <span class="more-drawer-icon">⭐</span>
+        <span>Posing</span>
+      </button>
+      <button class="more-drawer-item pl-only" data-tab="powerliftingTab"
+              onclick="closeMoreDrawer(); setTimeout(()=>showTab('powerliftingTab'), 220)">
+        <span class="more-drawer-icon">🏋️</span>
+        <span>Lifting</span>
+      </button>
+      <button class="more-drawer-item athlete-only" data-tab="crossfitTab"
+              onclick="closeMoreDrawer(); setTimeout(()=>showTab('crossfitTab'), 220)">
+        <span class="more-drawer-icon">⚡</span>
+        <span>CrossFit</span>
       </button>
       <button class="more-drawer-item coach-only" data-tab="clientsTab"
               onclick="closeMoreDrawer(); setTimeout(()=>showTab('clientsTab'), 220)">
@@ -2687,6 +2774,7 @@ function showTab(tabName) {
   switch (tabName) {
     case 'homeTab':
       renderHomeDashboard();
+      if (typeof renderArchetypeProfileCard === 'function') renderArchetypeProfileCard();
       if (typeof window.initAiCoach === 'function' && currentUser) window.initAiCoach(currentUser);
       break;
     case 'clientsTab':
@@ -2715,6 +2803,12 @@ function showTab(tabName) {
       if (typeof window.renderGamificationUI === 'function' && currentUser) {
         window.renderGamificationUI(currentUser);
       }
+      if (typeof getSmartTip === 'function') {
+        const tip = getSmartTip('logScreen');
+        const tipEl = document.getElementById('logSmartTip');
+        if (tipEl && tip) { tipEl.textContent = tip; tipEl.style.display = ''; }
+      }
+      if (typeof applyArchetypeDefaults === 'function') applyArchetypeDefaults();
       break;
     case 'weightTab':
       renderWeights();
@@ -7112,7 +7206,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (isCoachModeEnabled()) {
         showTab('clientsTab');
       } else if (activeTab && (activeTab.id === 'clientsTab' || activeTab.id === 'coachOpsTab')) {
-        showTab('homeTab');
+        showTab('logTab');
       }
     });
   }
@@ -7129,7 +7223,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (isCoachModeEnabled()) {
         showTab('clientsTab');
       } else if (activeTab && (activeTab.id === 'clientsTab' || activeTab.id === 'coachOpsTab')) {
-        showTab('homeTab');
+        showTab('logTab');
       }
     });
   }
@@ -7202,7 +7296,7 @@ function openSection(section) {
   const el = document.getElementById(section + 'Container');
   animateSwitch(el);
   if (section === 'pocketFit') {
-    showTab('homeTab');
+    showTab('logTab');
   } else if (section === 'pocketLifestyle') {
     if (!window.lifestyleInitialized && window.initLifestyle) {
       window.initLifestyle();
@@ -13725,12 +13819,197 @@ function _finishOnboarding() {
   }
 
   document.getElementById('onboardingOverlay').setAttribute('hidden', '');
-  openSection('pocketFit');
+  showTutorial();
 }
 
 document.addEventListener('DOMContentLoaded', _initOnboarding);
 
 window.showOnboarding = showOnboarding;
+
+// ─────────────────────────────────────────────
+// APP TUTORIAL (feature walkthrough)
+// ─────────────────────────────────────────────
+
+function showTutorial() {
+  const user = window.currentUser || localStorage.getItem('fitnessAppUser');
+  const key = user ? `tutorial_seen_${user}` : 'tutorial_seen';
+  if (localStorage.getItem(key)) { openSection('pocketFit'); return; }
+
+  const overlay = document.getElementById('tutorialOverlay');
+  if (!overlay) { openSection('pocketFit'); return; }
+
+  const track = document.getElementById('tutorialTrack');
+  const dots  = document.getElementById('tutorialDots');
+  const cta   = document.getElementById('tutorialCta');
+  const slides = track.querySelectorAll('.tutorial-slide');
+  const total  = slides.length;
+  let current  = 0;
+
+  // Build dots
+  dots.innerHTML = '';
+  for (let i = 0; i < total; i++) {
+    const d = document.createElement('span');
+    d.className = 'tutorial-dot' + (i === 0 ? ' active' : '');
+    dots.appendChild(d);
+  }
+  const allDots = dots.querySelectorAll('.tutorial-dot');
+
+  function updateUI() {
+    allDots.forEach((d, i) => d.classList.toggle('active', i === current));
+    cta.textContent = current === total - 1 ? "Get Started" : "Next";
+  }
+
+  let programmatic = false;
+
+  function goTo(idx) {
+    current = idx;
+    programmatic = true;
+    track.scrollTo({ left: idx * track.offsetWidth, behavior: 'smooth' });
+    updateUI();
+    setTimeout(() => { programmatic = false; }, 400);
+  }
+
+  function finish() {
+    localStorage.setItem(key, '1');
+    overlay.setAttribute('hidden', '');
+    openSection('pocketFit');
+  }
+
+  // Scroll-snap tracking (swipe gestures)
+  let scrollTimer;
+  track.addEventListener('scroll', () => {
+    if (programmatic) return;
+    clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(() => {
+      const idx = Math.round(track.scrollLeft / track.offsetWidth);
+      if (idx !== current && idx >= 0 && idx < total) {
+        current = idx;
+        updateUI();
+      }
+    }, 120);
+  });
+
+  cta.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (current < total - 1) goTo(current + 1);
+    else finish();
+  });
+
+  document.getElementById('tutorialSkip').addEventListener('click', (e) => {
+    e.stopPropagation();
+    finish();
+  });
+
+  overlay.removeAttribute('hidden');
+  updateUI();
+}
+
+window.showTutorial = showTutorial;
+
+// ─────────────────────────────────────────────
+// ARCHETYPE PROFILE CARD
+// ─────────────────────────────────────────────
+
+function renderArchetypeProfileCard() {
+  const container = document.getElementById('archetypeProfileCard');
+  if (!container) return;
+  if (typeof getCurrentArchetypeConfig !== 'function') return;
+
+  const user = window.currentUser || localStorage.getItem('fitnessAppUser');
+  if (!user) { container.innerHTML = ''; return; }
+
+  const archetype = getUserArchetype();
+  const cfg = getArchetypeConfig(archetype);
+  const cue = getRandomCoachingCue(archetype);
+
+  // Check for cached AI summary
+  const cacheKey = `aiProfile_${user}`;
+  let aiSummary = null;
+  try { aiSummary = JSON.parse(localStorage.getItem(cacheKey)); } catch {}
+
+  const focusChips = (aiSummary?.keyFocusAreas || cfg.periodisation.phases)
+    .map(f => `<span class="apc-chip">${f}</span>`).join('');
+
+  container.innerHTML = `
+    <div class="apc-card" style="margin:0 12px 12px;background:var(--card-bg);border:1px solid var(--border-color);border-radius:16px;padding:16px;position:relative;">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">
+        <div class="apc-badge">${cfg.label.charAt(0)}</div>
+        <div>
+          <div style="font-weight:700;font-size:1rem;color:var(--text-color);">${cfg.label}</div>
+          <div style="font-size:0.78rem;color:var(--text-muted);">${cfg.defaults.repRange} reps · ${cfg.defaults.restSeconds}s rest · ${cfg.defaults.setsPerExercise} sets</div>
+        </div>
+      </div>
+      ${aiSummary ? `
+        <div style="font-size:0.88rem;color:var(--secondary-text);line-height:1.5;margin-bottom:10px;">
+          ${aiSummary.philosophy}
+        </div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px;">
+          <span class="apc-meta">${aiSummary.splitRecommendation}</span>
+          <span class="apc-meta">${aiSummary.weeklyStructure}</span>
+          <span class="apc-meta">${aiSummary.estimatedSessionLength}</span>
+        </div>
+      ` : `
+        <div style="font-size:0.88rem;color:var(--secondary-text);line-height:1.5;margin-bottom:10px;">
+          ${cfg.nutritionFocus.proteinPerKg}g protein/kg · ${cfg.nutritionFocus.mealFrequency} · Deload ${cfg.periodisation.deloadFrequency.toLowerCase()}
+        </div>
+      `}
+      <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px;">
+        ${focusChips}
+      </div>
+      <div class="apc-cue">
+        <svg viewBox="0 0 24 24" fill="none" stroke="var(--primary)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;flex-shrink:0;"><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><circle cx="12" cy="12" r="10"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <span>${cue}</span>
+      </div>
+      ${!aiSummary ? `
+        <button id="generateProfileBtn" onclick="generateAiProfileSummary()" class="apc-gen-btn">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:14px;height:14px;"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+          Generate AI Profile
+        </button>
+      ` : ''}
+    </div>`;
+}
+
+async function generateAiProfileSummary() {
+  const btn = document.getElementById('generateProfileBtn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Generating…'; }
+
+  const user = window.currentUser || localStorage.getItem('fitnessAppUser');
+  const archetype = getUserArchetype();
+
+  let settings = {};
+  try { settings = JSON.parse(localStorage.getItem('settings_' + user) || '{}'); } catch {}
+
+  const payload = {
+    archetype,
+    experienceLevel: settings?.profile?.experienceLevel || 'intermediate',
+    goal: settings?.profile?.currentGoal || 'general fitness',
+    daysPerWeek: settings?.profile?.daysPerWeek || 4,
+    sex: settings?.profile?.sex,
+    bodyweight: settings?.profile?.bodyweight,
+    unit: localStorage.getItem('defaultWeightUnit') || 'kg',
+  };
+
+  try {
+    const resp = await fetch((window.SERVER_URL || '') + '/api/ai/profile-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!resp.ok) throw new Error('Request failed');
+    const data = await resp.json();
+    localStorage.setItem('aiProfile_' + user, JSON.stringify(data));
+    renderArchetypeProfileCard();
+    if (typeof nativeToast === 'function') nativeToast('Profile generated!', 'success');
+  } catch (err) {
+    console.error('[Profile AI]', err);
+    if (btn) { btn.disabled = false; btn.textContent = 'Generate AI Profile'; }
+    if (typeof nativeToast === 'function') nativeToast('Could not generate profile — try again later', 'error');
+  }
+}
+
+window.renderArchetypeProfileCard = renderArchetypeProfileCard;
+window.generateAiProfileSummary = generateAiProfileSummary;
 
 // ─────────────────────────────────────────────
 // POWERLIFTING TAB
@@ -14262,6 +14541,7 @@ window.renderMeetPrep = renderMeetPrep;
       });
     </script>
 
+  <script src="src/js/archetype-config.js"></script>
   <script src="src/js/archetype-features.js"></script>
   <script src="src/js/coaching-enhanced.js"></script>
   <script src="src/js/workout-archiver.js"></script>

--- a/src/js/archetype-config.js
+++ b/src/js/archetype-config.js
@@ -1,0 +1,233 @@
+// =============================================================
+// ARCHETYPE CONFIG
+// Rule-based personalization per training archetype.
+// Provides defaults, coaching cues, UI visibility, and metrics
+// focus without any API calls.
+// =============================================================
+
+(function () {
+  'use strict';
+
+  const ARCHETYPE_CONFIG = {
+    bodybuilder: {
+      label: 'Bodybuilder',
+      trainingMode: 'bodybuilding',
+      defaults: {
+        repRange: '8-12',
+        restSeconds: 90,
+        setsPerExercise: 4,
+        defaultUnit: 'kg',
+      },
+      volume: {
+        weeklySetTarget: 20,
+        minSetsPerMuscle: 10,
+        maxSetsPerMuscle: 25,
+      },
+      coachingCues: [
+        'Focus on mind-muscle connection — control the eccentric',
+        'Aim for 2-3 RIR on working sets',
+        'Volume is king — track sets per muscle group',
+        'Progressive overload via reps before weight',
+        'Prioritise lagging body parts early in the session',
+      ],
+      progressMetrics: ['volume', 'muscleGroupBalance', 'bodyweight', 'measurements'],
+      visibleTabs: ['posingTab'],
+      hiddenTabs: ['powerliftingTab', 'crossfitTab'],
+      periodisation: {
+        phases: ['hypertrophy', 'intensification', 'deload'],
+        blockLengthWeeks: 6,
+        deloadFrequency: 'Every 4-6 weeks',
+      },
+      nutritionFocus: {
+        proteinPerKg: 2.2,
+        mealFrequency: '4-6 meals',
+        periWorkout: 'Fast carbs + protein post-training',
+      },
+      smartTips: {
+        logScreen: 'Track tempo — 3-1-2 for hypertrophy',
+        progressScreen: 'Compare weekly volume per muscle group',
+        weightScreen: 'Weigh daily, use 7-day average for decisions',
+        macroScreen: 'Protein timing matters — spread evenly across meals',
+      },
+    },
+
+    powerlifter: {
+      label: 'Powerlifter',
+      trainingMode: 'powerlifting',
+      defaults: {
+        repRange: '1-5',
+        restSeconds: 180,
+        setsPerExercise: 5,
+        defaultUnit: 'kg',
+      },
+      volume: {
+        weeklySetTarget: 15,
+        minSetsPerMuscle: 6,
+        maxSetsPerMuscle: 15,
+      },
+      coachingCues: [
+        'Specificity — squat, bench, deadlift are priority',
+        'RPE 7-9 for main lifts, leave 1-2 reps in the tank',
+        'Technique practice at sub-maximal loads builds strength',
+        'Accessory work supports the big three — keep it simple',
+        'Competition commands: start, press, rack',
+      ],
+      progressMetrics: ['estimated1RM', 'wilksScore', 'totalKg', 'bodyweight'],
+      visibleTabs: ['powerliftingTab'],
+      hiddenTabs: ['posingTab', 'crossfitTab'],
+      periodisation: {
+        phases: ['accumulation', 'transmutation', 'realisation', 'deload'],
+        blockLengthWeeks: 4,
+        deloadFrequency: 'Every 3-4 weeks',
+      },
+      nutritionFocus: {
+        proteinPerKg: 2.0,
+        mealFrequency: '3-4 meals',
+        periWorkout: 'Carbs pre-training for performance',
+      },
+      smartTips: {
+        logScreen: 'Log RPE for every working set',
+        progressScreen: 'Track estimated 1RM trends for SBD',
+        weightScreen: 'Manage weight class — stay within 5% of target',
+        macroScreen: 'Fuel performance — carbs are your friend',
+      },
+    },
+
+    hybrid: {
+      label: 'Hybrid Athlete',
+      trainingMode: 'bodybuilding',
+      defaults: {
+        repRange: '6-10',
+        restSeconds: 120,
+        setsPerExercise: 3,
+        defaultUnit: 'kg',
+      },
+      volume: {
+        weeklySetTarget: 16,
+        minSetsPerMuscle: 8,
+        maxSetsPerMuscle: 18,
+      },
+      coachingCues: [
+        'Balance strength and conditioning — neither dominates',
+        'Compound movements are your bread and butter',
+        'Monitor fatigue — recovery is your limiting factor',
+        'Periodise cardio around strength blocks',
+        'Functional carry-over matters — train movements, not muscles',
+      ],
+      progressMetrics: ['volume', 'estimated1RM', 'cardioCapacity', 'bodyweight'],
+      visibleTabs: [],
+      hiddenTabs: ['posingTab', 'powerliftingTab', 'crossfitTab'],
+      periodisation: {
+        phases: ['strength', 'conditioning', 'hybrid', 'deload'],
+        blockLengthWeeks: 4,
+        deloadFrequency: 'Every 4 weeks',
+      },
+      nutritionFocus: {
+        proteinPerKg: 2.0,
+        mealFrequency: '4-5 meals',
+        periWorkout: 'Balanced pre and post nutrition',
+      },
+      smartTips: {
+        logScreen: 'Alternate heavy and volume days',
+        progressScreen: 'Track both strength and endurance metrics',
+        weightScreen: 'Body composition over scale weight',
+        macroScreen: 'Higher carbs on conditioning days',
+      },
+    },
+
+    recreational: {
+      label: 'Recreational',
+      trainingMode: 'bodybuilding',
+      defaults: {
+        repRange: '10-15',
+        restSeconds: 60,
+        setsPerExercise: 3,
+        defaultUnit: 'kg',
+      },
+      volume: {
+        weeklySetTarget: 12,
+        minSetsPerMuscle: 6,
+        maxSetsPerMuscle: 14,
+      },
+      coachingCues: [
+        'Consistency beats intensity — show up and move',
+        'Full-body sessions work great for 2-3 days per week',
+        'Keep it fun — enjoyment drives adherence',
+        'Progressive overload still matters — add a rep each week',
+        'Recovery is part of the programme — rest days count',
+      ],
+      progressMetrics: ['streaks', 'totalWorkouts', 'bodyweight'],
+      visibleTabs: [],
+      hiddenTabs: ['posingTab', 'powerliftingTab', 'crossfitTab'],
+      periodisation: {
+        phases: ['general', 'deload'],
+        blockLengthWeeks: 8,
+        deloadFrequency: 'Every 6-8 weeks or as needed',
+      },
+      nutritionFocus: {
+        proteinPerKg: 1.6,
+        mealFrequency: '3-4 meals',
+        periWorkout: 'Just eat well — no strict timing needed',
+      },
+      smartTips: {
+        logScreen: 'Simple is sustainable — pick 5-6 exercises per session',
+        progressScreen: 'Your streak is your most important metric',
+        weightScreen: 'Trends over time, not daily fluctuations',
+        macroScreen: 'Hit protein target — flexible with the rest',
+      },
+    },
+  };
+
+  function getUserArchetype() {
+    const user = window.currentUser || localStorage.getItem('fitnessAppUser');
+    if (!user) return 'hybrid';
+    try {
+      const settings = JSON.parse(localStorage.getItem('settings_' + user) || '{}');
+      return settings?.profile?.athleteArchetype || 'hybrid';
+    } catch { return 'hybrid'; }
+  }
+
+  function getArchetypeConfig(archetype) {
+    return ARCHETYPE_CONFIG[archetype] || ARCHETYPE_CONFIG.hybrid;
+  }
+
+  function getCurrentConfig() {
+    return getArchetypeConfig(getUserArchetype());
+  }
+
+  function getRandomCue(archetype) {
+    const cfg = getArchetypeConfig(archetype || getUserArchetype());
+    return cfg.coachingCues[Math.floor(Math.random() * cfg.coachingCues.length)];
+  }
+
+  function getSmartTip(screen, archetype) {
+    const cfg = getArchetypeConfig(archetype || getUserArchetype());
+    return cfg.smartTips?.[screen] || null;
+  }
+
+  // Apply defaults to the log form based on archetype
+  function applyArchetypeDefaults() {
+    const cfg = getCurrentConfig();
+    const setsInput = document.getElementById('sets');
+    if (setsInput && !setsInput.value) {
+      setsInput.placeholder = cfg.defaults.setsPerExercise + ' sets';
+    }
+    const unitSelect = document.getElementById('weightUnit');
+    if (unitSelect) {
+      const stored = localStorage.getItem('defaultWeightUnit');
+      if (!stored) {
+        unitSelect.value = cfg.defaults.defaultUnit;
+        localStorage.setItem('defaultWeightUnit', cfg.defaults.defaultUnit);
+      }
+    }
+  }
+
+  // Expose globally
+  window.ARCHETYPE_CONFIG = ARCHETYPE_CONFIG;
+  window.getUserArchetype = getUserArchetype;
+  window.getArchetypeConfig = getArchetypeConfig;
+  window.getCurrentArchetypeConfig = getCurrentConfig;
+  window.getRandomCoachingCue = getRandomCue;
+  window.getSmartTip = getSmartTip;
+  window.applyArchetypeDefaults = applyArchetypeDefaults;
+})();

--- a/src/routes/ai.js
+++ b/src/routes/ai.js
@@ -492,4 +492,76 @@ router.post('/coach-draft-message', async (req, res) => {
   }
 });
 
+// ── AI Profile Summary ───────────────────────────────────────────────────────
+
+const PROFILE_SUMMARY_SYSTEM_PROMPT = `You are an expert fitness coach inside Pocket Coach creating a personalized \
+training profile summary. Based on the user's archetype, experience level, and goals, generate a concise, \
+motivating profile that feels personal — not generic. \
+Respond ONLY with valid JSON in this exact structure: \
+{ \
+  "philosophy": string (1-2 sentences — their training philosophy based on archetype), \
+  "splitRecommendation": string (specific split recommendation e.g. "Push/Pull/Legs" or "Upper/Lower"), \
+  "weeklyStructure": string (e.g. "4 days lifting, 2 days cardio, 1 rest"), \
+  "keyFocusAreas": [string] (3-4 specific focus areas for their archetype + experience), \
+  "estimatedSessionLength": string (e.g. "60-75 minutes"), \
+  "coachNote": string (1-2 sentences — a personal coaching insight, reference their specific archetype and level) \
+}`;
+
+router.post('/profile-summary', async (req, res) => {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return res.status(404).json({ error: 'AI_NOT_CONFIGURED' });
+  }
+
+  const { archetype, experienceLevel, goal, daysPerWeek, sex, bodyweight, unit } = req.body;
+
+  if (!archetype) {
+    return res.status(400).json({ error: 'Missing required field: archetype' });
+  }
+
+  const parts = [
+    `Generate a personalized training profile summary for:`,
+    `Archetype: ${archetype}`,
+    `Experience: ${experienceLevel || 'intermediate'}`,
+    `Primary goal: ${goal || 'general fitness'}`,
+  ];
+  if (daysPerWeek) parts.push(`Available training days: ${daysPerWeek} per week`);
+  if (sex) parts.push(`Sex: ${sex}`);
+  if (bodyweight && unit) parts.push(`Bodyweight: ${bodyweight}${unit}`);
+
+  const userPrompt = parts.join('\n');
+
+  try {
+    const client = new Anthropic();
+    const message = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 512,
+      system: PROFILE_SUMMARY_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userPrompt }],
+    });
+
+    const raw = (message.content?.[0]?.text || '').trim();
+    const jsonStr = raw.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim();
+
+    let profile;
+    try {
+      profile = JSON.parse(jsonStr);
+    } catch {
+      console.error('[AI profile-summary] JSON parse failed:', jsonStr.slice(0, 200));
+      return res.status(502).json({ error: 'AI returned invalid JSON' });
+    }
+
+    return res.json({
+      philosophy: String(profile.philosophy || ''),
+      splitRecommendation: String(profile.splitRecommendation || ''),
+      weeklyStructure: String(profile.weeklyStructure || ''),
+      keyFocusAreas: Array.isArray(profile.keyFocusAreas) ? profile.keyFocusAreas.map(String) : [],
+      estimatedSessionLength: String(profile.estimatedSessionLength || ''),
+      coachNote: String(profile.coachNote || ''),
+    });
+  } catch (err) {
+    console.error('[AI profile-summary]', err.message);
+    return res.status(502).json({ error: 'AI request failed', details: err.message });
+  }
+});
+
 module.exports = router;

--- a/style.css
+++ b/style.css
@@ -18,18 +18,24 @@
 }
 
 .macros-subtab {
-  background: #fff;
-  border: 3px solid #111;
+  background: var(--card-bg, #121b17);
+  border: 1px solid var(--border-color, rgba(132,157,144,0.28));
   border-radius: 18px;
-  padding: 18px 26px;
-  font-weight: 700;
+  padding: 10px 20px;
+  font-weight: 600;
+  font-size: 0.88rem;
   cursor: pointer;
-  min-width: 180px;
+  min-width: 120px;
   text-align: center;
+  color: var(--secondary-text, #b8c2bc);
+  transition: background 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s;
 }
 
 .macros-subtab.active {
-  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.2);
+  background: linear-gradient(135deg, #38a870 0%, var(--primary, #2d7d5b) 55%, #245f47 100%);
+  border-color: var(--primary, #2d7d5b);
+  color: #fff;
+  box-shadow: 0 2px 12px rgba(45, 125, 91, 0.35);
   transform: translateY(-1px);
 }
 
@@ -110,7 +116,7 @@
 .heatmap div {
   width:12px;
   height:12px;
-  background:#eee;
+  background: rgba(255,255,255,0.08);
 }
 
 .coach-only {
@@ -199,12 +205,12 @@
 .pbv2-step {
   padding: 8px 10px;
   border-radius: 10px;
-  border: 1px solid rgba(0, 0, 0, .1);
-  background: white;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
 }
 
 .pbv2-step.active {
-  border-color: rgba(0, 0, 0, .3);
+  border-color: var(--primary);
   font-weight: 700;
 }
 
@@ -216,14 +222,14 @@
 .pbv2-dayRow {
   padding: 10px;
   border-radius: 12px;
-  border: 1px solid rgba(0, 0, 0, .08);
+  border: 1px solid var(--border-color);
   margin-bottom: 8px;
   cursor: pointer;
-  background: white;
+  background: var(--card-bg);
 }
 
 .pbv2-dayRow.active {
-  border-color: rgba(0, 0, 0, .25);
+  border-color: var(--primary);
 }
 
 .pbv2-dayActions button {
@@ -233,9 +239,9 @@
 .pbv2-exCard {
   padding: 12px;
   border-radius: 12px;
-  border: 1px solid rgba(0, 0, 0, .08);
+  border: 1px solid var(--border-color);
   margin-top: 10px;
-  background: white;
+  background: var(--card-bg);
 }
 
 .pbv2-exHeader {
@@ -930,7 +936,7 @@ body.theme-dark .set-row {
 }
 
 /* Progressive Overload Components */
-.progress-bar{background:#eee;height:10px;border-radius:6px;overflow:hidden;width:100%;}
+.progress-bar{background:rgba(255,255,255,0.1);height:10px;border-radius:6px;overflow:hidden;width:100%;}
 .progress-bar-fill{background:var(--primary);height:100%;width:0;transition:width 0.3s;}
 .progress-text{text-align:center;font-size:0.9rem;margin-top:4px;}
 .streak-counter{text-align:center;font-weight:bold;margin-top:6px;}
@@ -949,8 +955,8 @@ body.theme-dark .set-row {
 }
 
 .modal-content {
-  background: #fff;
-  color: #222;
+  background: var(--card-bg);
+  color: var(--text-color);
   border-radius: 12px;
   padding: 20px;
   width: min(90vw, 420px);
@@ -986,11 +992,11 @@ body.theme-dark .set-row {
 }
 
 .macro-card {
-  background: #f9f9f9;
-  border: 1px solid #d9d9d9;
+  background: var(--card-bg, #121b17);
+  border: 1px solid var(--border-color, rgba(132,157,144,0.28));
   border-radius: 12px;
   padding: 16px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
 }
 
 .macro-card h3 {
@@ -1018,7 +1024,7 @@ body.theme-dark .set-row {
 .macro-helper {
   margin-top: 10px;
   font-size: 0.9rem;
-  color: #4b4b4b;
+  color: var(--secondary-text, #b8c2bc);
 }
 
 .macro-stats {
@@ -1033,7 +1039,7 @@ body.theme-dark .set-row {
 
 .macro-advanced {
   margin-top: 12px;
-  border-top: 1px dashed #c9c9c9;
+  border-top: 1px dashed var(--border-color, rgba(132,157,144,0.28));
   padding-top: 10px;
 }
 
@@ -1080,12 +1086,13 @@ body.theme-dark .set-row {
 }
 
 .macros-mini-tab {
-  border: 1px solid #d6dce8;
-  background: #f2f5fb;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
   border-radius: 999px;
   padding: 8px 14px;
   cursor: pointer;
   font-weight: 600;
+  color: var(--secondary-text);
 }
 
 .macros-mini-tab.is-active {
@@ -1112,9 +1119,9 @@ body.theme-dark .set-row {
 .set-advanced {
   margin-top: 8px;
   padding: 10px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 10px;
-  background: #fafafa;
+  background: var(--card-bg);
 }
 .set-advanced-header {
   font-weight: 700;
@@ -1133,20 +1140,21 @@ body.theme-dark .set-row {
 .adv-row input {
   width: 100%;
   padding: 6px 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
 }
 .adv-btn {
   padding: 6px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   cursor: pointer;
-  background: #fff;
+  background: var(--surface-bg);
+  color: var(--text-color);
   font-size: 12px;
 }
 .adv-btn.primary {
-  border-color: #1e88e5;
-  background: #1e88e5;
+  border-color: var(--primary);
+  background: var(--primary);
   color: #fff;
 }
 .method-pills {
@@ -1159,13 +1167,15 @@ body.theme-dark .set-row {
 .method-pill {
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid #111;
+  border: 1px solid var(--border-color);
   font-size: 12px;
   cursor: pointer;
-  background: #fff;
+  background: var(--surface-bg);
+  color: var(--secondary-text);
 }
 .method-pill.active {
-  background: #111;
+  background: var(--primary);
+  border-color: var(--primary);
   color: #fff;
 }
 .tag-row {
@@ -1175,16 +1185,17 @@ body.theme-dark .set-row {
   margin-top: 8px;
 }
 .tag-chip {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 999px;
   padding: 6px 10px;
   font-size: 12px;
   cursor: pointer;
-  background: #fff;
+  background: var(--surface-bg);
+  color: var(--secondary-text);
 }
 .tag-chip.active {
-  border-color: #1e88e5;
-  color: #1e88e5;
+  border-color: var(--primary);
+  color: var(--primary);
 }
 .tag-input {
   margin-top: 6px;
@@ -1192,7 +1203,7 @@ body.theme-dark .set-row {
 .tag-input input {
   width: 100%;
   padding: 6px 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
 }
 .set-state {
@@ -1203,23 +1214,24 @@ body.theme-dark .set-row {
   flex-wrap: wrap;
 }
 .state-btn {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 4px 8px;
   cursor: pointer;
-  background: #fff;
+  background: var(--surface-bg);
+  color: var(--secondary-text);
   font-size: 12px;
 }
 .state-btn.active {
-  border-color: #111;
-  background: #111;
+  border-color: var(--primary);
+  background: var(--primary);
   color: #fff;
 }
 
 .gamification-panel {
-  border: 1px solid #e3e8f5;
+  border: 1px solid var(--border-color, rgba(132,157,144,0.28));
   border-radius: 10px;
-  background: #f8faff;
+  background: var(--card-bg, #121b17);
   padding: 10px;
 }
 
@@ -1243,17 +1255,17 @@ body.theme-dark .set-row {
   font-size: 0.76rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #64748b;
+  color: var(--text-muted, #8c9891);
 }
 
 .gamification-level {
   font-size: 1.15rem;
-  color: #0f172a;
+  color: var(--text-color, #f4f7f5);
 }
 
 .gamification-muted-row {
   font-size: 0.82rem;
-  color: #475569;
+  color: var(--secondary-text, #b8c2bc);
 }
 
 .gamification-meta-row {
@@ -1262,7 +1274,7 @@ body.theme-dark .set-row {
   gap: 8px;
   flex-wrap: wrap;
   font-size: 0.8rem;
-  color: #334155;
+  color: var(--secondary-text, #b8c2bc);
 }
 
 .gamification-card-title {
@@ -1275,13 +1287,13 @@ body.theme-dark .set-row {
 .gamification-hint-row {
   margin: 0;
   font-size: 0.88rem;
-  color: #2f3a54;
+  color: var(--secondary-text, #b8c2bc);
 }
 
 .gamification-xp-track {
   height: 10px;
   border-radius: 999px;
-  background: #e8edf8;
+  background: rgba(255, 255, 255, 0.08);
   overflow: hidden;
 }
 
@@ -1298,26 +1310,26 @@ body.theme-dark .set-row {
 }
 
 .gamification-stat-chip {
-  border: 1px solid #d9e2f5;
+  border: 1px solid var(--border-color);
   border-radius: 10px;
-  background: #fff;
+  background: var(--card-bg);
   padding: 8px;
   display: flex;
   flex-direction: column;
   gap: 3px;
   font-size: 0.78rem;
-  color: #4b5877;
+  color: var(--secondary-text);
 }
 
 .gamification-stat-chip strong {
-  color: #1f2a44;
+  color: var(--text-color);
   font-size: 0.96rem;
 }
 
 .gamification-mini-summary {
-  border: 1px solid #e3e8f5;
+  border: 1px solid var(--border-color);
   border-radius: 10px;
-  background: #fff;
+  background: var(--card-bg);
   padding: 10px;
 }
 
@@ -1326,13 +1338,13 @@ body.theme-dark .set-row {
   flex-wrap: wrap;
   gap: 8px 10px;
   font-size: 0.82rem;
-  color: #334155;
+  color: var(--secondary-text, #b8c2bc);
 }
 
 .gamification-mini-summary-note {
   margin: 8px 0 0;
   font-size: 0.82rem;
-  color: #55627f;
+  color: var(--text-muted, #8c9891);
 }
 
 .gamification-badge-grid {
@@ -1342,11 +1354,12 @@ body.theme-dark .set-row {
 }
 
 .gamification-badge-pill {
-  background: #ffffff;
-  border: 1px solid #dbe2ff;
+  background: rgba(45, 125, 91, 0.15);
+  border: 1px solid rgba(45, 125, 91, 0.35);
   border-radius: 999px;
   padding: 4px 10px;
   font-size: 0.85rem;
+  color: var(--secondary-text);
 }
 
 .gamification-events-feed {
@@ -1360,19 +1373,20 @@ body.theme-dark .set-row {
   justify-content: space-between;
   align-items: center;
   gap: 10px;
-  background: #fff;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 6px 8px;
   font-size: 0.85rem;
 }
 
 .gamification-event-item small {
-  color: #65708a;
+  color: var(--text-muted);
 }
 
 .gamification-empty {
   margin: 0;
-  color: #666;
+  color: var(--text-muted);
 }
 
 .profile-hub-form {
@@ -1400,18 +1414,18 @@ body.theme-dark .set-row {
 .profile-archetype-current {
   margin: 10px 0 6px;
   font-size: 0.92rem;
-  color: #3f4a64;
+  color: var(--secondary-text);
 }
 
 .profile-archetype-descriptions {
   margin: 0;
   padding: 10px 12px 10px 28px;
   border-radius: 10px;
-  background: rgba(0, 0, 0, 0.03);
+  background: rgba(255, 255, 255, 0.03);
   display: grid;
   gap: 6px;
   font-size: 0.86rem;
-  color: #4b5673;
+  color: var(--secondary-text);
 }
 
 .profile-edit-actions {
@@ -1428,7 +1442,8 @@ body.theme-dark .set-row {
 }
 
 .profile-summary-grid div {
-  background: rgba(0, 0, 0, 0.03);
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
   border-radius: 10px;
   padding: 10px;
   display: flex;
@@ -1442,12 +1457,12 @@ body.theme-dark .set-row {
 
 .season-archive-empty {
   margin: 0;
-  color: #666;
+  color: var(--text-muted);
 }
 
 .season-archive-summary {
   margin: 0 0 10px;
-  color: #4d5875;
+  color: var(--secondary-text);
 }
 
 .season-archive-list {
@@ -1458,7 +1473,8 @@ body.theme-dark .set-row {
 }
 
 .season-archive-item {
-  background: rgba(0, 0, 0, 0.03);
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 8px 10px;
 }
@@ -1472,7 +1488,7 @@ body.theme-dark .set-row {
 
 .season-archive-meta {
   font-size: 0.85rem;
-  color: #5e6a89;
+  color: var(--text-muted);
 }
 
 .season-archive-compare {
@@ -1675,4 +1691,128 @@ body.theme-dark .set-row {
   .checkin-slider-labels {
     font-size: 0.72rem;
   }
+}
+
+/* ── Litepicker dark theme overrides ────────────────────────── */
+.litepicker .container__months {
+  background: var(--card-bg, #121b17) !important;
+  color: var(--text-color, #f4f7f5) !important;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5) !important;
+  border: 1px solid var(--border-color, rgba(132,157,144,0.28)) !important;
+}
+.litepicker .month-item-header {
+  color: var(--text-color, #f4f7f5) !important;
+}
+.litepicker .month-item-weekdays-row > div {
+  color: var(--text-muted, #8c9891) !important;
+}
+.litepicker .day-item {
+  color: var(--secondary-text, #b8c2bc) !important;
+}
+.litepicker .day-item:hover {
+  background: rgba(45,125,91,0.2) !important;
+  color: var(--text-color) !important;
+}
+.litepicker .day-item.is-today {
+  color: var(--primary, #2d7d5b) !important;
+  font-weight: 700;
+}
+.litepicker .day-item.is-start-date,
+.litepicker .day-item.is-end-date {
+  background: var(--primary, #2d7d5b) !important;
+  color: #fff !important;
+}
+.litepicker .day-item.is-in-range {
+  background: rgba(45,125,91,0.15) !important;
+  color: var(--text-color) !important;
+}
+.litepicker .day-item.is-locked {
+  color: var(--text-muted, #8c9891) !important;
+  opacity: 0.4;
+}
+.litepicker .container__tooltip {
+  background: var(--card-bg, #121b17) !important;
+  color: var(--text-color, #f4f7f5) !important;
+  border: 1px solid var(--border-color) !important;
+}
+.litepicker button.previous-button,
+.litepicker button.next-button {
+  background: transparent !important;
+  color: var(--secondary-text) !important;
+  box-shadow: none !important;
+  border: none !important;
+}
+
+/* ── Archetype Profile Card ────────────────────────────────── */
+
+.apc-badge {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(45,125,91,0.2), rgba(45,125,91,0.08));
+  border: 1px solid rgba(45,125,91,0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: 1.1rem;
+  color: var(--primary);
+}
+
+.apc-chip {
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(45,125,91,0.25);
+  background: rgba(45,125,91,0.08);
+  color: var(--secondary-text);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.apc-meta {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  padding: 3px 10px;
+  background: rgba(255,255,255,0.04);
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+}
+
+.apc-cue {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(45,125,91,0.06);
+  border: 1px solid rgba(45,125,91,0.18);
+  border-left: 3px solid var(--primary);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.82rem;
+  color: var(--secondary-text);
+  line-height: 1.45;
+}
+
+.apc-gen-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  margin: 10px 0 0;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px dashed rgba(45,125,91,0.4);
+  background: transparent;
+  color: var(--primary);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: none;
+}
+
+.apc-gen-btn:hover {
+  background: rgba(45,125,91,0.08);
+  transform: none;
+  box-shadow: none;
 }


### PR DESCRIPTION
## Summary
- **Dark theme fixes**: Converted all hardcoded white/light colors across `style.css` and `css/base.css` to CSS variables — modals, pills, buttons, cards, tables, gamification panels, Litepicker calendar
- **App tutorial**: 6-slide swipeable walkthrough shown once after signup onboarding (Welcome, Log, Progress, Weight, Macros, More features)
- **Archetype personalization**: Rule-based config system for 4 archetypes (bodybuilder, powerlifter, hybrid, recreational) providing smart defaults, coaching cues, and per-screen tips
- **AI profile summary**: New `/api/ai/profile-summary` endpoint + frontend profile card on Home tab with one-click AI-generated training philosophy

## Test plan
- [ ] Verify no white boxes remain on any tab (Macros, Streaks, Progress, Log)
- [ ] Sign up as new user → onboarding wizard → tutorial slides → app
- [ ] Swipe through all 6 tutorial slides, verify Skip and Get Started work
- [ ] Check Home tab shows archetype profile card with correct defaults
- [ ] Verify Log tab shows contextual coaching tip
- [ ] Test "Generate AI Profile" button (requires ANTHROPIC_API_KEY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)