### PR TITLE
feat: persistent rest timer banner above workout-in-progress strip

### DIFF
--- a/css/log.css
+++ b/css/log.css
@@ -60,6 +60,107 @@
   flex-shrink: 0;
 }
 
+/* ── Rest timer banner (persistent, above workout timer) ─────── */
+
+.rest-banner {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 8px 12px 4px;
+  padding: 10px 14px 10px 12px;
+  background: rgba(240, 160, 64, 0.07);
+  border: 1px solid rgba(240, 160, 64, 0.22);
+  border-left: 3px solid #f0a040;
+  border-radius: 0 10px 10px 0;
+}
+
+.rest-banner[hidden] { display: none !important; }
+
+/* Circular ring */
+.rest-banner-ring-wrap {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  flex-shrink: 0;
+}
+
+.rest-banner-ring-svg {
+  width: 50px;
+  height: 50px;
+  display: block;
+  transform: rotate(-90deg);
+}
+
+.rest-banner-ring-track {
+  fill: none;
+  stroke: rgba(240, 160, 64, 0.15);
+  stroke-width: 5;
+}
+
+.rest-banner-ring-fill {
+  fill: none;
+  stroke: #f0a040;
+  stroke-width: 5;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.9s linear;
+}
+
+.rest-banner-ring-pct {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: #f0a040;
+  pointer-events: none;
+}
+
+/* Text info */
+.rest-banner-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+}
+
+.rest-banner-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted, #7a8f7d);
+  font-weight: 600;
+}
+
+.rest-banner-time {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #f0a040;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+/* Skip button */
+.rest-banner-skip {
+  padding: 7px 14px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  background: transparent;
+  border: 1px solid rgba(240, 160, 64, 0.35);
+  border-radius: 8px;
+  color: #f0a040;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-family: 'Poppins', sans-serif;
+  transition: background 0.15s;
+}
+
+.rest-banner-skip:hover {
+  background: rgba(240, 160, 64, 0.1);
+}
+
 /* ── Resistance section ─────────────────────────────────────── */
 
 #resistance-section {

--- a/index.html
+++ b/index.html
@@ -585,6 +585,23 @@
       <!-- Session context flags: alt-machine / alt-gym -->
       <div id="sessionContextBar" style="padding:0 12px;"></div>
 
+      <!-- Rest timer banner — shown while a rest is active -->
+      <div id="restBanner" class="rest-banner" hidden aria-live="polite">
+        <div class="rest-banner-ring-wrap">
+          <svg class="rest-banner-ring-svg" viewBox="0 0 56 56">
+            <circle class="rest-banner-ring-track" cx="28" cy="28" r="22"/>
+            <circle class="rest-banner-ring-fill" id="restBannerRingFill" cx="28" cy="28" r="22"
+              stroke-dasharray="138.23" stroke-dashoffset="0"/>
+          </svg>
+          <span class="rest-banner-ring-pct" id="restBannerPct">100%</span>
+        </div>
+        <div class="rest-banner-info">
+          <span class="rest-banner-label">Rest timer</span>
+          <span class="rest-banner-time" id="restBannerTime">0:00</span>
+        </div>
+        <button class="rest-banner-skip" type="button" onclick="skipRestTimer()">Skip ✕</button>
+      </div>
+
       <!-- Workout session timer — styled as a full-width banner -->
       <div id="workoutTimer" class="workout-timer" aria-live="polite">
         <div class="workout-timer-info">
@@ -5683,6 +5700,19 @@ function changeSetType(workoutIndex, entryIndex, setIndex, type) {
 }
 
 let restInterval;
+function _updateRestBanner(remaining, total) {
+  const banner   = document.getElementById('restBanner');
+  const timeEl   = document.getElementById('restBannerTime');
+  const pctEl    = document.getElementById('restBannerPct');
+  const ringFill = document.getElementById('restBannerRingFill');
+  if (!banner) return;
+  const pct = total > 0 ? remaining / total : 0;
+  const C = 138.23; // 2π × r(22)
+  if (timeEl)   timeEl.textContent   = formatRestTime(remaining);
+  if (pctEl)    pctEl.textContent    = Math.ceil(pct * 100) + '%';
+  if (ringFill) ringFill.style.strokeDashoffset = C * (1 - pct);
+}
+
 function startRestTimer() {
   const minutes = +document.getElementById('restMinutes').value || 0;
   const seconds = +document.getElementById('restSeconds').value || 0;
@@ -5692,19 +5722,35 @@ function startRestTimer() {
     return;
   }
   let remaining = totalSeconds;
+
+  // Show the persistent banner in the log view
+  const banner = document.getElementById('restBanner');
+  if (banner) banner.hidden = false;
+  _updateRestBanner(remaining, totalSeconds);
+
   const display = document.getElementById('restTimerDisplay');
-  display.textContent = formatRestTime(remaining);
+  if (display) display.textContent = formatRestTime(remaining);
   clearInterval(restInterval);
   restInterval = setInterval(() => {
     remaining--;
     if (remaining <= 0) {
       clearInterval(restInterval);
-      display.textContent = 'Rest Over!';
+      if (display) display.textContent = 'Rest Over!';
+      if (banner) banner.hidden = true;
       logRestBreak(totalSeconds / 60);
     } else {
-      display.textContent = formatRestTime(remaining);
+      if (display) display.textContent = formatRestTime(remaining);
+      _updateRestBanner(remaining, totalSeconds);
     }
   }, 1000);
+}
+
+function skipRestTimer() {
+  clearInterval(restInterval);
+  const banner  = document.getElementById('restBanner');
+  const display = document.getElementById('restTimerDisplay');
+  if (banner)  banner.hidden = true;
+  if (display) display.textContent = '';
 }
 
 function formatRestTime(sec) {


### PR DESCRIPTION
Shows a circular ring + countdown above the workout timer in the log view so users can see remaining rest time without switching sub-tabs. Ring depletes from full (100%) to empty as rest counts down, matches the amber #f0a040 accent. Skip button dismisses early. Banner auto-hides when timer completes or is skipped.