### PR TITLE
feat: add standalone pricing page and link from login screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
   <p id="loginError" class="form-error" role="alert" aria-live="polite"></p>
   <button id="loginButton" class="loading-btn" onclick="startLogin()"><span>Login</span><span class="spinner"></span></button>
   <button id="signupButton" class="loading-btn" onclick="startSignup()"><span>Sign Up</span><span class="spinner"></span></button>
+  <a href="pricing.html" style="display:block;text-align:center;margin-top:12px;color:var(--primary);font-size:0.85rem;font-weight:600;text-decoration:none;">View pricing & plans →</a>
 </div>
 <!-- ── Onboarding Wizard (shown after first signup) ─────────────────── -->
 <div id="onboardingOverlay" class="onboarding-overlay" hidden>

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,622 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pocket Coach — Pricing</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg:        #080b0a;
+      --surface:   #0e1411;
+      --card:      #121b17;
+      --elevated:  #18231e;
+      --border:    rgba(132,157,144,0.22);
+      --primary:   #2d7d5b;
+      --primary-h: #38a374;
+      --gold:      #c6944f;
+      --gold-h:    #d9a85e;
+      --text:      #f4f7f5;
+      --muted:     #8c9891;
+      --sub:       #b8c2bc;
+      --glow:      0 0 28px rgba(45,125,91,0.35);
+      --gold-glow: 0 0 28px rgba(198,148,79,0.35);
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Poppins', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+
+    /* ── HEADER ── */
+    header {
+      text-align: center;
+      padding: 64px 24px 48px;
+      position: relative;
+    }
+    .logo {
+      font-size: 0.8rem;
+      font-weight: 600;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--primary-h);
+      margin-bottom: 20px;
+    }
+    header h1 {
+      font-size: clamp(2rem, 6vw, 3.4rem);
+      font-weight: 700;
+      line-height: 1.15;
+      margin-bottom: 16px;
+    }
+    header h1 span {
+      color: var(--primary-h);
+    }
+    header p {
+      color: var(--sub);
+      font-size: 1.05rem;
+      max-width: 520px;
+      margin: 0 auto 36px;
+      line-height: 1.6;
+    }
+
+    /* toggle */
+    .billing-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 6px 18px;
+      font-size: 0.85rem;
+      color: var(--sub);
+    }
+    .toggle-switch {
+      position: relative;
+      width: 40px;
+      height: 22px;
+      cursor: pointer;
+    }
+    .toggle-switch input { opacity: 0; width: 0; height: 0; }
+    .slider {
+      position: absolute;
+      inset: 0;
+      background: var(--elevated);
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      transition: background 0.25s;
+    }
+    .slider::after {
+      content: '';
+      position: absolute;
+      left: 3px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 14px; height: 14px;
+      background: var(--muted);
+      border-radius: 50%;
+      transition: left 0.25s, background 0.25s;
+    }
+    input:checked + .slider { background: var(--primary); }
+    input:checked + .slider::after { left: 21px; background: #fff; }
+    .save-badge {
+      background: var(--primary);
+      color: #fff;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 999px;
+    }
+
+    /* ── CARDS ── */
+    .pricing-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 20px;
+      max-width: 1060px;
+      margin: 0 auto;
+      padding: 0 24px 80px;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 36px 32px;
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      position: relative;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    .card:hover { transform: translateY(-4px); }
+
+    .card.pro {
+      border-color: var(--primary);
+      box-shadow: var(--glow);
+    }
+    .card.coach {
+      border-color: var(--gold);
+      box-shadow: var(--gold-glow);
+      background: linear-gradient(145deg, #121b17, #16211a);
+    }
+
+    .popular-badge {
+      position: absolute;
+      top: -13px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--primary);
+      color: #fff;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      padding: 4px 14px;
+      border-radius: 999px;
+    }
+    .coach-badge {
+      background: var(--gold);
+      color: #0d0d0d;
+    }
+
+    .tier-label {
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 10px;
+    }
+    .card.pro .tier-label { color: var(--primary-h); }
+    .card.coach .tier-label { color: var(--gold); }
+
+    .tier-name {
+      font-size: 1.7rem;
+      font-weight: 700;
+      margin-bottom: 6px;
+    }
+    .tier-desc {
+      color: var(--sub);
+      font-size: 0.88rem;
+      line-height: 1.5;
+      margin-bottom: 28px;
+    }
+
+    .price-block {
+      display: flex;
+      align-items: baseline;
+      gap: 4px;
+      margin-bottom: 6px;
+    }
+    .currency { font-size: 1.1rem; font-weight: 600; color: var(--sub); }
+    .amount { font-size: 3rem; font-weight: 700; line-height: 1; }
+    .period { font-size: 0.85rem; color: var(--muted); }
+    .annual-note {
+      font-size: 0.78rem;
+      color: var(--muted);
+      margin-bottom: 28px;
+      min-height: 18px;
+    }
+    .annual-note span { color: var(--primary-h); font-weight: 600; }
+    .card.coach .annual-note span { color: var(--gold); }
+
+    .cta-btn {
+      display: block;
+      text-align: center;
+      padding: 14px 20px;
+      border-radius: 12px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      border: none;
+      transition: filter 0.2s, transform 0.15s;
+      margin-bottom: 32px;
+      text-decoration: none;
+    }
+    .cta-btn:hover { filter: brightness(1.12); transform: scale(1.02); }
+
+    .btn-free { background: var(--elevated); color: var(--text); border: 1px solid var(--border); }
+    .btn-pro  { background: var(--primary); color: #fff; box-shadow: 0 4px 18px rgba(45,125,91,0.4); }
+    .btn-coach { background: var(--gold); color: #0d0d0d; box-shadow: 0 4px 18px rgba(198,148,79,0.4); }
+
+    .divider {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin-bottom: 24px;
+    }
+
+    .features-label {
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 14px;
+    }
+
+    .feature-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 11px;
+      flex: 1;
+    }
+    .feature-list li {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      font-size: 0.88rem;
+      color: var(--sub);
+      line-height: 1.4;
+    }
+    .feature-list li .icon {
+      flex-shrink: 0;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.65rem;
+      margin-top: 1px;
+    }
+    .icon-free  { background: var(--elevated); color: var(--primary-h); border: 1px solid var(--primary); }
+    .icon-pro   { background: var(--primary); color: #fff; }
+    .icon-coach { background: var(--gold); color: #0d0d0d; }
+    .icon-locked { background: var(--elevated); color: var(--muted); border: 1px solid var(--border); }
+
+    .feature-list li.locked { opacity: 0.45; }
+
+    /* ── COMPARISON TABLE ── */
+    .compare-section {
+      max-width: 900px;
+      margin: 0 auto 80px;
+      padding: 0 24px;
+    }
+    .compare-section h2 {
+      text-align: center;
+      font-size: 1.6rem;
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+    .compare-section > p {
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.88rem;
+      margin-bottom: 32px;
+    }
+
+    .compare-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.88rem;
+    }
+    .compare-table thead th {
+      padding: 12px 16px;
+      text-align: center;
+      font-weight: 600;
+      border-bottom: 1px solid var(--border);
+    }
+    .compare-table thead th:first-child { text-align: left; color: var(--muted); }
+    .compare-table thead th:nth-child(2) { color: var(--sub); }
+    .compare-table thead th:nth-child(3) { color: var(--primary-h); }
+    .compare-table thead th:nth-child(4) { color: var(--gold); }
+
+    .compare-table tbody tr:nth-child(even) { background: rgba(255,255,255,0.02); }
+    .compare-table tbody td {
+      padding: 11px 16px;
+      color: var(--sub);
+      border-bottom: 1px solid rgba(132,157,144,0.08);
+    }
+    .compare-table tbody td:first-child { color: var(--text); font-weight: 500; }
+    .compare-table tbody td:not(:first-child) { text-align: center; }
+
+    .check-free  { color: var(--primary-h); }
+    .check-pro   { color: var(--primary-h); }
+    .check-coach { color: var(--gold); }
+    .cross       { color: var(--muted); opacity: 0.5; }
+
+    .section-row td {
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--muted);
+      padding-top: 20px;
+      padding-bottom: 6px;
+      background: transparent !important;
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* ── COMPETITOR NOTE ── */
+    .competitor-note {
+      max-width: 700px;
+      margin: 0 auto 80px;
+      padding: 28px 32px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-left: 3px solid var(--gold);
+      border-radius: 16px;
+      font-size: 0.9rem;
+      color: var(--sub);
+      line-height: 1.6;
+    }
+    .competitor-note strong { color: var(--text); }
+    .competitor-note .highlight { color: var(--gold); font-weight: 600; }
+
+    /* ── FAQ ── */
+    .faq-section {
+      max-width: 680px;
+      margin: 0 auto 80px;
+      padding: 0 24px;
+    }
+    .faq-section h2 {
+      text-align: center;
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 28px;
+    }
+    .faq-item {
+      border-bottom: 1px solid var(--border);
+      padding: 18px 0;
+    }
+    .faq-item:last-child { border-bottom: none; }
+    .faq-q {
+      font-weight: 600;
+      font-size: 0.95rem;
+      margin-bottom: 8px;
+      color: var(--text);
+    }
+    .faq-a {
+      font-size: 0.88rem;
+      color: var(--sub);
+      line-height: 1.6;
+    }
+
+    /* ── FOOTER ── */
+    footer {
+      text-align: center;
+      padding: 32px 24px;
+      border-top: 1px solid var(--border);
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+    footer a { color: var(--primary-h); text-decoration: none; }
+
+    @media (max-width: 680px) {
+      .pricing-grid { grid-template-columns: 1fr; }
+      .compare-table { font-size: 0.78rem; }
+      .compare-table thead th, .compare-table tbody td { padding: 9px 8px; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- ── HEADER ── -->
+<header>
+  <div class="logo">Pocket Coach</div>
+  <h1>Train free.<br><span>Coach with power.</span></h1>
+  <p>Every athlete gets a full toolkit at no cost. Coaches and AI features unlock with Pro — one flat price, unlimited clients.</p>
+  <div class="billing-toggle">
+    <span>Monthly</span>
+    <label class="toggle-switch">
+      <input type="checkbox" id="billingToggle" onchange="toggleBilling()">
+      <span class="slider"></span>
+    </label>
+    <span>Annual <span class="save-badge">Save 20%</span></span>
+  </div>
+</header>
+
+<!-- ── PRICING CARDS ── -->
+<div class="pricing-grid">
+
+  <!-- FREE -->
+  <div class="card">
+    <div class="tier-label">For athletes</div>
+    <div class="tier-name">Free</div>
+    <div class="tier-desc">Everything you need to train, track, and improve. No card required, forever.</div>
+    <div class="price-block">
+      <span class="currency">£</span>
+      <span class="amount">0</span>
+      <span class="period">/month</span>
+    </div>
+    <div class="annual-note"></div>
+    <a href="index.html" class="cta-btn btn-free">Get started free</a>
+    <hr class="divider">
+    <div class="features-label">What's included</div>
+    <ul class="feature-list">
+      <li><span class="icon icon-free">✓</span> Workout logging (all modes)</li>
+      <li><span class="icon icon-free">✓</span> Macro & calorie tracking</li>
+      <li><span class="icon icon-free">✓</span> Bodyweight & cardio tracking</li>
+      <li><span class="icon icon-free">✓</span> Program builder</li>
+      <li><span class="icon icon-free">✓</span> Progress charts & PRs</li>
+      <li><span class="icon icon-free">✓</span> Weekly check-ins</li>
+      <li><span class="icon icon-free">✓</span> Plate calculator</li>
+      <li><span class="icon icon-free">✓</span> SMART goals</li>
+      <li><span class="icon icon-free">✓</span> Community & leaderboard</li>
+      <li><span class="icon icon-free">✓</span> Workout history archive</li>
+      <li class="locked"><span class="icon icon-locked">🔒</span> Coaching dashboard</li>
+      <li class="locked"><span class="icon icon-locked">🔒</span> AI insights & analysis</li>
+    </ul>
+  </div>
+
+  <!-- PRO -->
+  <div class="card pro">
+    <div class="popular-badge">Most popular</div>
+    <div class="tier-label">For coaches & serious athletes</div>
+    <div class="tier-name">Pro</div>
+    <div class="tier-desc">Unlock Coaching Mode and AI-powered features. One price, unlimited clients — no per-seat fees.</div>
+    <div class="price-block">
+      <span class="currency">£</span>
+      <span class="amount" id="proAmount">9</span>
+      <span class="period">/month</span>
+    </div>
+    <div class="annual-note" id="proNote"><span>£86/year</span> — save £22</div>
+    <a href="#" class="cta-btn btn-pro">Start 7-day free trial</a>
+    <hr class="divider">
+    <div class="features-label">Everything in Free, plus</div>
+    <ul class="feature-list">
+      <li><span class="icon icon-pro">✓</span> <strong style="color:#f4f7f5">Coach Dashboard</strong> — full client roster</li>
+      <li><span class="icon icon-pro">✓</span> Client progress dashboards</li>
+      <li><span class="icon icon-pro">✓</span> Coach annotations & notes</li>
+      <li><span class="icon icon-pro">✓</span> Client check-in reviews</li>
+      <li><span class="icon icon-pro">✓</span> Compliance & alert tracking</li>
+      <li><span class="icon icon-pro">✓</span> <strong style="color:#f4f7f5">AI program analysis</strong></li>
+      <li><span class="icon icon-pro">✓</span> AI macro & nutrition insights</li>
+      <li><span class="icon icon-pro">✓</span> Smart check-in summaries</li>
+      <li><span class="icon icon-pro">✓</span> Unlimited clients — flat fee</li>
+      <li><span class="icon icon-pro">✓</span> Priority support</li>
+    </ul>
+  </div>
+
+  <!-- COMING SOON: COACH BUSINESS -->
+  <div class="card coach">
+    <div class="popular-badge coach-badge">Coming soon</div>
+    <div class="tier-label">For coaching businesses</div>
+    <div class="tier-name">Coach Business</div>
+    <div class="tier-desc">White-label profiles, team seats, and client payment collection in one place.</div>
+    <div class="price-block">
+      <span class="currency"></span>
+      <span class="amount" style="font-size:2rem; color: var(--gold)">TBC</span>
+    </div>
+    <div class="annual-note">Join the waitlist for early access pricing</div>
+    <a href="#" class="cta-btn btn-coach">Join waitlist</a>
+    <hr class="divider">
+    <div class="features-label">Everything in Pro, plus</div>
+    <ul class="feature-list">
+      <li><span class="icon icon-coach">✓</span> Custom branding & logo</li>
+      <li><span class="icon icon-coach">✓</span> Multiple coach seats</li>
+      <li><span class="icon icon-coach">✓</span> In-app client billing via Stripe</li>
+      <li><span class="icon icon-coach">✓</span> Team-level analytics</li>
+      <li><span class="icon icon-coach">✓</span> Dedicated onboarding support</li>
+      <li><span class="icon icon-coach">✓</span> API access (planned)</li>
+    </ul>
+  </div>
+
+</div>
+
+<!-- ── COMPARISON TABLE ── -->
+<div class="compare-section">
+  <h2>Full feature breakdown</h2>
+  <p>Everything in Pocket Coach, mapped to each tier.</p>
+  <table class="compare-table">
+    <thead>
+      <tr>
+        <th>Feature</th>
+        <th>Free</th>
+        <th>Pro</th>
+        <th>Business</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="section-row"><td colspan="4">Training & Tracking</td></tr>
+      <tr><td>Workout logging</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Bodybuilding / Powerlifting / Athletic modes</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Bodyweight & cardio tracking</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Posing log</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Plate calculator</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Workout history archive</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+
+      <tr class="section-row"><td colspan="4">Nutrition</td></tr>
+      <tr><td>Macro tracking & calculator</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Meal logging</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>AI nutrition insights</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+
+      <tr class="section-row"><td colspan="4">Programming & Goals</td></tr>
+      <tr><td>Program builder</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>SMART goals</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>CrossFit WOD log</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>AI program analysis & suggestions</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+
+      <tr class="section-row"><td colspan="4">Progress & Check-ins</td></tr>
+      <tr><td>Progress charts & PRs</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Weekly check-ins</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>AI check-in summaries</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+
+      <tr class="section-row"><td colspan="4">Community</td></tr>
+      <tr><td>Community groups</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Leaderboard</td><td><span class="check-free">✓</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+
+      <tr class="section-row"><td colspan="4">Coaching</td></tr>
+      <tr><td>Coach dashboard</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Client roster & profiles</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Client check-in reviews</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Compliance & alert tracking</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Annotations & coach notes</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Unlimited clients (flat fee)</td><td><span class="cross">—</span></td><td><span class="check-pro">✓</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Custom branding</td><td><span class="cross">—</span></td><td><span class="cross">—</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>Team coach seats</td><td><span class="cross">—</span></td><td><span class="cross">—</span></td><td><span class="check-coach">✓</span></td></tr>
+      <tr><td>In-app client billing</td><td><span class="cross">—</span></td><td><span class="cross">—</span></td><td><span class="check-coach">✓</span></td></tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- ── COMPETITIVE CALLOUT ── -->
+<div style="padding: 0 24px;">
+<div class="competitor-note">
+  <strong>Why coaches choose Pocket Coach over TrueCoach or Trainerize</strong><br><br>
+  TrueCoach charges <span class="highlight">$26/month for 5 clients</span>, jumping to $137/month at 21 clients — the same features, more money every time your roster grows. Trainerize starts at $10 but that's for 2 clients only.<br><br>
+  Pocket Coach Pro is <span class="highlight">one flat price, unlimited clients</span>. We also take <span class="highlight">zero transaction fees</span> on your client payments — what you earn is yours.
+</div>
+</div>
+
+<!-- ── FAQ ── -->
+<div class="faq-section" style="margin-top: 60px;">
+  <h2>Common questions</h2>
+  <div class="faq-item">
+    <div class="faq-q">Can I use Pocket Coach as just an athlete, for free?</div>
+    <div class="faq-a">Yes, forever. Workout logging, macros, tracking, programs, check-ins, progress, community — all free, no credit card needed.</div>
+  </div>
+  <div class="faq-item">
+    <div class="faq-q">Is there a limit on how many clients I can manage on Pro?</div>
+    <div class="faq-a">No. Pro is a flat monthly fee regardless of how many clients you coach. We don't penalise you for growing.</div>
+  </div>
+  <div class="faq-item">
+    <div class="faq-q">What AI features does Pro include?</div>
+    <div class="faq-a">AI program analysis and suggestions, macro and nutrition insights, and smart check-in summaries. AI features are powered by Claude and use real context from your training data.</div>
+  </div>
+  <div class="faq-item">
+    <div class="faq-q">Can I try Pro before paying?</div>
+    <div class="faq-a">Yes — Pro includes a 7-day free trial. Cancel any time during the trial and you won't be charged.</div>
+  </div>
+  <div class="faq-item">
+    <div class="faq-q">Do you take a cut of my coaching payments?</div>
+    <div class="faq-a">No. We don't take a percentage of anything you charge your clients. Stripe's standard processing fee (1.4%–2.9% + 30p) applies to card payments, but that goes to Stripe, not us.</div>
+  </div>
+  <div class="faq-item">
+    <div class="faq-q">What is Coach Business?</div>
+    <div class="faq-a">A forthcoming tier for gym owners and coaching businesses who need custom branding, multiple coach logins, and in-app client payment collection. Join the waitlist to get early pricing.</div>
+  </div>
+</div>
+
+<footer>
+  © 2026 Pocket Coach &nbsp;·&nbsp; <a href="privacy.html">Privacy</a> &nbsp;·&nbsp; <a href="index.html">Back to App</a> &nbsp;·&nbsp; <a href="mailto:armanbahali@gmail.com">Contact</a>
+</footer>
+
+<script>
+  let annual = false;
+
+  function toggleBilling() {
+    annual = document.getElementById('billingToggle').checked;
+    const proAmount = document.getElementById('proAmount');
+    const proNote   = document.getElementById('proNote');
+
+    if (annual) {
+      proAmount.textContent = '7';
+      proNote.innerHTML = '<span>£84/year</span> — billed annually, save £24';
+    } else {
+      proAmount.textContent = '9';
+      proNote.innerHTML = '<span>£86/year</span> if billed annually — save £22';
+    }
+  }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
- Add pricing.html with full 3-tier pricing page (Free/Pro/Coach Business) including feature comparison table, FAQ, competitor callout, monthly/annual billing toggle
- Link footer to privacy.html and contact email
- Add "View pricing & plans →" link on login screen below Sign Up button
- CTA buttons link to app signup