### PR TITLE
fix: program builder crash on adding exercises + add PDF export

### DIFF
--- a/ProgramTab.css
+++ b/ProgramTab.css
@@ -943,6 +943,20 @@
 }
 .prog-card-load:hover { background: var(--primary, #5fa87e); color: #0b130d; }
 
+.prog-card-export {
+  padding: 9px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border, #2a3a2e);
+  background: transparent;
+  color: var(--text-muted, #7a8f7d);
+  font-size: 0.84rem;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s;
+}
+.prog-card-export:hover { border-color: var(--primary, #5fa87e); color: var(--primary, #5fa87e); }
+
 .prog-card-del {
   padding: 9px 12px;
   border-radius: 8px;

--- a/src/js/ProgramTabV2.js
+++ b/src/js/ProgramTabV2.js
@@ -114,6 +114,128 @@
     }, 3200);
   }
 
+  /* ── PDF export ──────────────────────────────────────────────── */
+
+  const SPLIT_LABELS = { fullbody: 'Full Body', upperlower: 'Upper / Lower', ppl: 'Push / Pull / Legs', custom: 'Custom' };
+  const GOAL_LABELS  = { strength: 'Strength', hypertrophy: 'Muscle Growth', 'fat-loss': 'Fat Loss', general: 'General Fitness' };
+
+  function buildProgramReportHTML(program) {
+    const p = program || {};
+    const title = p.title || p.name || 'Untitled Program';
+    const days = Array.isArray(p.days) ? p.days : [];
+    const wdNames = (p.schedule?.weekdays || []).map(d => WEEKDAYS[d - 1]).filter(Boolean).join(', ');
+    const splitLabel = SPLIT_LABELS[p.split?.type] || p.split?.type || '—';
+    const goalLabel = GOAL_LABELS[p.archetype] || p.archetype || '—';
+
+    const dayBlocks = days.length
+      ? days.map(day => {
+          const exercises = Array.isArray(day.exercises) ? day.exercises : [];
+          const exBlocks = exercises.length
+            ? exercises.map(ex => {
+                const sets = Array.isArray(ex.sets) ? ex.sets : [];
+                const setRows = sets.length
+                  ? sets.map((s, i) => `
+                      <tr>
+                        <td>${i + 1}</td>
+                        <td>${s.reps ?? '—'}</td>
+                        <td>${s.weight ?? '—'}</td>
+                        <td>${s.rpe ?? '—'}</td>
+                      </tr>
+                    `).join('')
+                  : `<tr><td colspan="4" style="text-align:center;color:#aaa">No sets</td></tr>`;
+                return `
+                  <div class="ex-block">
+                    <div class="ex-name">${esc(ex.name)} <span class="ex-set-count">${sets.length} set${sets.length !== 1 ? 's' : ''}</span></div>
+                    ${ex.notes ? `<div class="ex-notes">${esc(ex.notes)}</div>` : ''}
+                    <table>
+                      <thead><tr><th>Set</th><th>Reps</th><th>Weight</th><th>RPE</th></tr></thead>
+                      <tbody>${setRows}</tbody>
+                    </table>
+                  </div>
+                `;
+              }).join('')
+            : '<p class="empty-note">No exercises added to this day.</p>';
+          return `
+            <div class="day-section">
+              <h2>${esc(day.name)}</h2>
+              ${day.notes ? `<p class="day-notes">${esc(day.notes)}</p>` : ''}
+              ${exBlocks}
+            </div>
+          `;
+        }).join('')
+      : '<p class="empty-note">No training days added yet.</p>';
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${esc(title)} — Program</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Segoe UI', Arial, sans-serif;
+      background: #fff;
+      color: #1a1a1a;
+      padding: 32px 40px;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    h1 { font-size: 1.8rem; color: #2e7d55; margin-bottom: 4px; }
+    h2 { font-size: 1.15rem; color: #2e7d55; margin: 20px 0 8px; border-bottom: 2px solid #2e7d55; padding-bottom: 4px; }
+    .meta { font-size: 0.85rem; color: #666; margin-bottom: 20px; }
+    .day-section { margin-bottom: 20px; page-break-inside: avoid; }
+    .day-notes { font-size: 0.85rem; color: #666; margin-bottom: 10px; font-style: italic; }
+    .ex-block { margin-bottom: 14px; }
+    .ex-name { font-weight: 700; font-size: 0.95rem; margin-bottom: 2px; }
+    .ex-set-count { font-weight: 400; font-size: 0.78rem; color: #888; }
+    .ex-notes { font-size: 0.8rem; color: #666; margin-bottom: 6px; }
+    .empty-note { color: #aaa; font-size: 0.9rem; padding: 8px 0; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.85rem; margin-bottom: 4px; }
+    th { background: #f0faf4; color: #2e7d55; text-align: left; padding: 6px 10px; border-bottom: 2px solid #c8e6c9; }
+    td { padding: 6px 10px; border-bottom: 1px solid #eee; }
+    tr:last-child td { border-bottom: none; }
+    .footer { margin-top: 28px; font-size: 0.75rem; color: #aaa; text-align: center; border-top: 1px solid #eee; padding-top: 12px; }
+    @media print {
+      body { padding: 16px 20px; }
+      .no-print { display: none; }
+      @page { margin: 15mm; }
+    }
+  </style>
+</head>
+<body>
+  <button class="no-print" onclick="window.print()"
+    style="float:right;padding:8px 20px;background:#2e7d55;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:0.9rem;">
+    🖨️ Print / Save PDF
+  </button>
+  <h1>${esc(title)}</h1>
+  <p class="meta">
+    Goal: <strong>${esc(goalLabel)}</strong> &nbsp;·&nbsp;
+    Split: <strong>${esc(splitLabel)}</strong> &nbsp;·&nbsp;
+    Schedule: <strong>${esc(wdNames || 'Not set')}</strong>
+  </p>
+  ${p.progressionNotes ? `<h2>Progression Notes</h2><p style="font-size:0.9rem;">${esc(p.progressionNotes)}</p>` : ''}
+  ${dayBlocks}
+  <div class="footer">Generated by Pocket Coach &nbsp;·&nbsp; ${new Date().toLocaleString()}</div>
+</body>
+</html>`;
+  }
+
+  function exportProgramPDF(program) {
+    const html = buildProgramReportHTML(program);
+    const title = (program && (program.title || program.name)) || 'Program';
+    const filename = title.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'program';
+    if (typeof window.openReportWindow === 'function') {
+      window.openReportWindow(html, { title, filename: `${filename}.html` });
+    } else {
+      const win = window.open('', '_blank', 'width=960,height=800,scrollbars=yes');
+      if (!win) { showToast('Pop-up blocked — allow pop-ups for this site and try again.', true); return; }
+      win.document.write(html);
+      win.document.close();
+      win.focus();
+    }
+  }
+
   /* ── initProgramTabV2 ────────────────────────────────────────── */
 
   function initProgramTabV2(mountEl) {
@@ -767,7 +889,7 @@
           <td><input type="number" min="1" max="10" step="0.5" value="${s.rpe ?? ''}" placeholder="—"></td>
           <td><button type="button" class="pbv2-del-set-btn" title="Remove set">✕</button></td>
         `;
-        const [, repsInp, weightInp, rpeInp] = tr.querySelectorAll('input');
+        const [repsInp, weightInp, rpeInp] = tr.querySelectorAll('input');
         repsInp.addEventListener('change', e => updateSetField(dayId, ex.exerciseId, idx, 'reps', e.target.value));
         weightInp.addEventListener('change', e => updateSetField(dayId, ex.exerciseId, idx, 'weight', e.target.value));
         rpeInp.addEventListener('change', e => updateSetField(dayId, ex.exerciseId, idx, 'rpe', e.target.value));
@@ -881,6 +1003,7 @@
           </div>
 
           <button type="button" class="pbv2-save-btn" id="pbv2SaveFinalBtn">Save Program ✅</button>
+          <button type="button" class="pbv2-advanced-btn" id="pbv2ExportPdfBtn" style="width:100%;margin-top:8px;">📄 Export as PDF</button>
 
           <details class="pbv2-save-advanced">
             <summary>Advanced — Templates &amp; Client Assignment</summary>
@@ -918,6 +1041,7 @@
       wrap.querySelector('#pbv2AssignNotes').addEventListener('input', e => { advancedForm.assignmentNotes = e.target.value; });
 
       wrap.querySelector('#pbv2SaveFinalBtn').addEventListener('click', saveFinal);
+      wrap.querySelector('#pbv2ExportPdfBtn').addEventListener('click', () => exportProgramPDF(core.normalizeDraft(draft)));
       wrap.querySelector('#pbv2SaveTplBtn').addEventListener('click', saveTemplate);
       wrap.querySelector('#pbv2AssignBtn').addEventListener('click', assignToClient);
 
@@ -1127,10 +1251,13 @@
         </div>
         <div class="prog-card-actions">
           <button type="button" class="prog-card-load" data-idx="${origIdx}">Load into Builder</button>
+          <button type="button" class="prog-card-export" data-idx="${origIdx}" title="Export as PDF">📄 PDF</button>
           <button type="button" class="prog-card-del" data-idx="${origIdx}">Delete</button>
         </div>
         <button type="button" class="prog-card-analyse">✨ Analyse with AI</button>
       `;
+
+      card.querySelector('.prog-card-export').addEventListener('click', () => exportProgramPDF(prog));
 
       card.querySelector('.prog-card-load').addEventListener('click', () => {
         // Load this program into the draft and switch to builder

--- a/src/js/programBuilderV2Core.js
+++ b/src/js/programBuilderV2Core.js
@@ -246,10 +246,10 @@
                   const safeSet = set && typeof set === "object" ? set : {};
                   return {
                     setType: typeof safeSet.setType === "string" && safeSet.setType ? safeSet.setType : "straight",
-                    reps: Number.isFinite(Number(safeSet.reps)) ? Number(safeSet.reps) : null,
-                    weight: Number.isFinite(Number(safeSet.weight)) ? Number(safeSet.weight) : null,
-                    rpe: Number.isFinite(Number(safeSet.rpe)) ? Number(safeSet.rpe) : null,
-                    rir: Number.isFinite(Number(safeSet.rir)) ? Number(safeSet.rir) : null,
+                    reps: safeSet.reps === null || safeSet.reps === undefined || safeSet.reps === "" ? null : (Number.isFinite(Number(safeSet.reps)) ? Number(safeSet.reps) : null),
+                    weight: safeSet.weight === null || safeSet.weight === undefined || safeSet.weight === "" ? null : (Number.isFinite(Number(safeSet.weight)) ? Number(safeSet.weight) : null),
+                    rpe: safeSet.rpe === null || safeSet.rpe === undefined || safeSet.rpe === "" ? null : (Number.isFinite(Number(safeSet.rpe)) ? Number(safeSet.rpe) : null),
+                    rir: safeSet.rir === null || safeSet.rir === undefined || safeSet.rir === "" ? null : (Number.isFinite(Number(safeSet.rir)) ? Number(safeSet.rir) : null),
                     restSec: Number.isFinite(Number(safeSet.restSec)) ? Number(safeSet.restSec) : 120,
                   };
                 }),


### PR DESCRIPTION
## Summary
- Fixes a crash in the Program Builder's Exercises step: adding an exercise to any day threw a `TypeError` (`Cannot read properties of undefined (reading 'addEventListener')`) because the sets-table row destructured 4 variables from only 3 `<input>` elements (a stray leading comma in `const [, repsInp, weightInp, rpeInp] = tr.querySelectorAll('input')`). This left `rpeInp` undefined and broke rendering mid-way, so the exercise never appeared and the tab was left in a broken state — matches the reported bug where "adding exercises to certain days" crashed the section.
- Fixes a related data bug: `normalizeDraft` coerced unset `weight`/`rpe`/`rir` set fields to `0` instead of `null` (`Number(null) === 0`, which passed the `isFinite` check), silently turning "not entered" into "0".
- Adds a PDF export feature for programs: an "Export as PDF" button on the builder's Save step, and a "📄 PDF" button on each card in the saved-programs list. Both open a print-ready report (program name, goal, split, schedule, and each day's exercises with set counts and per-set reps/weight/RPE) via the existing `openReportWindow` helper already used by the app's Progress Report / Coach exports — so it also works with the native share sheet on Capacitor builds.

## Why
User reported that creating a program and adding exercises to a day crashed the Program Builder tab. Root-caused to the destructuring bug above, verified live in the browser (reproduced the exact `TypeError` via `window.onerror`, confirmed the fix resolves it). PDF export was a follow-up feature request in the same session.

## Test plan
- [x] `npx jest tests/programBuilderV2Core.test.js` — 15/15 passing
- [x] Reproduced the crash live via the static preview server, confirmed the exact stack trace, applied the fix, and confirmed adding exercises/sets no longer throws and renders correctly
- [x] Verified the same flow against the current `main` branch state after cherry-picking (main had diverged significantly since this branch was based on an older local `main`) — no conflicts in behavior, tests still pass
- [x] Exported PDF from both the builder Save step and the saved-programs list; confirmed generated report includes correct title, goal, split, schedule, and per-exercise set counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)