### PR TITLE
Compact the set-logging card (smaller inputs, collapsible Advanced)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5381,16 +5381,28 @@ function createSetRow(workoutIndex, entryIndex, entry, setIndex) {
   advancedBlock.dataset.workout = workoutIndex;
   advancedBlock.dataset.entry = entryIndex;
   advancedBlock.dataset.set = setIndex;
+  // Collapsed by default — a plain set is just Weight/Reps/Done, like a
+  // paper logbook. Only sets that already have a method/state/tag set
+  // (e.g. re-opening a workout mid-session) start expanded.
+  const hasAdvancedContent = Boolean(
+    advancedData.method || advancedData.state || Object.values(advancedData.tags || {}).some(Boolean)
+  );
+  if (hasAdvancedContent) advancedBlock.classList.add('expanded');
   advancedBlock.innerHTML = `
     <div class="set-advanced-header">Advanced</div>
-    <div class="method-pills">${methodPills}</div>
-    ${renderMethodForm(advancedData, baseWeight)}
-    <div class="set-state">${stateRow}</div>
-    <div class="tag-row">${tagsRow}</div>
-    <div class="tag-input" id="${tagInputId}" style="display:none;">
-      <input type="text" data-adv="tagText" placeholder="Type and press Enter" />
+    <div class="set-advanced-body">
+      <div class="method-pills">${methodPills}</div>
+      ${renderMethodForm(advancedData, baseWeight)}
+      <div class="set-state">${stateRow}</div>
+      <div class="tag-row">${tagsRow}</div>
+      <div class="tag-input" id="${tagInputId}" style="display:none;">
+        <input type="text" data-adv="tagText" placeholder="Type and press Enter" />
+      </div>
     </div>
   `;
+  advancedBlock.querySelector('.set-advanced-header').addEventListener('click', () => {
+    advancedBlock.classList.toggle('expanded');
+  });
 
   wrapper.appendChild(advancedBlock);
   return wrapper;

--- a/style.css
+++ b/style.css
@@ -486,16 +486,16 @@ body.theme-dark .set-menu-btn:hover {
 .set-row-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.3rem;
 }
 
 .set-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
-  padding: 0.75rem;
-  border-radius: 10px;
+  padding: 0.4rem 0.55rem;
+  border-radius: 8px;
   border: 1px solid var(--border-color);
   background: rgba(0, 0, 0, 0.02);
 }
@@ -525,26 +525,34 @@ body.theme-dark .set-row {
 
 .set-index {
   font-weight: 600;
-  min-width: 48px;
+  font-size: 0.8rem;
+  min-width: 38px;
 }
 
 .set-field {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  min-width: 90px;
+  align-items: baseline;
+  gap: 0.35rem;
+  min-width: 0;
 }
 
 .set-field-label {
-  font-size: 0.7rem;
+  font-size: 0.62rem;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.03em;
   color: var(--secondary-text);
+  white-space: nowrap;
 }
 
 .set-field input {
-  width: 110px;
+  width: 4.2rem;
   margin: 0;
+  padding: 0.25rem 0.4rem;
+  /* Deliberately kept at 16px, not shrunk further — iOS Safari zooms the
+     whole page in on focus for any input with font-size below 16px, which
+     would be a worse regression than a slightly taller box. */
+  font-size: 1rem;
+  border-radius: 6px;
 }
 
 .set-unit {
@@ -591,8 +599,14 @@ body.theme-dark .set-row {
 .set-complete {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  font-size: 0.85rem;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+}
+
+.set-complete input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
 }
 
 .goal-row {
@@ -689,12 +703,13 @@ body.theme-dark .set-row {
 }
 
 @media (max-width: 520px) {
+  /* Deliberately NOT stretching inputs to full width here anymore — that
+     was the main cause of the oversized, spaced-out feel on phones. Weight
+     and Reps now stay compact and sit side by side, like a paper logbook,
+     instead of stacking as two full-width blocks. */
   .set-row {
-    align-items: flex-start;
-  }
-
-  .set-field input {
-    width: 100%;
+    align-items: center;
+    padding: 0.35rem 0.5rem;
   }
 
   .menu-button,
@@ -1115,42 +1130,68 @@ body.theme-dark .set-row {
   }
 }
 
-/* Advanced set logging UI */
+/* Advanced set logging UI — collapsed by default (see .set-advanced-header
+   click handler in createSetRow) so a plain set is just Weight/Reps/Done,
+   like a paper logbook. Only sets that already have something set (a
+   method, a state, a tag) default open. */
 .set-advanced {
-  margin-top: 8px;
-  padding: 10px;
+  margin-top: 4px;
+  padding: 6px 8px;
   border: 1px solid var(--border-color);
-  border-radius: 10px;
+  border-radius: 8px;
   background: var(--card-bg);
 }
 .set-advanced-header {
-  font-weight: 700;
-  margin-bottom: 6px;
+  font-weight: 600;
+  font-size: 0.78rem;
+  color: var(--secondary-text);
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.set-advanced-header::before {
+  content: '▸';
+  display: inline-block;
+  font-size: 0.7em;
+  transition: transform 0.15s ease;
+}
+.set-advanced.expanded .set-advanced-header::before {
+  transform: rotate(90deg);
+}
+.set-advanced-body {
+  display: none;
+  margin-top: 6px;
+}
+.set-advanced.expanded .set-advanced-body {
+  display: block;
 }
 .adv-row {
   display: grid;
   grid-template-columns: 1fr 1fr auto;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
 }
 .adv-row.single {
   grid-template-columns: 1fr;
 }
 .adv-row input {
   width: 100%;
-  padding: 6px 8px;
+  padding: 0.25rem 0.4rem;
+  font-size: 1rem; /* keep >=16px — see .set-field input comment on iOS zoom */
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: 6px;
 }
 .adv-btn {
-  padding: 6px 10px;
+  padding: 4px 8px;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: 6px;
   cursor: pointer;
   background: var(--surface-bg);
   color: var(--text-color);
-  font-size: 12px;
+  font-size: 11px;
 }
 .adv-btn.primary {
   border-color: var(--primary);
@@ -1160,15 +1201,15 @@ body.theme-dark .set-row {
 .method-pills {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 6px;
-  margin-bottom: 6px;
+  gap: 4px;
+  margin-top: 4px;
+  margin-bottom: 4px;
 }
 .method-pill {
-  padding: 6px 10px;
+  padding: 3px 8px;
   border-radius: 999px;
   border: 1px solid var(--border-color);
-  font-size: 12px;
+  font-size: 11px;
   cursor: pointer;
   background: var(--surface-bg);
   color: var(--secondary-text);
@@ -1180,15 +1221,15 @@ body.theme-dark .set-row {
 }
 .tag-row {
   display: flex;
-  gap: 8px;
+  gap: 4px;
   flex-wrap: wrap;
-  margin-top: 8px;
+  margin-top: 6px;
 }
 .tag-chip {
   border: 1px solid var(--border-color);
   border-radius: 999px;
-  padding: 6px 10px;
-  font-size: 12px;
+  padding: 3px 8px;
+  font-size: 11px;
   cursor: pointer;
   background: var(--surface-bg);
   color: var(--secondary-text);
@@ -1198,29 +1239,30 @@ body.theme-dark .set-row {
   color: var(--primary);
 }
 .tag-input {
-  margin-top: 6px;
+  margin-top: 4px;
 }
 .tag-input input {
   width: 100%;
-  padding: 6px 8px;
+  padding: 0.25rem 0.4rem;
+  font-size: 1rem;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: 6px;
 }
 .set-state {
   display: flex;
-  gap: 6px;
+  gap: 4px;
   align-items: center;
-  margin-top: 8px;
+  margin-top: 6px;
   flex-wrap: wrap;
 }
 .state-btn {
   border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 4px 8px;
+  border-radius: 6px;
+  padding: 3px 6px;
   cursor: pointer;
   background: var(--surface-bg);
   color: var(--secondary-text);
-  font-size: 12px;
+  font-size: 11px;
 }
 .state-btn.active {
   border-color: var(--primary);


### PR DESCRIPTION
## What

Compacts the per-set logging card shown in the screenshot you shared. Two root causes for the "big and broad" feel:

1. A mobile media query stretched Weight/Reps inputs to full width instead of side by side.
2. The "Advanced" section (Dropset/Rest-Pause/Myo-reps/Back-off/Tempo/etc, Hit/Grind/Miss/Fatigued, Pain/Pump/Grip/Cue/Note) rendered fully expanded for *every* set with no way to collapse it.

## Changes

- Weight/Reps inputs: 224px-wide/44px-tall full-width boxes → 67px-wide/33px boxes side by side, like a paper logbook. Font-size deliberately kept at exactly 16px, not shrunk further — iOS Safari zooms the whole page in on focus for inputs below 16px, which would be a worse regression than a slightly taller box.
- "Advanced" is now a real collapse/expand toggle (tap the header, chevron rotates) instead of always-open. Collapsed by default; a set that already has something set (method/state/tag) still opens automatically so you don't lose visibility into it.
- Tightened padding/gaps throughout the set row, method pills, state buttons, and tag chips.

## Verification

I don't have working screenshot capture in this session, so I measured the actual rendered layout directly in a live mobile-viewport browser session instead of eyeballing it: collapsed set height dropped from ~346px to ~146px, inputs confirmed side-by-side (not stacked), the collapse/expand toggle confirmed working both ways, and clicking a method pill (Dropset) confirmed non-throwing. `jest`: 72/75 passing, same 3 pre-existing failures as clean `main` — unrelated.

**I have not merged this yet** — since I can't visually confirm the actual pixel result myself, wanted you to look it over (or try it live) before it goes to `main`. Let me know if it looks right or if you want any further sizing tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
