### PR TITLE
feat: redesign program builder — stacked layout, always-visible exercises, modern equipment pills

### DIFF
--- a/ProgramTab.css
+++ b/ProgramTab.css
@@ -1174,3 +1174,158 @@
 
   .pbv2-step-label { display: none; } /* too cramped on small screens */
 }
+
+/* ── New stacked exercise builder layout ─────────────────────────── */
+
+/* Horizontal day tab row */
+.pbv2-day-tabs-row {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 10px 14px 0;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  border-bottom: 1px solid var(--border, #2a3a2e);
+}
+.pbv2-day-tabs-row::-webkit-scrollbar { display: none; }
+
+/* Individual day pill tab */
+.pbv2-day-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 7px 14px;
+  border-radius: 20px 20px 0 0;
+  border: 1px solid var(--border, #2a3a2e);
+  border-bottom: none;
+  background: transparent;
+  color: var(--text-muted, #7a8f7d);
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s, color 0.2s;
+}
+.pbv2-day-tab:hover {
+  background: var(--card-bg, #0f1510);
+  color: var(--text, #e8f5e9);
+}
+.pbv2-day-tab.active {
+  background: var(--card-bg, #0f1510);
+  color: var(--primary, #5fa87e);
+  border-color: var(--primary, #5fa87e);
+}
+
+/* Exercise count badge on the tab */
+.pbv2-day-tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--primary, #5fa87e);
+  color: #0b130d;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+/* Inline rename/delete actions inside the tab pill */
+.pbv2-day-tab-actions {
+  display: inline-flex;
+  gap: 2px;
+  align-items: center;
+  margin-left: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.pbv2-day-tab:hover .pbv2-day-tab-actions,
+.pbv2-day-tab.active .pbv2-day-tab-actions {
+  opacity: 1;
+}
+.pbv2-day-tab-actions span {
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 2px 3px;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+.pbv2-day-tab-actions span:hover {
+  background: var(--surface-bg, #141e17);
+}
+
+/* Add-day pill (+ tab) */
+.pbv2-day-tab-add {
+  border-style: dashed;
+  color: var(--text-muted, #7a8f7d);
+  opacity: 0.7;
+}
+.pbv2-day-tab-add:hover { opacity: 1; }
+
+/* Vertical exercise stack — full-width scrollable body */
+.pbv2-ex-stack {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Added-exercises section at the top of the stack */
+.pbv2-added-section {
+  background: var(--surface-bg, #141e17);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.pbv2-added-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #7a8f7d);
+  margin-bottom: 8px;
+}
+
+.pbv2-added-empty {
+  font-size: 0.85rem;
+  color: var(--text-muted, #7a8f7d);
+  text-align: center;
+  padding: 14px 0;
+  opacity: 0.7;
+}
+
+/* ── AI generator equipment pill toggles ─────────────────────────── */
+
+.pag-eq-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--border, #2a3a2e);
+  background: transparent;
+  color: var(--text-muted, #7a8f7d);
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.18s, color 0.18s, border-color 0.18s;
+}
+.pag-eq-pill.active {
+  background: rgba(95, 168, 126, 0.12);
+  border-color: var(--primary, #5fa87e);
+  color: var(--primary, #5fa87e);
+}
+.pag-eq-pill:hover:not(.active) {
+  border-color: var(--text-muted, #7a8f7d);
+  color: var(--text, #e8f5e9);
+}

--- a/css/archetype-features.css
+++ b/css/archetype-features.css
@@ -5,6 +5,154 @@
    Depends on: tokens.css
    ============================================================= */
 
+/* ── Macro tracker cards ────────────────────────────────────── */
+
+.macro-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 10px 0 4px;
+}
+
+.macro-card {
+  background: var(--surface-bg, #141e17);
+  border: 1px solid var(--border, #2a3a2e);
+  border-radius: 14px;
+  padding: 14px 16px 12px;
+}
+
+.macro-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.macro-card-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.macro-card-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.macro-dot-cal     { background: #f0a040; box-shadow: 0 0 6px #f0a04066; }
+.macro-dot-protein { background: #4da8da; box-shadow: 0 0 6px #4da8da66; }
+.macro-dot-carbs   { background: #6fcf97; box-shadow: 0 0 6px #6fcf9766; }
+.macro-dot-fat     { background: #eb5757; box-shadow: 0 0 6px #eb575766; }
+
+.macro-card-name {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--text, #e8f5e9);
+  font-family: 'Poppins', sans-serif;
+  letter-spacing: 0.01em;
+}
+
+.macro-card-nums {
+  display: flex;
+  align-items: baseline;
+  gap: 3px;
+  font-family: 'Poppins', sans-serif;
+}
+
+.macro-card-consumed {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text, #e8f5e9);
+  font-variant-numeric: tabular-nums;
+}
+
+.macro-card-sep {
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.82rem;
+  font-weight: 400;
+}
+
+.macro-card-target {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text-muted, #7a8f7d);
+  font-variant-numeric: tabular-nums;
+}
+
+.macro-card-unit {
+  font-size: 0.75rem;
+  color: var(--text-muted, #7a8f7d);
+  font-weight: 600;
+}
+
+.macro-card-bar-track {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.macro-card-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  width: 0%;
+  transition: width 0.4s ease;
+}
+
+.macro-bar-cal     { background: #f0a040; }
+.macro-bar-protein { background: #4da8da; }
+.macro-bar-carbs   { background: #6fcf97; }
+.macro-bar-fat     { background: #eb5757; }
+
+.macro-card-net {
+  font-size: 0.72rem;
+  color: var(--text-muted, #7a8f7d);
+  margin-bottom: 10px;
+  margin-top: -4px;
+}
+
+.macro-card-qa {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.macro-qa-input {
+  width: 72px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border, #2a3a2e);
+  background: var(--card-bg, #0f1510);
+  color: var(--text, #e8f5e9);
+  font-size: 0.9rem;
+  text-align: center;
+  font-family: 'Poppins', sans-serif;
+  margin: 0;
+}
+
+.macro-qa-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: var(--primary, #5fa87e);
+  color: #0b130d;
+  font-size: 1.2rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, transform 0.1s;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.macro-qa-btn:active { transform: scale(0.88); }
+
 /* ── Macro progress rings ───────────────────────────────────── */
 
 .macro-rings-row {

--- a/css/archetype-features.css
+++ b/css/archetype-features.css
@@ -153,6 +153,12 @@
 
 .macro-qa-btn:active { transform: scale(0.88); }
 
+/* Override global .macro-card input[type="number"] { width:100% } for quick-add inputs */
+.macro-card .macro-card-qa .macro-qa-input {
+  width: 72px !important;
+  flex-shrink: 0;
+}
+
 /* ── Macro progress rings ───────────────────────────────────── */
 
 .macro-rings-row {

--- a/index.html
+++ b/index.html
@@ -2242,21 +2242,107 @@
               </div>
             </div>
 
-            <p style="font-size:1.1rem;">Energy: <span id="macroCalsProgress">0</span> / <span id="macroCalsTarget">0</span> kcal (<span id="macroCalsNet">0</span> net)</p>
-            <progress id="calsBar" value="0" max="100" style="width:100%;height:20px;margin-bottom:6px;"></progress>
-            <div class="quick-add"><input id="qaCals" type="number" value="100"><button onclick="subtractMacro('cal')">–</button><button onclick="addMacro('cal')">+</button></div>
+            <!-- Macro tracker cards -->
+            <div class="macro-cards">
 
-            <p style="font-size:1rem;">Protein: <span id="macroProteinProgress">0</span> / <span id="macroProteinTarget">0</span> g</p>
-            <progress id="proteinBar" value="0" max="100" style="width:100%;height:15px;margin-bottom:6px;"></progress>
-            <div class="quick-add"><input id="qaProtein" type="number" value="10"><button onclick="subtractMacro('protein')">–</button><button onclick="addMacro('protein')">+</button></div>
+              <div class="macro-card">
+                <div class="macro-card-header">
+                  <div class="macro-card-label">
+                    <span class="macro-card-dot macro-dot-cal"></span>
+                    <span class="macro-card-name">Energy</span>
+                  </div>
+                  <div class="macro-card-nums">
+                    <span class="macro-card-consumed" id="macroCalsProgress">0</span>
+                    <span class="macro-card-sep"> / </span>
+                    <span class="macro-card-target" id="macroCalsTarget">0</span>
+                    <span class="macro-card-unit"> kcal</span>
+                  </div>
+                </div>
+                <div class="macro-card-bar-track">
+                  <div class="macro-card-bar-fill macro-bar-cal" id="calsVisBar"></div>
+                </div>
+                <div class="macro-card-net"><span id="macroCalsNet">0</span> kcal net</div>
+                <div class="macro-card-qa">
+                  <input id="qaCals" type="number" value="100" class="macro-qa-input">
+                  <button class="macro-qa-btn" onclick="subtractMacro('cal')">–</button>
+                  <button class="macro-qa-btn" onclick="addMacro('cal')">+</button>
+                </div>
+                <progress id="calsBar" value="0" max="100"></progress>
+              </div>
 
-            <p style="font-size:1rem;">Carbs: <span id="macroCarbsProgress">0</span> / <span id="macroCarbsTarget">0</span> g</p>
-            <progress id="carbBar" value="0" max="100" style="width:100%;height:15px;margin-bottom:6px;"></progress>
-            <div class="quick-add"><input id="qaCarbs" type="number" value="10"><button onclick="subtractMacro('carbs')">–</button><button onclick="addMacro('carbs')">+</button></div>
+              <div class="macro-card">
+                <div class="macro-card-header">
+                  <div class="macro-card-label">
+                    <span class="macro-card-dot macro-dot-protein"></span>
+                    <span class="macro-card-name">Protein</span>
+                  </div>
+                  <div class="macro-card-nums">
+                    <span class="macro-card-consumed" id="macroProteinProgress">0</span>
+                    <span class="macro-card-sep"> / </span>
+                    <span class="macro-card-target" id="macroProteinTarget">0</span>
+                    <span class="macro-card-unit"> g</span>
+                  </div>
+                </div>
+                <div class="macro-card-bar-track">
+                  <div class="macro-card-bar-fill macro-bar-protein" id="proteinVisBar"></div>
+                </div>
+                <div class="macro-card-qa">
+                  <input id="qaProtein" type="number" value="10" class="macro-qa-input">
+                  <button class="macro-qa-btn" onclick="subtractMacro('protein')">–</button>
+                  <button class="macro-qa-btn" onclick="addMacro('protein')">+</button>
+                </div>
+                <progress id="proteinBar" value="0" max="100"></progress>
+              </div>
 
-            <p style="font-size:1rem;">Fat: <span id="macroFatProgress">0</span> / <span id="macroFatTarget">0</span> g</p>
-            <progress id="fatBar" value="0" max="100" style="width:100%;height:15px;margin-bottom:6px;"></progress>
-            <div class="quick-add"><input id="qaFat" type="number" value="5"><button onclick="subtractMacro('fat')">–</button><button onclick="addMacro('fat')">+</button></div>
+              <div class="macro-card">
+                <div class="macro-card-header">
+                  <div class="macro-card-label">
+                    <span class="macro-card-dot macro-dot-carbs"></span>
+                    <span class="macro-card-name">Carbs</span>
+                  </div>
+                  <div class="macro-card-nums">
+                    <span class="macro-card-consumed" id="macroCarbsProgress">0</span>
+                    <span class="macro-card-sep"> / </span>
+                    <span class="macro-card-target" id="macroCarbsTarget">0</span>
+                    <span class="macro-card-unit"> g</span>
+                  </div>
+                </div>
+                <div class="macro-card-bar-track">
+                  <div class="macro-card-bar-fill macro-bar-carbs" id="carbsVisBar"></div>
+                </div>
+                <div class="macro-card-qa">
+                  <input id="qaCarbs" type="number" value="10" class="macro-qa-input">
+                  <button class="macro-qa-btn" onclick="subtractMacro('carbs')">–</button>
+                  <button class="macro-qa-btn" onclick="addMacro('carbs')">+</button>
+                </div>
+                <progress id="carbBar" value="0" max="100"></progress>
+              </div>
+
+              <div class="macro-card">
+                <div class="macro-card-header">
+                  <div class="macro-card-label">
+                    <span class="macro-card-dot macro-dot-fat"></span>
+                    <span class="macro-card-name">Fat</span>
+                  </div>
+                  <div class="macro-card-nums">
+                    <span class="macro-card-consumed" id="macroFatProgress">0</span>
+                    <span class="macro-card-sep"> / </span>
+                    <span class="macro-card-target" id="macroFatTarget">0</span>
+                    <span class="macro-card-unit"> g</span>
+                  </div>
+                </div>
+                <div class="macro-card-bar-track">
+                  <div class="macro-card-bar-fill macro-bar-fat" id="fatVisBar"></div>
+                </div>
+                <div class="macro-card-qa">
+                  <input id="qaFat" type="number" value="5" class="macro-qa-input">
+                  <button class="macro-qa-btn" onclick="subtractMacro('fat')">–</button>
+                  <button class="macro-qa-btn" onclick="addMacro('fat')">+</button>
+                </div>
+                <progress id="fatBar" value="0" max="100"></progress>
+              </div>
+
+            </div><!-- /.macro-cards -->
 
             <!-- ── Water Tracker ── -->
             <div class="water-tracker-widget">

--- a/index.html
+++ b/index.html
@@ -17445,12 +17445,12 @@ window.renderMeetPrep = renderMeetPrep;
       + '<label style="display:flex;flex-direction:column;gap:5px;font-size:0.88rem;color:var(--secondary-text);">Days / week<select id="pagDays"><option value="3">3 days</option><option value="4" selected>4 days</option><option value="5">5 days</option><option value="6">6 days</option></select></label>'
       + '<label style="display:flex;flex-direction:column;gap:5px;font-size:0.88rem;color:var(--secondary-text);">Session length<select id="pagLength"><option value="45">45 min</option><option value="60" selected>60 min</option><option value="75">75 min</option><option value="90">90 min</option></select></label>'
       + '</div>'
-      + '<div style="font-size:0.88rem;color:var(--secondary-text);margin-bottom:2px;">Equipment available</div>'
+      + '<div style="font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-muted,#7a8f7d);">Equipment available</div>'
       + '<div style="display:flex;flex-wrap:wrap;gap:8px;">'
-      + '<label style="display:flex;align-items:center;gap:6px;font-size:0.88rem;"><input type="checkbox" id="pagEqBarbell" checked> Barbell</label>'
-      + '<label style="display:flex;align-items:center;gap:6px;font-size:0.88rem;"><input type="checkbox" id="pagEqDumbbells" checked> Dumbbells</label>'
-      + '<label style="display:flex;align-items:center;gap:6px;font-size:0.88rem;"><input type="checkbox" id="pagEqCables" checked> Cables / Machine</label>'
-      + '<label style="display:flex;align-items:center;gap:6px;font-size:0.88rem;"><input type="checkbox" id="pagEqBodyweight"> Bodyweight only</label>'
+      + '<button type="button" id="pagEqBarbell" class="pag-eq-pill active" onclick="this.classList.toggle(\'active\')">🏋️ Barbell</button>'
+      + '<button type="button" id="pagEqDumbbells" class="pag-eq-pill active" onclick="this.classList.toggle(\'active\')">💪 Dumbbells</button>'
+      + '<button type="button" id="pagEqCables" class="pag-eq-pill active" onclick="this.classList.toggle(\'active\')">🔗 Cables / Machine</button>'
+      + '<button type="button" id="pagEqBodyweight" class="pag-eq-pill" onclick="this.classList.toggle(\'active\')">🤸 Bodyweight</button>'
       + '</div>'
       + '<div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">'
       + '<label style="display:flex;flex-direction:column;gap:5px;font-size:0.88rem;color:var(--secondary-text);">Training mode<select id="pagMode">' + modeOptions + '</select></label>'
@@ -17548,10 +17548,10 @@ window.renderMeetPrep = renderMeetPrep;
     }
 
     var equipment = [];
-    if (document.getElementById('pagEqBarbell')?.checked)    equipment.push('barbell');
-    if (document.getElementById('pagEqDumbbells')?.checked)  equipment.push('dumbbells');
-    if (document.getElementById('pagEqCables')?.checked)     equipment.push('cables');
-    if (document.getElementById('pagEqBodyweight')?.checked) equipment.push('bodyweight');
+    if (document.getElementById('pagEqBarbell')?.classList.contains('active'))    equipment.push('barbell');
+    if (document.getElementById('pagEqDumbbells')?.classList.contains('active'))  equipment.push('dumbbells');
+    if (document.getElementById('pagEqCables')?.classList.contains('active'))     equipment.push('cables');
+    if (document.getElementById('pagEqBodyweight')?.classList.contains('active')) equipment.push('bodyweight');
     if (!equipment.length) equipment.push('bodyweight');
 
     // Loading state

--- a/src/js/ProgramTabV2.js
+++ b/src/js/ProgramTabV2.js
@@ -493,19 +493,17 @@
       return wrap;
     }
 
-    /* ── Exercises step — layout shell ─ */
+    /* ── Exercises step — mobile-first stacked layout ─ */
     function buildExercisesStep() {
       const wrap = document.createElement('div');
       wrap.id = 'pbv2ExWrap';
       wrap.innerHTML = `
         <div class="pbv2-step-heading" style="padding-bottom:0;">
-          <h2>Add exercises to each day</h2>
-          <p>Search the library or type any name to add a custom exercise.</p>
+          <h2>Build your days</h2>
+          <p>Pick a day, search for exercises, tap to add.</p>
         </div>
-        <div class="pbv2-ex-layout">
-          <div class="pbv2-day-pane" id="pbv2DayPane"></div>
-          <div class="pbv2-exercise-pane" id="pbv2ExPane"></div>
-        </div>
+        <div class="pbv2-day-tabs-row" id="pbv2DayPane"></div>
+        <div class="pbv2-ex-stack" id="pbv2ExPane"></div>
       `;
       _renderDayPane(wrap.querySelector('#pbv2DayPane'));
       _renderExercisePane(wrap.querySelector('#pbv2ExPane'));
@@ -519,6 +517,9 @@
       if (!dayPane || !exPane) { render(); return; }
       _renderDayPane(dayPane);
       _renderExercisePane(exPane);
+      // Scroll newly added exercise card into view
+      const cards = exPane.querySelectorAll('.pbv2-ex-card');
+      if (cards.length) cards[cards.length - 1].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
 
     function _renderDayPane(host) {
@@ -526,14 +527,14 @@
       (draft.days || []).forEach(day => {
         const btn = document.createElement('button');
         btn.type = 'button';
-        btn.className = 'pbv2-day-btn' + (day.dayId === selectedDayId ? ' active' : '');
+        btn.className = 'pbv2-day-tab' + (day.dayId === selectedDayId ? ' active' : '');
         const exCount = (day.exercises || []).length;
         btn.innerHTML = `
-          ${esc(day.name)}
-          <span class="pbv2-day-btn-meta">${exCount} exercise${exCount !== 1 ? 's' : ''}</span>
-          <span class="pbv2-day-actions">
-            <span class="pbv2-day-action-btn" data-act="rename" data-id="${day.dayId}" title="Rename">✏️</span>
-            <span class="pbv2-day-action-btn" data-act="delete" data-id="${day.dayId}" title="Delete">🗑️</span>
+          <span class="pbv2-day-tab-name">${esc(day.name)}</span>
+          ${exCount ? `<span class="pbv2-day-tab-count">${exCount}</span>` : ''}
+          <span class="pbv2-day-tab-actions">
+            <span data-act="rename" data-id="${day.dayId}" title="Rename">✏️</span>
+            <span data-act="delete" data-id="${day.dayId}" title="Delete">🗑</span>
           </span>
         `;
         btn.addEventListener('click', e => {
@@ -551,8 +552,8 @@
 
       const addBtn = document.createElement('button');
       addBtn.type = 'button';
-      addBtn.className = 'pbv2-add-day-btn';
-      addBtn.textContent = '+ Add Day';
+      addBtn.className = 'pbv2-day-tab pbv2-day-tab-add';
+      addBtn.textContent = '+ Day';
       addBtn.addEventListener('click', addDay);
       host.appendChild(addBtn);
     }
@@ -625,65 +626,66 @@
     function _renderExercisePane(host) {
       host.innerHTML = '';
 
-      // Ensure a day is selected
       if (!selectedDayId && draft.days?.length) selectedDayId = draft.days[0].dayId;
       const day = (draft.days || []).find(d => d.dayId === selectedDayId);
 
       if (!day) {
-        host.innerHTML = '<div class="pbv2-no-exercises">Add a day first →</div>';
+        host.innerHTML = '<div class="pbv2-no-exercises">Tap a day above to get started.</div>';
         return;
       }
 
-      /* ── Template loader strip ──────────────────────────────── */
+      /* ── 1. Already-added exercises — always visible at top ─ */
+      const addedSection = document.createElement('div');
+      addedSection.className = 'pbv2-added-section';
+
+      if ((day.exercises || []).length === 0) {
+        addedSection.innerHTML = '<div class="pbv2-added-empty">No exercises yet — search below to add some.</div>';
+      } else {
+        const addedHeader = document.createElement('div');
+        addedHeader.className = 'pbv2-added-header';
+        addedHeader.innerHTML = `<span>${day.exercises.length} exercise${day.exercises.length !== 1 ? 's' : ''} in ${esc(day.name)}</span>`;
+        addedSection.appendChild(addedHeader);
+
+        (day.exercises || []).forEach(ex => {
+          addedSection.appendChild(_buildExCard(day.dayId, ex));
+        });
+      }
+      host.appendChild(addedSection);
+
+      /* ── 2. Template loader ─ */
       const availableTpls = _getAvailableTemplates();
       if (availableTpls.length) {
         const strip = document.createElement('div');
         strip.className = 'pbv2-template-strip';
-        strip.title = 'Load a saved workout template into this day';
-
         const sel = document.createElement('select');
         sel.className = 'pbv2-template-select';
-        sel.innerHTML =
-          '<option value="">📋 Load from template…</option>' +
-          availableTpls.map(t =>
-            `<option value="${esc(t.id)}">${esc(t.name)}</option>`
-          ).join('');
-
+        sel.innerHTML = '<option value="">📋 Load from template…</option>' +
+          availableTpls.map(t => `<option value="${esc(t.id)}">${esc(t.name)}</option>`).join('');
         const loadBtn = document.createElement('button');
         loadBtn.type = 'button';
         loadBtn.className = 'pbv2-template-load-btn';
         loadBtn.textContent = 'Load';
         loadBtn.addEventListener('click', () => {
-          const id = sel.value;
-          if (!id) { window.showToast('Choose a template first.', 'warn'); return; }
-          _loadTemplateIntoDay(selectedDayId, id);
+          if (!sel.value) { window.showToast('Choose a template first.', 'warn'); return; }
+          _loadTemplateIntoDay(selectedDayId, sel.value);
           sel.value = '';
         });
-
         strip.appendChild(sel);
         strip.appendChild(loadBtn);
         host.appendChild(strip);
       }
 
-      /* Exercise picker */
+      /* ── 3. Exercise picker ─ */
       const picker = document.createElement('div');
       picker.className = 'pbv2-picker';
-
-      const pickerHeader = document.createElement('div');
-      pickerHeader.className = 'pbv2-picker-header';
 
       const searchInput = document.createElement('input');
       searchInput.type = 'text';
       searchInput.className = 'pbv2-picker-search';
       searchInput.placeholder = '🔍 Search or type any exercise…';
       searchInput.value = pickerQuery;
-      searchInput.addEventListener('input', e => {
-        pickerQuery = e.target.value;
-        _updatePickerList(pickerList);
-      });
-      pickerHeader.appendChild(searchInput);
+      searchInput.addEventListener('input', e => { pickerQuery = e.target.value; _updatePickerList(pickerList); });
 
-      // Category pills
       const catsRow = document.createElement('div');
       catsRow.className = 'pbv2-picker-cats';
       ['All', ...Object.keys(EXERCISE_LIB)].forEach(cat => {
@@ -700,7 +702,7 @@
         catsRow.appendChild(pill);
       });
 
-      picker.appendChild(pickerHeader);
+      picker.appendChild(searchInput);
       picker.appendChild(catsRow);
 
       const pickerList = document.createElement('div');
@@ -708,18 +710,6 @@
       _updatePickerList(pickerList);
       picker.appendChild(pickerList);
       host.appendChild(picker);
-
-      /* Current exercises for this day */
-      if ((day.exercises || []).length === 0) {
-        const empty = document.createElement('div');
-        empty.className = 'pbv2-no-exercises';
-        empty.textContent = 'Tap an exercise above to add it here.';
-        host.appendChild(empty);
-      } else {
-        (day.exercises || []).forEach(ex => {
-          host.appendChild(_buildExCard(day.dayId, ex));
-        });
-      }
     }
 
     function _updatePickerList(listEl) {
@@ -1217,5 +1207,18 @@
   };
 
   window.initProgramTabV2 = initProgramTabV2;
+
+  // Wire up the entry point called by the tab switcher
+  window.initProgramBuilder = function () {
+    let mount = document.getElementById('programBuilderV2Mount');
+    if (!mount) {
+      const container = document.getElementById('programBuilderContainer');
+      if (!container) return;
+      mount = document.createElement('div');
+      mount.id = 'programBuilderV2Mount';
+      container.appendChild(mount);
+    }
+    initProgramTabV2(mount);
+  };
 
 })();

--- a/src/js/archetype-features.js
+++ b/src/js/archetype-features.js
@@ -55,7 +55,25 @@ function _fmt(totalSeconds) {
     val.textContent = Math.round(bar.value);
   }
 
-  function syncAll() { RING_CONFIGS.forEach(syncRing); }
+  const VIS_BAR_CONFIGS = [
+    { barId: 'calsBar',    fillId: 'calsVisBar' },
+    { barId: 'proteinBar', fillId: 'proteinVisBar' },
+    { barId: 'carbBar',    fillId: 'carbsVisBar' },
+    { barId: 'fatBar',     fillId: 'fatVisBar' },
+  ];
+
+  function syncVisBar({ barId, fillId }) {
+    const bar  = document.getElementById(barId);
+    const fill = document.getElementById(fillId);
+    if (!bar || !fill) return;
+    const pct = bar.max > 0 ? Math.min((bar.value / bar.max) * 100, 100) : 0;
+    fill.style.width = pct + '%';
+  }
+
+  function syncAll() {
+    RING_CONFIGS.forEach(syncRing);
+    VIS_BAR_CONFIGS.forEach(syncVisBar);
+  }
 
   // Poll at 300 ms so we don't need to touch every JS call that sets bar values.
   // Interval is paused when the app is backgrounded to avoid draining battery.


### PR DESCRIPTION
## Summary

### Program builder
- **Builder now mounts correctly** — added \`window.initProgramBuilder\` entry point; previously the Build tab was empty
- **Exercises always visible** — replaced two-pane grid with stacked layout: horizontal day pill tabs + full-width added-exercises section above the picker
- **AI generator equipment** — checkboxes replaced with green pill toggle buttons

### Macro tracker cards
- **Modern card layout** — replaced plain paragraph text + native \`<progress>\` bars with styled card rows per macro
- Each card: colored dot label, consumed / target numbers, animated fill bar (color-matched to the ring), and integrated + / – quick-add
- Visual fill bars sync from the same hidden \`<progress>\` polling used by the rings (no extra JS calls needed)

## Test plan

- [ ] Programs tab → Build should load and show day tabs
- [ ] Add exercises to a day — they should appear in the "Added exercises" section at the top
- [ ] AI generator equipment picker shows pill buttons, toggles active state
- [ ] Macro tab → Targets view shows Energy / Protein / Carbs / Fat cards
- [ ] Tap + on a macro card — number updates, fill bar animates, ring updates
- [ ] Targets loaded from localStorage show correct target numbers in cards

🤖 Generated with [Claude Code](https://claude.ai/claude-code)