### PR TITLE
Wire exercise autocomplete to the new Firestore-backed library

### DIFF
--- a/index.html
+++ b/index.html
@@ -3400,12 +3400,18 @@ const defaultExercises = [
   'Leg Extension', 'Calf Raise'
 ];
 let userExercises = [];
+// Firestore-backed exercise library (~870 entries) — fetched once and cached
+// in localStorage so the datalist populates instantly on future loads
+// without re-fetching every page load.
+let exerciseLibraryNames = [];
+const EXERCISE_LIBRARY_CACHE_KEY = 'exerciseLibraryCache_v1';
+const EXERCISE_LIBRARY_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 function updateExerciseSuggestions() {
   const list = document.getElementById('exerciseSuggestions');
   if (!list) return;
   list.innerHTML = '';
-  const all = Array.from(new Set([...defaultExercises, ...userExercises]));
+  const all = Array.from(new Set([...defaultExercises, ...exerciseLibraryNames, ...userExercises]));
   all.forEach(name => {
     const opt = document.createElement('option');
     opt.value = name;
@@ -3413,11 +3419,37 @@ function updateExerciseSuggestions() {
   });
 }
 
+async function loadExerciseLibrary() {
+  try {
+    const cached = JSON.parse(localStorage.getItem(EXERCISE_LIBRARY_CACHE_KEY) || 'null');
+    if (cached && Array.isArray(cached.names) && (Date.now() - cached.cachedAt) < EXERCISE_LIBRARY_CACHE_MAX_AGE_MS) {
+      exerciseLibraryNames = cached.names;
+      updateExerciseSuggestions();
+      return;
+    }
+  } catch { /* corrupt cache — fall through to a fresh fetch */ }
+
+  try {
+    const serverUrl = ensureServerUrl();
+    const res = await fetch(`${serverUrl}/exercises?limit=1000`, { headers: getAuthHeaders() });
+    if (!res.ok) return; // keep whatever's cached (possibly nothing) — non-fatal
+    const data = await res.json();
+    const names = (data.items || []).map(e => e.name).filter(Boolean);
+    if (!names.length) return;
+    exerciseLibraryNames = names;
+    localStorage.setItem(EXERCISE_LIBRARY_CACHE_KEY, JSON.stringify({ names, cachedAt: Date.now() }));
+    updateExerciseSuggestions();
+  } catch (err) {
+    console.warn('[ExerciseLibrary] Fetch failed, using cached/default list only:', err.message);
+  }
+}
+
 function loadUserExercises() {
   if (!currentUser) return;
   const data = JSON.parse(localStorage.getItem(`exercises_${currentUser}`)) || [];
   userExercises = Array.isArray(data) ? data : [];
   updateExerciseSuggestions();
+  loadExerciseLibrary(); // fire-and-forget — renders with defaults/cache immediately, upgrades when it resolves
 }
 
 function saveUserExercise(name) {


### PR DESCRIPTION
## What

Wires the workout-log exercise-name field's datalist up to the new Firestore-backed exercise library (~873 exercises, seeded from free-exercise-db — backend commits f099a4f/64081c7 in traininglog-backend), instead of just a 13-entry hardcoded list plus per-user typed history.

- `loadExerciseLibrary()`: 7-day localStorage cache, falls back to fetching `GET /exercises?limit=1000` on a miss. Fails silently on error — never blocks the UI, keeps whatever's cached/default.
- `updateExerciseSuggestions()` merges default list + library + user history into the datalist, deduped.

## Note

`exerciseAutocomplete.js` (similarly-named file) turned out to be dead code — never loaded via a `<script>` tag. The real datalist logic lives inline in `index.html`, which is what this PR edits instead. Left `exerciseMuscleMap.js`/`exerciseVarietyEngine.js` alone — those analyze historical logged workouts, unrelated to picking exercises going forward.

## Verification

Backend route tested against production already (873 real exercises seeded and searchable). This PR's frontend logic was verified in a live browser session with `fetch` mocked (the real endpoint needs a production-authenticated session): confirmed the fresh-fetch path populates and caches correctly, the cache-hit path skips the network call entirely, and a failed fetch degrades gracefully with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
