### PR TITLE
Phase 1 Firebase Auth: client flows (signup w/ email, username login, verify gate)

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,12 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
 
+  <!-- Firebase Auth (Phase 1 migration) — compat SDK for this script-tag codebase -->
+  <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-auth-compat.js"></script>
+  <script src="src/js/firebase-config.js"></script>
+  <script src="src/js/firebase-auth.js"></script>
+
 </head>
 
  
@@ -91,6 +97,11 @@
         <input type="text" id="username" class="login-input" placeholder="Enter your username"
                autocomplete="username" autocorrect="off" autocapitalize="none" spellcheck="false" />
       </div>
+      <div class="login-field" id="signupEmailField" style="display:none;">
+        <label class="login-field-label" for="signupEmail">Email</label>
+        <input type="email" id="signupEmail" class="login-input" placeholder="Enter your email"
+               autocomplete="email" autocorrect="off" autocapitalize="none" spellcheck="false" />
+      </div>
       <div class="login-field">
         <label class="login-field-label" for="password">Password</label>
         <div class="login-pw-wrap">
@@ -123,6 +134,22 @@
     <a href="pricing.html" class="login-pricing-link">See pricing &amp; plans →</a>
   </div>
 
+</div>
+
+<!-- ── Verify-email screen (Firebase signups; server blocks unverified accounts) ── -->
+<div id="verifyEmailContainer" class="login-screen" style="display:none;">
+  <div class="login-card">
+    <p class="login-heading">Check your email</p>
+    <p>We sent a verification link to <strong id="verifyEmailAddress"></strong>. You need to verify before you can use Pocket Coach.</p>
+    <p style="font-size:0.85em;opacity:0.75;">Don't see it? Check your spam folder.</p>
+    <p id="verifyEmailError" class="login-error" role="alert" aria-live="polite"></p>
+    <button id="verifiedContinueButton" class="login-cta loading-btn" onclick="continueAfterVerification()">
+      <span>I've verified — continue</span><span class="spinner"></span>
+    </button>
+    <button id="resendVerificationButton" class="login-cta loading-btn" onclick="resendVerificationEmail()">
+      <span>Resend email</span><span class="spinner"></span>
+    </button>
+  </div>
 </div>
 <!-- ── Onboarding Wizard (shown after first signup) ─────────────────── -->
 <div id="onboardingOverlay" class="onboarding-overlay" hidden>
@@ -3540,7 +3567,7 @@ window.currentSubStatus = 'none';
 async function startLogin() {
   const btn = document.getElementById('loginButton');
   setLoading(btn, true);
-  const username = document.getElementById("username").value.trim();
+  let username = document.getElementById("username").value.trim();
   const password = document.getElementById("password").value.trim();
   const errorEl = document.getElementById('loginError');
 
@@ -3560,7 +3587,32 @@ async function startLogin() {
 
   try {
     let result;
-    if (typeof window.login === 'function') {
+
+    // ── Firebase Auth path (Phase 1 migration) ──────────────────────────────
+    // Resolves username → email server-side, signs in via Firebase, and hands
+    // the ID token to the same post-login flow the legacy JWT used. Unknown
+    // usernames fall through to legacy /login for pre-migration accounts.
+    if (window.firebaseAuth?.isAvailable()) {
+      try {
+        const fb = await window.firebaseAuth.login({ usernameOrEmail: username, password });
+        if (fb.needsVerification) {
+          showVerifyEmailScreen(username, 'login');
+          return;
+        }
+        if (fb.username) username = fb.username;
+        result = { success: true, token: fb.token, username };
+      } catch (fbErr) {
+        if (!fbErr.tryLegacy) {
+          if (errorEl) errorEl.textContent = fbErr.message || 'Login failed.';
+          return;
+        }
+        // No Firebase account for this username — try the legacy server login below
+      }
+    }
+
+    if (result) {
+      // handled by Firebase — skip legacy fetch
+    } else if (typeof window.login === 'function') {
       result = await window.login(username, password);
     } else {
       if (errorEl) errorEl.textContent = 'Connecting to server…';
@@ -4019,6 +4071,32 @@ async function startSignup() {
     return;
   }
 
+  // ── Firebase Auth path (Phase 1 migration) ────────────────────────────────
+  // Signup collects all three: username (login identifier), email (new —
+  // Firebase identity + verification), password (owned by Firebase). The
+  // email field is shown by _switchLoginTab when this path is active.
+  if (window.firebaseAuth?.isAvailable()) {
+    const email = document.getElementById('signupEmail')?.value.trim() || '';
+    if (!email || !email.includes('@')) {
+      if (errorEl) errorEl.textContent = 'Please enter a valid email address.';
+      setLoading(btn, false);
+      return;
+    }
+    try {
+      if (errorEl) errorEl.textContent = 'Creating your account…';
+      await window.firebaseAuth.signup({ username, email, password });
+      // Identity is stored, but the app stays locked until email verification —
+      // the server rejects every protected route for unverified accounts.
+      persistLoginIdentity(username, null);
+      showVerifyEmailScreen(email, 'signup');
+    } catch (fbErr) {
+      if (errorEl) errorEl.textContent = fbErr.message || 'Signup failed. Please try again.';
+    } finally {
+      setLoading(btn, false);
+    }
+    return;
+  }
+
   try {
     if (errorEl) errorEl.textContent = 'Creating your account…';
     const response = await fetch(`${window.SERVER_URL}/register`, {
@@ -4063,7 +4141,73 @@ async function startSignup() {
     setLoading(btn, false);
   }
 }
-  
+
+// ── Verify-email screen (Firebase signups/logins) ───────────────────────────
+// The server rejects every protected route until email_verified is true, so
+// the app stays on this screen instead of dropping the user into a broken UI.
+let _verifyEmailContext = null; // 'signup' | 'login'
+
+function showVerifyEmailScreen(emailOrUsername, context) {
+  _verifyEmailContext = context || 'signup';
+  const loginEl = document.getElementById('loginContainer');
+  const verifyEl = document.getElementById('verifyEmailContainer');
+  const addressEl = document.getElementById('verifyEmailAddress');
+  if (addressEl) addressEl.textContent = emailOrUsername || 'your email';
+  if (loginEl) loginEl.style.display = 'none';
+  if (verifyEl) verifyEl.style.display = '';
+}
+
+async function continueAfterVerification() {
+  const btn = document.getElementById('verifiedContinueButton');
+  const errorEl = document.getElementById('verifyEmailError');
+  setLoading(btn, true);
+  if (errorEl) errorEl.textContent = '';
+  try {
+    const res = await window.firebaseAuth.reloadAndGetToken();
+    if (!res.verified) {
+      if (errorEl) errorEl.textContent = "Not verified yet — click the link in your email first.";
+      return;
+    }
+    const username = localStorage.getItem('username') || '';
+    if (username) {
+      setCurrentUser(username);
+      localStorage.setItem('fitnessAppUser', username);
+    }
+    const verifyEl = document.getElementById('verifyEmailContainer');
+    if (verifyEl) verifyEl.style.display = 'none';
+    if (_verifyEmailContext === 'signup') {
+      showOnboarding();
+    } else {
+      // Login flow: stored token + fitnessAppUser make the normal session
+      // restore path take over on reload
+      window.location.reload();
+    }
+  } catch (err) {
+    if (errorEl) errorEl.textContent = err.message || 'Could not confirm verification.';
+  } finally {
+    setLoading(btn, false);
+  }
+}
+
+async function resendVerificationEmail() {
+  const btn = document.getElementById('resendVerificationButton');
+  const errorEl = document.getElementById('verifyEmailError');
+  setLoading(btn, true);
+  if (errorEl) errorEl.textContent = '';
+  try {
+    await window.firebaseAuth.resendVerification();
+    if (errorEl) errorEl.textContent = 'Verification email sent again — check spam too.';
+  } catch (err) {
+    if (errorEl) errorEl.textContent = err.message || 'Could not resend. Wait a minute and retry.';
+  } finally {
+    setLoading(btn, false);
+  }
+}
+
+window.showVerifyEmailScreen = showVerifyEmailScreen;
+window.continueAfterVerification = continueAfterVerification;
+window.resendVerificationEmail = resendVerificationEmail;
+
 function toggleWorkoutDetails(index) {
   const el = document.getElementById(`workoutDetails${index}`);
   el.style.display = el.style.display === 'none' ? 'block' : 'none';
@@ -8228,8 +8372,11 @@ function logout(options = {}) {
   localStorage.removeItem('authToken');
   localStorage.removeItem('username');
   localStorage.removeItem('Username');
+  // Firebase keeps its session in IndexedDB — sign out there too, or the
+  // onIdTokenChanged listener re-populates the token on next load
+  const fbSignOut = window.firebaseAuth?.logout?.() || Promise.resolve();
   if (!options.suppressReload) {
-    location.reload();
+    Promise.resolve(fbSignOut).finally(() => location.reload());
   }
 }
 function animateSwitch(newEl) {
@@ -14282,6 +14429,11 @@ function _switchLoginTab(mode) {
   const signupBtn = document.getElementById('signupButton');
   if (loginBtn)  loginBtn.classList.toggle('login-cta--hidden', !isLogin);
   if (signupBtn) signupBtn.classList.toggle('login-cta--hidden', isLogin);
+  // Firebase signups collect email (new field — legacy accounts have none)
+  const emailField = document.getElementById('signupEmailField');
+  if (emailField) {
+    emailField.style.display = (!isLogin && window.firebaseAuth?.isAvailable()) ? '' : 'none';
+  }
   const pw = document.getElementById('password');
   if (pw) pw.autocomplete = isLogin ? 'current-password' : 'new-password';
   const err = document.getElementById('loginError');

--- a/src/js/firebase-auth.js
+++ b/src/js/firebase-auth.js
@@ -1,0 +1,198 @@
+// Firebase Auth client flows — Phase 1 of the Firebase Auth migration.
+// Exposes window.firebaseAuth.{isAvailable, signup, login, resendVerification,
+// reloadAndGetToken, logout}. startLogin/startSignup in index.html call these
+// when window.FIREBASE_ENABLED is true, and fall back to legacy /login and
+// /register otherwise.
+//
+// Account model (per migration plan): username (login identifier, unique),
+// email (new — Firebase Auth identity + verification), password (owned by
+// Firebase, never stored in our own database).
+(function () {
+  'use strict';
+
+  function available() {
+    return Boolean(window.FIREBASE_ENABLED) && typeof firebase !== 'undefined' && firebase.auth;
+  }
+
+  function serverUrl() {
+    return window.SERVER_URL || 'https://traininglog-backend.onrender.com';
+  }
+
+  // Keep the stored token fresh: Firebase ID tokens expire hourly, and every
+  // existing fetch in the app reads localStorage('token'/'authToken').
+  function watchTokenRefresh() {
+    firebase.auth().onIdTokenChanged(async (user) => {
+      if (!user) return;
+      try {
+        const token = await user.getIdToken();
+        localStorage.setItem('token', token);
+        localStorage.setItem('authToken', token);
+      } catch (err) {
+        console.warn('[Firebase] Token refresh failed:', err.message);
+      }
+    });
+  }
+  if (available()) watchTokenRefresh();
+
+  async function postJson(path, body, token) {
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    const res = await fetch(`${serverUrl()}${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    });
+    const data = await res.json().catch(() => ({}));
+    return { ok: res.ok, status: res.status, data };
+  }
+
+  function friendlyAuthError(err) {
+    const code = err?.code || '';
+    if (code === 'auth/email-already-in-use') return 'That email already has an account. Try logging in.';
+    if (code === 'auth/invalid-email') return 'That email address doesn’t look valid.';
+    if (code === 'auth/weak-password') return 'Password is too weak — use at least 6 characters.';
+    if (code === 'auth/wrong-password' || code === 'auth/user-not-found' || code === 'auth/invalid-credential') {
+      return 'Invalid username or password.';
+    }
+    if (code === 'auth/too-many-requests') return 'Too many attempts — please wait a few minutes.';
+    if (code === 'auth/network-request-failed') return 'Network error — check your connection.';
+    return err?.message || 'Authentication failed. Please try again.';
+  }
+
+  // Signup: availability check → create Firebase account → send verification
+  // email → /auth/signup-complete (claims username, sets custom claims).
+  // Returns { needsVerification: true } — the server rejects all protected
+  // routes until the email is verified, so the UI must show the verify screen.
+  async function signup({ username, email, password, referredBy }) {
+    if (!available()) throw new Error('Firebase is not configured.');
+
+    const availRes = await fetch(
+      `${serverUrl()}/auth/username-available?username=${encodeURIComponent(username)}`
+    );
+    const avail = await availRes.json().catch(() => ({}));
+    if (availRes.ok && avail.available === false) {
+      throw new Error('That username is already taken.');
+    }
+
+    let cred;
+    try {
+      cred = await firebase.auth().createUserWithEmailAndPassword(email, password);
+    } catch (err) {
+      throw new Error(friendlyAuthError(err));
+    }
+
+    try {
+      await cred.user.sendEmailVerification();
+    } catch (err) {
+      console.warn('[Firebase] sendEmailVerification failed (resend available):', err.message);
+    }
+
+    const idToken = await cred.user.getIdToken();
+    const complete = await postJson('/auth/signup-complete', { username, referredBy }, idToken);
+    if (!complete.ok) {
+      const message = complete.data?.error?.message || 'Could not complete signup.';
+      if (complete.data?.error?.code === 'auth.username_taken') {
+        // Auth account exists but the username was taken in a race — the UI
+        // should prompt for a different username and call completeSignup again.
+        const err = new Error(message);
+        err.retryUsernameOnly = true;
+        throw err;
+      }
+      throw new Error(message);
+    }
+
+    return { username, email, needsVerification: !cred.user.emailVerified };
+  }
+
+  // Retry only the username-claim step (after a 409 race in signup).
+  async function completeSignup({ username, referredBy }) {
+    const user = firebase.auth().currentUser;
+    if (!user) throw new Error('Not signed in.');
+    const idToken = await user.getIdToken();
+    const complete = await postJson('/auth/signup-complete', { username, referredBy }, idToken);
+    if (!complete.ok) throw new Error(complete.data?.error?.message || 'Could not complete signup.');
+    return { username };
+  }
+
+  // Login by username (or email — detected by '@'). Username→email resolution
+  // is a required step: Firebase authenticates by email under the hood.
+  async function login({ usernameOrEmail, password }) {
+    if (!available()) throw new Error('Firebase is not configured.');
+
+    let email = usernameOrEmail;
+    let username = null;
+    if (!usernameOrEmail.includes('@')) {
+      username = usernameOrEmail;
+      const resolved = await postJson('/auth/email-for-username', { username: usernameOrEmail });
+      if (!resolved.ok) {
+        if (resolved.status === 404) {
+          // No Firebase account for this username — may be a legacy account.
+          const err = new Error('No account found for that username.');
+          err.tryLegacy = true;
+          throw err;
+        }
+        throw new Error(resolved.data?.error?.message || 'Could not look up username.');
+      }
+      email = resolved.data.email;
+    }
+
+    let cred;
+    try {
+      cred = await firebase.auth().signInWithEmailAndPassword(email, password);
+    } catch (err) {
+      throw new Error(friendlyAuthError(err));
+    }
+
+    const idToken = await cred.user.getIdToken();
+    localStorage.setItem('token', idToken);
+    localStorage.setItem('authToken', idToken);
+
+    if (!username) {
+      // Logged in by email — recover the username from the custom claim
+      const decoded = await cred.user.getIdTokenResult();
+      username = decoded.claims.username || null;
+    }
+
+    return {
+      token: idToken,
+      username,
+      emailVerified: cred.user.emailVerified,
+      needsVerification: !cred.user.emailVerified
+    };
+  }
+
+  async function resendVerification() {
+    const user = firebase.auth().currentUser;
+    if (!user) throw new Error('Not signed in.');
+    await user.sendEmailVerification();
+  }
+
+  // After the user clicks the email link: reload the account, mint a fresh
+  // token (email_verified flips to true), and return it.
+  async function reloadAndGetToken() {
+    const user = firebase.auth().currentUser;
+    if (!user) throw new Error('Not signed in.');
+    await user.reload();
+    if (!firebase.auth().currentUser.emailVerified) return { verified: false };
+    const token = await firebase.auth().currentUser.getIdToken(true);
+    localStorage.setItem('token', token);
+    localStorage.setItem('authToken', token);
+    return { verified: true, token };
+  }
+
+  async function logout() {
+    if (available()) {
+      try { await firebase.auth().signOut(); } catch { /* non-critical */ }
+    }
+  }
+
+  window.firebaseAuth = {
+    isAvailable: available,
+    signup,
+    completeSignup,
+    login,
+    resendVerification,
+    reloadAndGetToken,
+    logout
+  };
+})();

--- a/src/js/firebase-config.js
+++ b/src/js/firebase-config.js
@@ -1,0 +1,28 @@
+// Firebase web app config — Phase 1 of the Firebase Auth migration.
+// This is the PUBLIC client config (safe to ship, unlike the Admin service
+// account on the server). Get the real values from:
+//   Firebase Console → Project Settings → General → Your apps → Web app
+//
+// Until the placeholders below are replaced, window.FIREBASE_ENABLED stays
+// false and the app keeps using legacy username/password auth — safe to deploy
+// before the Firebase project exists.
+(function () {
+  const config = {
+    apiKey: 'REPLACE_ME',
+    authDomain: 'REPLACE_ME.firebaseapp.com',
+    projectId: 'REPLACE_ME',
+    appId: 'REPLACE_ME'
+  };
+
+  const configured = Object.values(config).every(v => typeof v === 'string' && !v.includes('REPLACE_ME'));
+  window.FIREBASE_CONFIG = config;
+  window.FIREBASE_ENABLED = configured && typeof firebase !== 'undefined';
+
+  if (!configured) {
+    console.info('[Firebase] Client config not filled in yet — using legacy auth.');
+  } else if (typeof firebase === 'undefined') {
+    console.warn('[Firebase] SDK failed to load (offline?) — falling back to legacy auth.');
+  } else {
+    firebase.initializeApp(config);
+  }
+})();


### PR DESCRIPTION
## What

Client half of the Phase 1 Firebase Auth migration (server half landed in traininglog-backend `ca3c707`):

- **`src/js/firebase-config.js`** — public web config with `REPLACE_ME` placeholders. Until real values are pasted, `window.FIREBASE_ENABLED` stays false and the app runs on legacy auth — safe to merge and deploy before the Firebase project exists.
- **`src/js/firebase-auth.js`** — signup (username + email + password), username→email resolution for login (`/auth/email-for-username`), email verification + resend, ID-token refresh into localStorage, logout.
- **`index.html`** — Firebase compat SDK tags; email field on the Sign Up tab (only shown when Firebase is configured); verify-email screen (server 403s unverified accounts on every route); Firebase branches in `startLogin`/`startSignup` with legacy fallback for pre-migration accounts; logout clears the Firebase IndexedDB session.

## Verification

- Served and exercised in a browser: SDK loads, placeholder config correctly falls back to legacy auth, email field toggles with the Sign Up tab + Firebase state, verify screen and handlers present, zero console errors.
- `npx jest tests/`: 72 passing; the 3 failing suites (`prepMode`, `addLogEntry`, `settingsTab`) fail identically on clean `main` — pre-existing.

## After merge (manual)

Follow `FIREBASE-SETUP.md` in traininglog-backend: create the Firebase project, enable Email/Password, add `FIREBASE_SERVICE_ACCOUNT` on Render, paste web config into `firebase-config.js`. Legacy JWT removal waits for end-to-end verification (plan step 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)