### PR TITLE
fix: prevent data loss on hard refresh and auth errors

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -31,7 +31,9 @@ function clearAuthState() {
   const storage = resolveStorage();
   storage.removeItem('token');
   storage.removeItem('authToken');
-  storage.removeItem('fitnessAppUser');
+  // Do NOT remove fitnessAppUser — it's the key used to find all user data
+  // in localStorage. Removing it makes bodyweight, workout, and macro data
+  // inaccessible until the user logs in again.
 }
 
 function isInvalidSignatureError(value) {

--- a/index.html
+++ b/index.html
@@ -2789,8 +2789,8 @@
 <script src="src/js/ProgramTabV2.js"></script>
 <script>
 
-let currentUser = null;
-let savedUser = localStorage.getItem("fitnessAppUser");
+let currentUser = localStorage.getItem("fitnessAppUser") || localStorage.getItem("username") || localStorage.getItem("Username") || null;
+let savedUser = currentUser;
 let activeSection = null;
 let activeTab = null;
 
@@ -2803,10 +2803,8 @@ function forceFreshLogin() {
   } else {
     localStorage.removeItem('token');
     localStorage.removeItem('authToken');
-    localStorage.removeItem('fitnessAppUser');
   }
-
-  localStorage.removeItem('fitnessAppUser');
+  // Do NOT remove fitnessAppUser — data keys depend on it
   savedUser = null;
 }
 


### PR DESCRIPTION
Root cause: clearAuthState() was removing 'fitnessAppUser' from localStorage, which is the key used to build all data storage keys (bodyweightLog_USERNAME, workouts_USERNAME, etc). When removed, currentUser became null on next page load and all user data became inaccessible.

Fixes:
- Initialize currentUser immediately from localStorage on script load, not just after login — survives hard refresh
- Remove fitnessAppUser from clearAuthState() — only clear tokens, never the user identity that data keys depend on
- Remove duplicate fitnessAppUser removal from forceFreshLogin()
- User data stays accessible even when auth tokens expire