### PR TITLE
fix: refresh macro tab after onboarding

### DIFF
--- a/index.html
+++ b/index.html
@@ -15473,6 +15473,9 @@ function _finishOnboarding() {
             fat:      plan.macros.fatGrams,
           };
           localStorage.setItem(`macroTargets_${user}`, JSON.stringify(targets));
+          // Refresh the macro tab display immediately so targets aren't shown as 0
+          if (typeof renderMacroTargets === 'function') renderMacroTargets();
+          if (typeof loadMacroDayContext === 'function') loadMacroDayContext();
         } catch (err) {
           console.warn('[Onboarding] Macro engine error:', err);
         }


### PR DESCRIPTION
## Summary
- After onboarding finishes and saves calculated macro targets, immediately calls `renderMacroTargets()` and `loadMacroDayContext()` so the macro tab rings/values update without requiring a page reload

## Root cause
Onboarding correctly saved targets to `macroTargets_USER` in localStorage, but the macro tab had already rendered at page load with zeros and nothing triggered a re-render after onboarding completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)