### PR TITLE
feat: weekly average and rate of gain/loss in Weight tab

### DIFF
--- a/css/features.css
+++ b/css/features.css
@@ -1761,6 +1761,104 @@
   margin: 0 6px;
 }
 
+/* ── Weekly breakdown card ── */
+.wt-weekly-card {
+  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 14px;
+  padding: 14px;
+  margin-top: 10px;
+}
+
+.wt-weekly-header {
+  margin-bottom: 10px;
+}
+
+.wt-weekly-title {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--text, #e8f5e9);
+}
+
+.wt-weekly-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.wt-week-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: var(--surface-bg, #141e17);
+  border-radius: 8px;
+  font-size: 0.82rem;
+}
+
+.wt-week-label {
+  color: var(--secondary-text, #b8c2bc);
+  font-weight: 600;
+}
+
+.wt-week-avg {
+  color: var(--text, #e8f5e9);
+  font-weight: 700;
+  text-align: right;
+}
+
+.wt-week-change {
+  font-weight: 700;
+  text-align: right;
+  min-width: 55px;
+}
+
+.wt-week-change.up { color: #eb5757; }
+.wt-week-change.down { color: var(--primary, #5fa87e); }
+.wt-week-change.flat { color: var(--text-muted, #7a8f7d); }
+
+.wt-week-count {
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.7rem;
+  text-align: right;
+  min-width: 20px;
+}
+
+.wt-rate-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border, #2a3a2e);
+}
+
+.wt-rate-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  text-align: center;
+}
+
+.wt-rate-val {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text, #e8f5e9);
+}
+
+.wt-rate-val.wt-gaining { color: #eb5757; }
+.wt-rate-val.wt-losing  { color: var(--primary, #5fa87e); }
+.wt-rate-val.wt-stable   { color: var(--highlight, #c6944f); }
+
+.wt-rate-lbl {
+  font-size: 0.62rem;
+  color: var(--text-muted, #7a8f7d);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
 /* ── Entry card ── */
 .wt-entry-card {
   background: var(--card-bg, #0f1510);

--- a/index.html
+++ b/index.html
@@ -534,6 +534,28 @@
         </div>
       </div>
 
+      <!-- ── Weekly averages & rate card ── -->
+      <div class="wt-weekly-card" id="wtWeeklyCard" style="display:none;">
+        <div class="wt-weekly-header">
+          <span class="wt-weekly-title">📊 Weekly Breakdown</span>
+        </div>
+        <div class="wt-weekly-grid" id="wtWeeklyGrid"></div>
+        <div class="wt-rate-row" id="wtRateRow">
+          <div class="wt-rate-item">
+            <span class="wt-rate-val" id="wtRateWeekly">—</span>
+            <span class="wt-rate-lbl">Rate / week</span>
+          </div>
+          <div class="wt-rate-item">
+            <span class="wt-rate-val" id="wtRateMonthly">—</span>
+            <span class="wt-rate-lbl">Projected / month</span>
+          </div>
+          <div class="wt-rate-item">
+            <span class="wt-rate-val" id="wtRateDirection">—</span>
+            <span class="wt-rate-lbl">Trend</span>
+          </div>
+        </div>
+      </div>
+
       <!-- ── Entry card ── -->
       <div class="wt-entry-card">
         <div class="wt-entry-row">
@@ -10153,10 +10175,15 @@ function renderWeights() {
     if (sta) sta.textContent = toDisp(firstKg);
     if (chg) { chg.textContent = changeDisp; chg.className = 'wt-stat-val ' + (changeKg > 0 ? 'wt-up' : changeKg < 0 ? 'wt-down' : ''); }
     if (ent) ent.textContent = log.length;
+
+    // ── Weekly averages & rate ──
+    renderWeeklyBreakdown(log, displayUnit);
   } else {
     if (strip)    strip.style.display = 'none';
     if (emptyMsg) emptyMsg.style.display = 'block';
     if (logCount) logCount.textContent = '';
+    const wkCard = document.getElementById('wtWeeklyCard');
+    if (wkCard) wkCard.style.display = 'none';
   }
 
   log.slice().reverse().forEach((entry, revIdx) => {
@@ -10178,6 +10205,109 @@ function renderWeights() {
       showWorkoutProgress();
     }
   }
+}
+
+function renderWeeklyBreakdown(log, displayUnit) {
+  const card = document.getElementById('wtWeeklyCard');
+  const grid = document.getElementById('wtWeeklyGrid');
+  if (!card || !grid) return;
+
+  if (log.length < 2) { card.style.display = 'none'; return; }
+
+  // Group entries by ISO week (Mon-Sun)
+  const sorted = log.slice().sort((a, b) => a.date.localeCompare(b.date));
+  const weeks = {};
+  sorted.forEach(entry => {
+    const d = new Date(entry.date + 'T00:00:00');
+    const day = d.getDay() || 7;
+    const mon = new Date(d);
+    mon.setDate(d.getDate() - day + 1);
+    const key = mon.toISOString().slice(0, 10);
+    if (!weeks[key]) weeks[key] = [];
+    const kg = getEntryWeightKg(entry);
+    if (kg != null) weeks[key].push(kg);
+  });
+
+  const weekKeys = Object.keys(weeks).sort().slice(-6);
+  if (weekKeys.length < 1) { card.style.display = 'none'; return; }
+
+  const weekData = weekKeys.map(key => {
+    const vals = weeks[key];
+    const avg = vals.reduce((s, v) => s + v, 0) / vals.length;
+    return { key, avg, count: vals.length };
+  });
+
+  // Compute week-over-week change
+  let html = '';
+  weekData.forEach((wk, i) => {
+    const mon = new Date(wk.key + 'T00:00:00');
+    const sun = new Date(mon);
+    sun.setDate(sun.getDate() + 6);
+    const label = mon.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+      + ' – ' + sun.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+    const avgDisp = convertWeightValue(wk.avg, 'kg', displayUnit, 1) + ' ' + displayUnit;
+
+    let changeHtml = '';
+    if (i > 0) {
+      const delta = wk.avg - weekData[i - 1].avg;
+      const deltaDisp = convertWeightValue(Math.abs(delta), 'kg', displayUnit, 1);
+      const cls = Math.abs(delta) < 0.05 ? 'flat' : delta > 0 ? 'up' : 'down';
+      const sign = delta > 0 ? '+' : delta < 0 ? '−' : '';
+      changeHtml = '<span class="wt-week-change ' + cls + '">' + sign + deltaDisp + '</span>';
+    } else {
+      changeHtml = '<span class="wt-week-change flat">—</span>';
+    }
+
+    html += '<div class="wt-week-row">'
+      + '<span class="wt-week-label">' + label + '</span>'
+      + '<span class="wt-week-avg">' + avgDisp + '</span>'
+      + changeHtml
+      + '<span class="wt-week-count">' + wk.count + 'd</span>'
+      + '</div>';
+  });
+  grid.innerHTML = html;
+
+  // Rate calculations (last 3 weeks if available, otherwise all)
+  const rateWeeks = weekData.length >= 3 ? weekData.slice(-3) : weekData;
+  const rateWeeklyEl = document.getElementById('wtRateWeekly');
+  const rateMonthlyEl = document.getElementById('wtRateMonthly');
+  const rateDirEl = document.getElementById('wtRateDirection');
+
+  if (rateWeeks.length >= 2) {
+    const first = rateWeeks[0];
+    const last = rateWeeks[rateWeeks.length - 1];
+    const weeksBetween = Math.max(1, rateWeeks.length - 1);
+    const rateKgPerWeek = (last.avg - first.avg) / weeksBetween;
+    const ratePerMonth = rateKgPerWeek * 4.33;
+
+    const rateDisp = convertWeightValue(Math.abs(rateKgPerWeek), 'kg', displayUnit, 2);
+    const monthDisp = convertWeightValue(Math.abs(ratePerMonth), 'kg', displayUnit, 1);
+    const sign = rateKgPerWeek > 0 ? '+' : rateKgPerWeek < 0 ? '−' : '';
+
+    const cls = Math.abs(rateKgPerWeek) < 0.05 ? 'wt-stable'
+      : rateKgPerWeek > 0 ? 'wt-gaining' : 'wt-losing';
+
+    if (rateWeeklyEl) {
+      rateWeeklyEl.textContent = sign + rateDisp + ' ' + displayUnit;
+      rateWeeklyEl.className = 'wt-rate-val ' + cls;
+    }
+    if (rateMonthlyEl) {
+      rateMonthlyEl.textContent = sign + monthDisp + ' ' + displayUnit;
+      rateMonthlyEl.className = 'wt-rate-val ' + cls;
+    }
+    if (rateDirEl) {
+      const dir = Math.abs(rateKgPerWeek) < 0.05 ? 'Maintaining'
+        : rateKgPerWeek > 0 ? 'Gaining' : 'Losing';
+      rateDirEl.textContent = dir;
+      rateDirEl.className = 'wt-rate-val ' + cls;
+    }
+  } else {
+    if (rateWeeklyEl) rateWeeklyEl.textContent = '—';
+    if (rateMonthlyEl) rateMonthlyEl.textContent = '—';
+    if (rateDirEl) rateDirEl.textContent = 'Need more data';
+  }
+
+  card.style.display = '';
 }
 
 function removeWeightEntry(index) {


### PR DESCRIPTION
- Add Weekly Breakdown card below stat strip showing up to 6 weeks of averaged bodyweight with week-over-week change
- Rate per week and projected monthly change calculated from last 3 weeks
- Trend indicator (Gaining/Losing/Maintaining) with color coding
- Respects user's preferred unit (kg/lb)