### PR TITLE
Phase 2 client: legacy account reclaim prompt on signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,11 @@
         <input type="email" id="signupEmail" class="login-input" placeholder="Enter your email"
                autocomplete="email" autocorrect="off" autocapitalize="none" spellcheck="false" />
       </div>
+      <div class="login-field" id="legacySignupPasswordField" style="display:none;">
+        <label class="login-field-label" for="legacySignupPassword">Existing account password</label>
+        <input type="password" id="legacySignupPassword" class="login-input"
+               placeholder="Password for this username's existing account" autocomplete="off" />
+      </div>
       <div class="login-field">
         <label class="login-field-label" for="password">Password</label>
         <div class="login-pw-wrap">
@@ -4219,15 +4224,35 @@ async function startSignup() {
       setLoading(btn, false);
       return;
     }
+    // Phase 2: this username may belong to a pre-Firebase Airtable account —
+    // if so the field below is visible and the server verifies it against
+    // that account's password, then migrates its data onto the new uid.
+    const legacyField = document.getElementById('legacySignupPasswordField');
+    const legacyPassword = document.getElementById('legacySignupPassword')?.value || '';
     try {
       if (errorEl) errorEl.textContent = 'Creating your account…';
-      await window.firebaseAuth.signup({ username, email, password });
+      // If a prior attempt already created the Firebase account (we're
+      // retrying after a needsLegacyPassword prompt), don't call
+      // createUserWithEmailAndPassword again — it would fail as
+      // "already in use". completeSignup reuses the signed-in session instead.
+      const alreadyCreated = typeof firebase !== 'undefined' && firebase.auth?.().currentUser;
+      const result = alreadyCreated
+        ? await window.firebaseAuth.completeSignup({ username, legacyPassword })
+        : await window.firebaseAuth.signup({ username, email, password, legacyPassword });
       // Identity is stored, but the app stays locked until email verification —
       // the server rejects every protected route for unverified accounts.
       persistLoginIdentity(username, null);
       showVerifyEmailScreen(email, 'signup');
     } catch (fbErr) {
-      if (errorEl) errorEl.textContent = fbErr.message || 'Signup failed. Please try again.';
+      if (fbErr.needsLegacyPassword) {
+        if (legacyField) legacyField.style.display = '';
+        document.getElementById('legacySignupPassword')?.focus();
+        if (errorEl) errorEl.textContent = fbErr.message || 'Enter the existing account\'s password, then tap Sign Up again.';
+      } else if (fbErr.legacyPasswordInvalid) {
+        if (errorEl) errorEl.textContent = fbErr.message || 'That password doesn\'t match the existing account.';
+      } else {
+        if (errorEl) errorEl.textContent = fbErr.message || 'Signup failed. Please try again.';
+      }
     } finally {
       setLoading(btn, false);
     }
@@ -14865,6 +14890,9 @@ function _switchLoginTab(mode) {
   if (emailField) {
     emailField.style.display = (!isLogin && window.firebaseAuth?.isAvailable()) ? '' : 'none';
   }
+  // Only shown reactively after a needsLegacyPassword error — reset on tab switch
+  const legacyField = document.getElementById('legacySignupPasswordField');
+  if (legacyField) legacyField.style.display = 'none';
   const pw = document.getElementById('password');
   if (pw) pw.autocomplete = isLogin ? 'current-password' : 'new-password';
   const err = document.getElementById('loginError');

--- a/src/js/firebase-auth.js
+++ b/src/js/firebase-auth.js
@@ -63,7 +63,12 @@
   // email → /auth/signup-complete (claims username, sets custom claims).
   // Returns { needsVerification: true } — the server rejects all protected
   // routes until the email is verified, so the UI must show the verify screen.
-  async function signup({ username, email, password, referredBy }) {
+  //
+  // Phase 2: a username matching an existing (pre-Firebase) Airtable account
+  // is "reclaimable", not simply taken — the UI should prompt for that
+  // account's old password and pass it as legacyPassword. If correct, the
+  // server migrates that account's data onto the new uid.
+  async function signup({ username, email, password, referredBy, legacyPassword }) {
     if (!available()) throw new Error('Firebase is not configured.');
 
     const availRes = await fetch(
@@ -71,7 +76,16 @@
     );
     const avail = await availRes.json().catch(() => ({}));
     if (availRes.ok && avail.available === false) {
-      throw new Error('That username is already taken.');
+      if (avail.reclaimable && !legacyPassword) {
+        const err = new Error('This username belongs to an existing account. Enter its password to reclaim it.');
+        err.needsLegacyPassword = true;
+        throw err;
+      }
+      if (!avail.reclaimable) {
+        throw new Error('That username is already taken.');
+      }
+      // reclaimable && legacyPassword provided — fall through, let
+      // signup-complete verify it (it owns the real check against the hash).
     }
 
     let cred;
@@ -88,10 +102,24 @@
     }
 
     const idToken = await cred.user.getIdToken();
-    const complete = await postJson('/auth/signup-complete', { username, referredBy }, idToken);
+    const complete = await postJson('/auth/signup-complete', { username, referredBy, legacyPassword }, idToken);
     if (!complete.ok) {
+      const code = complete.data?.error?.code;
       const message = complete.data?.error?.message || 'Could not complete signup.';
-      if (complete.data?.error?.code === 'auth.username_taken') {
+      if (code === 'auth.legacy_verification_required') {
+        // Someone else claimed the username between the availability check and
+        // now, or the caller skipped it — prompt for the old password and retry
+        // via completeSignup (the Firebase account itself was already created).
+        const err = new Error(message);
+        err.needsLegacyPassword = true;
+        throw err;
+      }
+      if (code === 'auth.legacy_password_invalid') {
+        const err = new Error(message);
+        err.legacyPasswordInvalid = true;
+        throw err;
+      }
+      if (code === 'auth.username_taken') {
         // Auth account exists but the username was taken in a race — the UI
         // should prompt for a different username and call completeSignup again.
         const err = new Error(message);
@@ -104,13 +132,28 @@
     return { username, email, needsVerification: !cred.user.emailVerified };
   }
 
-  // Retry only the username-claim step (after a 409 race in signup).
-  async function completeSignup({ username, referredBy }) {
+  // Retry only the username-claim step (after a 409 race in signup, or after
+  // the user supplies a legacyPassword following a needsLegacyPassword error).
+  async function completeSignup({ username, referredBy, legacyPassword }) {
     const user = firebase.auth().currentUser;
     if (!user) throw new Error('Not signed in.');
     const idToken = await user.getIdToken();
-    const complete = await postJson('/auth/signup-complete', { username, referredBy }, idToken);
-    if (!complete.ok) throw new Error(complete.data?.error?.message || 'Could not complete signup.');
+    const complete = await postJson('/auth/signup-complete', { username, referredBy, legacyPassword }, idToken);
+    if (!complete.ok) {
+      const code = complete.data?.error?.code;
+      const message = complete.data?.error?.message || 'Could not complete signup.';
+      if (code === 'auth.legacy_verification_required') {
+        const err = new Error(message);
+        err.needsLegacyPassword = true;
+        throw err;
+      }
+      if (code === 'auth.legacy_password_invalid') {
+        const err = new Error(message);
+        err.legacyPasswordInvalid = true;
+        throw err;
+      }
+      throw new Error(message);
+    }
     return { username };
   }
 


### PR DESCRIPTION
## What

Client half of Phase 2's legacy-account-reclaim flow (server half already live in traininglog-backend `2eaaf7e`):

- A username matching an existing pre-Firebase Airtable account now shows a password field for that old account (`legacySignupPasswordField`) instead of just rejecting signup.
- `firebase-auth.js` surfaces `needsLegacyPassword` / `legacyPasswordInvalid` as distinct errors so the UI can react correctly.
- `startSignup()` picks `completeSignup()` vs `signup()` on retry based on whether the Firebase account already exists (avoids "email already in use" if the user already got past account creation on the first attempt).

On successful verification, the server migrates that account's Airtable history (templates, macro targets, workouts, programs, bodyweight, measurements, cardio, crossfit, mobility, daily missions, and coach roster if applicable) onto the new Firebase uid, and carries over plan/billing/referral fields instead of resetting to free.

## Verification

- Inline JS + `firebase-auth.js` syntax checks pass.
- `jest tests/`: 72/75 passing — the 3 failures (`prepMode`, `addLogEntry`, `settingsTab`) are pre-existing on clean `main`, unrelated to this change.
- Full reclaim flow exercised against **production** with synthetic Airtable data (created and cleaned up after): confirmed `reclaimable: true` on the availability check, `409 auth.legacy_verification_required` when the password is omitted, `401 auth.legacy_password_invalid` on a wrong password, `201` success with correct password, and correct custom claims (`tier`, `isCoach`) afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
