### PR TITLE
feat: add Recovery Map with weekly muscle set targets

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "static",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["-y", "serve", "-l", "5500", "."],
+      "port": 5500
+    }
+  ]
+}

--- a/css/progress.css
+++ b/css/progress.css
@@ -289,3 +289,209 @@
 #bodybuildingProgressPanel summary {
   color: #dce7e1;
 }
+
+/* ── Recovery Map panel ──────────────────────────────────────── */
+
+.recovery-panel {
+  margin-top: 14px;
+  color: var(--text-color);
+  /* fatigue scale — semantic, deliberately separate from --primary/--highlight */
+  --scale-0: #f2ece0;
+  --scale-1: #f3d36b;
+  --scale-2: #e8863f;
+  --scale-3: var(--danger);
+}
+
+.recovery-sub {
+  margin: 0 0 16px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.recovery-figures {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.recovery-figure-col {
+  text-align: center;
+  width: 170px;
+}
+
+.recovery-figure-col svg {
+  width: 100%;
+  height: auto;
+}
+
+.recovery-figure-label {
+  margin: 2px 0 0;
+  font-size: 0.62rem;
+  letter-spacing: 0.16em;
+  color: var(--text-muted);
+}
+
+.recovery-zone {
+  stroke: var(--card-bg);
+  stroke-width: 1.5;
+  cursor: pointer;
+  transition: opacity 0.15s ease, stroke-width 0.15s ease;
+}
+
+.recovery-zone.is-dim {
+  opacity: 0.28;
+}
+
+.recovery-zone.is-active {
+  stroke: var(--text-color);
+  stroke-width: 2.5;
+}
+
+.recovery-neutral {
+  fill: var(--elevated-bg);
+  stroke: var(--border-color);
+  stroke-width: 1;
+}
+
+.recovery-legend {
+  max-width: 380px;
+  margin: 20px auto 0;
+}
+
+.recovery-legend-bar {
+  height: 7px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, var(--scale-0), var(--scale-1), var(--scale-2), var(--scale-3));
+}
+
+.recovery-legend-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 5px;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.recovery-hint {
+  text-align: center;
+  margin: 14px 0 10px;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+.recovery-table-wrap {
+  overflow-x: auto;
+}
+
+.recovery-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+  background: rgba(14, 21, 18, 0.92);
+}
+
+.recovery-table th {
+  text-align: left;
+  padding: 6px 10px;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.recovery-table th.num {
+  text-align: right;
+}
+
+.recovery-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(132, 157, 144, 0.12);
+  color: #e5ece8;
+  vertical-align: middle;
+}
+
+.recovery-table td.muscle {
+  font-weight: 600;
+}
+
+.recovery-table td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.recovery-table td.recovery-days {
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+
+.recovery-table tbody tr {
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.recovery-table tbody tr:hover {
+  background: rgba(244, 247, 245, 0.03);
+}
+
+.recovery-table tbody tr.is-dim {
+  opacity: 0.35;
+}
+
+.recovery-table tbody tr.is-active {
+  background: rgba(198, 148, 79, 0.08);
+}
+
+.ratio-track {
+  position: relative;
+  width: 90px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--elevated-bg);
+  overflow: hidden;
+}
+
+.ratio-fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: var(--primary);
+  border-radius: 3px;
+}
+
+.ratio-track.is-over .ratio-fill {
+  background: var(--highlight);
+}
+
+.recovery-table .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.recovery-table .chip .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+}
+
+@media (max-width: 460px) {
+  .recovery-table th:nth-child(4),
+  .recovery-table td:nth-child(4) {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recovery-zone,
+  .recovery-table tbody tr,
+  .ratio-fill {
+    transition: none;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -2689,6 +2689,7 @@
           <button id="workoutProgressBtn" onclick="showWorkoutProgress()">Workout</button>
           <button id="cardioProgressBtn" onclick="showCardioProgress()">Cardio</button>
           <button id="bodyweightProgressBtn" onclick="showBodyweightProgress()">Bodyweight</button>
+          <button id="recoveryProgressBtn" onclick="showRecoveryProgress()">Recovery</button>
           <button id="exerciseProgressBtn" onclick="showExerciseProgress()">Exercise</button>
           <input type="date" id="startRange" onchange="refreshProgress()">
           <input type="date" id="endRange" onchange="refreshProgress()">
@@ -2711,6 +2712,96 @@
             <canvas id="monotonyCanvas" height="180" style="max-height:180px; margin-bottom:10px;"></canvas>
             <canvas id="strainCanvas" height="180" style="max-height:180px;"></canvas>
             <div id="loadAlerts" style="margin-top:8px;"></div>
+          </div>
+          <div id="recoveryPanel" class="recovery-panel" style="display:none;">
+            <h3 style="margin-bottom:6px;">Recovery Map</h3>
+            <p class="recovery-sub">Trailing 7-day set volume and estimated fatigue per muscle group.</p>
+            <div class="recovery-figures">
+              <div class="recovery-figure-col">
+                <svg viewBox="0 0 220 440" xmlns="http://www.w3.org/2000/svg">
+                  <circle class="recovery-neutral" cx="110" cy="30" r="20"></circle>
+                  <rect class="recovery-neutral" x="100" y="48" width="20" height="12" rx="4"></rect>
+
+                  <circle class="recovery-zone" data-muscle="shoulders" cx="58" cy="72" r="17"></circle>
+                  <circle class="recovery-zone" data-muscle="shoulders" cx="162" cy="72" r="17"></circle>
+
+                  <rect class="recovery-zone" data-muscle="biceps" x="30" y="76" width="24" height="64" rx="12"></rect>
+                  <rect class="recovery-zone" data-muscle="biceps" x="166" y="76" width="24" height="64" rx="12"></rect>
+
+                  <rect class="recovery-zone" data-muscle="chest" x="72" y="66" width="76" height="56" rx="18"></rect>
+                  <rect class="recovery-zone" data-muscle="abs" x="84" y="126" width="52" height="56" rx="14"></rect>
+
+                  <rect class="recovery-zone" data-muscle="forearms" x="24" y="144" width="22" height="64" rx="11"></rect>
+                  <rect class="recovery-zone" data-muscle="forearms" x="174" y="144" width="22" height="64" rx="11"></rect>
+                  <circle class="recovery-neutral" cx="35" cy="216" r="11"></circle>
+                  <circle class="recovery-neutral" cx="185" cy="216" r="11"></circle>
+
+                  <rect class="recovery-neutral" x="78" y="182" width="64" height="22" rx="10"></rect>
+
+                  <rect class="recovery-zone" data-muscle="quads" x="62" y="204" width="34" height="110" rx="16"></rect>
+                  <rect class="recovery-zone" data-muscle="quads" x="124" y="204" width="34" height="110" rx="16"></rect>
+                  <rect class="recovery-zone" data-muscle="adductors" x="96" y="214" width="28" height="70" rx="12"></rect>
+
+                  <circle class="recovery-neutral" cx="79" cy="320" r="12"></circle>
+                  <circle class="recovery-neutral" cx="141" cy="320" r="12"></circle>
+                  <rect class="recovery-neutral" x="68" y="326" width="24" height="86" rx="10"></rect>
+                  <rect class="recovery-neutral" x="128" y="326" width="24" height="86" rx="10"></rect>
+                  <rect class="recovery-neutral" x="64" y="412" width="32" height="14" rx="6"></rect>
+                  <rect class="recovery-neutral" x="124" y="412" width="32" height="14" rx="6"></rect>
+                </svg>
+                <p class="recovery-figure-label">FRONT</p>
+              </div>
+              <div class="recovery-figure-col">
+                <svg viewBox="0 0 220 440" xmlns="http://www.w3.org/2000/svg">
+                  <circle class="recovery-neutral" cx="110" cy="30" r="20"></circle>
+                  <rect class="recovery-neutral" x="100" y="48" width="20" height="12" rx="4"></rect>
+
+                  <rect class="recovery-zone" data-muscle="traps" x="88" y="64" width="44" height="30" rx="8"></rect>
+                  <circle class="recovery-zone" data-muscle="shoulders" cx="58" cy="72" r="17"></circle>
+                  <circle class="recovery-zone" data-muscle="shoulders" cx="162" cy="72" r="17"></circle>
+
+                  <rect class="recovery-zone" data-muscle="triceps" x="30" y="76" width="24" height="64" rx="12"></rect>
+                  <rect class="recovery-zone" data-muscle="triceps" x="166" y="76" width="24" height="64" rx="12"></rect>
+
+                  <rect class="recovery-zone" data-muscle="back" x="72" y="92" width="76" height="90" rx="20"></rect>
+
+                  <rect class="recovery-zone" data-muscle="forearms" x="24" y="144" width="22" height="64" rx="11"></rect>
+                  <rect class="recovery-zone" data-muscle="forearms" x="174" y="144" width="22" height="64" rx="11"></rect>
+                  <circle class="recovery-neutral" cx="35" cy="216" r="11"></circle>
+                  <circle class="recovery-neutral" cx="185" cy="216" r="11"></circle>
+
+                  <rect class="recovery-zone" data-muscle="glutes" x="74" y="184" width="72" height="44" rx="20"></rect>
+
+                  <rect class="recovery-zone" data-muscle="hamstrings" x="66" y="214" width="34" height="100" rx="16"></rect>
+                  <rect class="recovery-zone" data-muscle="hamstrings" x="120" y="214" width="34" height="100" rx="16"></rect>
+                  <rect class="recovery-zone" data-muscle="abductors" x="58" y="214" width="16" height="90" rx="8"></rect>
+                  <rect class="recovery-zone" data-muscle="abductors" x="146" y="214" width="16" height="90" rx="8"></rect>
+
+                  <circle class="recovery-neutral" cx="79" cy="320" r="12"></circle>
+                  <circle class="recovery-neutral" cx="141" cy="320" r="12"></circle>
+                  <rect class="recovery-zone" data-muscle="calves" x="68" y="326" width="24" height="86" rx="10"></rect>
+                  <rect class="recovery-zone" data-muscle="calves" x="128" y="326" width="24" height="86" rx="10"></rect>
+                  <rect class="recovery-neutral" x="64" y="412" width="32" height="14" rx="6"></rect>
+                  <rect class="recovery-neutral" x="124" y="412" width="32" height="14" rx="6"></rect>
+                </svg>
+                <p class="recovery-figure-label">BACK</p>
+              </div>
+            </div>
+            <div class="recovery-legend">
+              <div class="recovery-legend-bar"></div>
+              <div class="recovery-legend-labels">
+                <span>Fresh</span><span>Moderate</span><span>Fatigued</span><span>Overreached</span>
+              </div>
+            </div>
+            <p class="recovery-hint">Tap a muscle to isolate it in the table below</p>
+            <div class="recovery-table-wrap">
+              <table class="recovery-table">
+                <thead>
+                  <tr><th>Muscle</th><th class="num">Sets</th><th>Volume</th><th>Last trained</th><th>Status</th></tr>
+                </thead>
+                <tbody id="recoveryTableBody"></tbody>
+              </table>
+            </div>
           </div>
           <div id="bodybuildingProgressPanel"></div>
           <div id="goalBar" style="margin-top:10px;"></div>
@@ -3205,7 +3296,9 @@
 <script src="archiveOldWorkouts.js"></script>
 <script src="progressiveOverload.js"></script>
 <script src="community.js"></script>
+<script src="exerciseMuscleMap.js"></script>
 <script src="leaderboard.js"></script>
+<script src="recoveryMap.js"></script>
 <script src="exerciseLeaderboard.js"></script>
 <script src="stats.js"></script>
 <script src="src/config/constants.js"></script>
@@ -4150,6 +4243,7 @@ function showTab(tabName) {
         autoIncrementToggle.checked = localStorage.getItem('autoIncrementEnabled') !== 'false';
       }
       initSmartGoalForm();
+      if (typeof initMuscleTargetsForm === 'function') initMuscleTargetsForm();
       if (typeof renderRemindersPanel === 'function') renderRemindersPanel();
       loadKnowledgeModules();
       renderSubscriptionPanel();
@@ -13311,6 +13405,7 @@ async function showWorkoutProgress(data) {
     : await fetchWorkoutHistory();
   const filtered = applyDateRange(history);
   const filteredWorkouts = applyDateRange(rawWorkouts);
+  document.getElementById('recoveryPanel').style.display = 'none';
   const dates = filtered.map(h => h.date);
   const vols = filtered.map(h => h.volume);
   const intensities = filtered.map(h => Number(h.averageIntensity || 0));
@@ -13335,6 +13430,7 @@ async function showWorkoutProgress(data) {
 
 async function showCardioProgress() {
   setActiveProgress('cardioProgressBtn');
+  document.getElementById('recoveryPanel').style.display = 'none';
   const cardioHistory = await fetchCardioHistory();
   const filtered = applyDateRange(cardioHistory);
   const dates = filtered.map(h => h.date);
@@ -13357,6 +13453,7 @@ async function showCardioProgress() {
 
 async function showBodyweightProgress() {
   setActiveProgress('bodyweightProgressBtn');
+  document.getElementById('recoveryPanel').style.display = 'none';
   const bodyweightHistory = await fetchBodyweightHistory();
   const filtered = applyDateRange(bodyweightHistory);
   const dates = filtered.map(h => h.date);
@@ -13428,6 +13525,7 @@ async function showBodyweightProgress() {
     cardioHistory: applyDateRange(await fetchCardioHistory()),
     bodyweightHistory: filtered
   });
+  document.getElementById('recoveryPanel').style.display = 'none';
 }
 
 function showExerciseProgress() {
@@ -13435,6 +13533,7 @@ function showExerciseProgress() {
   document.getElementById('progressCanvas').style.display = 'none';
   document.getElementById('exerciseProgress').style.display = 'block';
   document.getElementById('trainingLoadPanel').style.display = 'none';
+  document.getElementById('recoveryPanel').style.display = 'none';
   renderExerciseProgress();
   fetchWorkouts().then(renderBodybuildingProgressPanel);
   renderProgressComplianceSummary();
@@ -13448,6 +13547,107 @@ function showExerciseProgress() {
   });
 }
 
+function getTodaySorenessForRecovery() {
+  try {
+    const all = JSON.parse(localStorage.getItem('dailyReadiness_v1')) || {};
+    const entry = all[new Date().toDateString()];
+    return entry && Number.isFinite(entry.soreness) ? entry.soreness : null;
+  } catch {
+    return null;
+  }
+}
+
+function initRecoveryPanelInteractions() {
+  const panel = document.getElementById('recoveryPanel');
+  if (!panel || panel.dataset.boundInteractions) return;
+  panel.dataset.boundInteractions = '1';
+
+  let focused = null;
+  function setFocus(muscle) {
+    focused = (focused === muscle) ? null : muscle;
+    panel.querySelectorAll('.recovery-zone').forEach((el) => {
+      const m = el.dataset.muscle;
+      el.classList.toggle('is-dim', !!focused && m !== focused);
+      el.classList.toggle('is-active', !!focused && m === focused);
+    });
+    panel.querySelectorAll('#recoveryTableBody tr').forEach((tr) => {
+      const m = tr.dataset.muscle;
+      tr.classList.toggle('is-dim', !!focused && m !== focused);
+      tr.classList.toggle('is-active', !!focused && m === focused);
+    });
+  }
+
+  panel.addEventListener('click', (e) => {
+    const zone = e.target.closest('.recovery-zone');
+    const row = e.target.closest('#recoveryTableBody tr');
+    const muscle = zone?.dataset.muscle || row?.dataset.muscle;
+    if (muscle) setFocus(muscle);
+  });
+}
+
+function renderRecoveryProgress(workouts) {
+  const panel = document.getElementById('recoveryPanel');
+  if (!panel || typeof computeMuscleRecoverySummary !== 'function') return;
+
+  const soreness = getTodaySorenessForRecovery();
+  let savedTargets = null;
+  try {
+    savedTargets = JSON.parse(localStorage.getItem(`muscleWeeklyTargets_${currentUser}`));
+  } catch {
+    savedTargets = null;
+  }
+
+  const summary = computeMuscleRecoverySummary(workouts, {
+    soreness,
+    weeklyTargets: savedTargets || undefined
+  });
+  const byMuscle = {};
+  summary.forEach((row) => { byMuscle[row.muscle] = row; });
+
+  panel.querySelectorAll('.recovery-zone').forEach((zone) => {
+    const row = byMuscle[zone.dataset.muscle];
+    if (row) zone.style.fill = row.color;
+  });
+
+  const tbody = document.getElementById('recoveryTableBody');
+  if (tbody) {
+    tbody.innerHTML = summary.map((row) => {
+      const pct = Math.round(Math.min(1, row.ratio) * 100);
+      const over = row.sets > row.target;
+      const label = row.muscle.charAt(0).toUpperCase() + row.muscle.slice(1);
+      const daysLabel = row.daysSinceTrained === null
+        ? 'Not trained'
+        : (row.daysSinceTrained === 0 ? 'Today' : `${row.daysSinceTrained}d ago`);
+      return `<tr data-muscle="${row.muscle}">
+        <td class="muscle">${label}</td>
+        <td class="num mono">${row.sets.toFixed(1)} / ${row.target}</td>
+        <td><div class="ratio-track${over ? ' is-over' : ''}"><div class="ratio-fill" style="width:${pct}%"></div></div></td>
+        <td class="recovery-days">${daysLabel}</td>
+        <td><span class="chip"><span class="dot" style="background:${row.color}"></span>${row.status}</span></td>
+      </tr>`;
+    }).join('');
+  }
+
+  initRecoveryPanelInteractions();
+}
+
+async function showRecoveryProgress() {
+  setActiveProgress('recoveryProgressBtn');
+  document.getElementById('progressCanvas').style.display = 'none';
+  document.getElementById('exerciseProgress').style.display = 'none';
+  document.getElementById('trainingLoadPanel').style.display = 'none';
+  document.getElementById('recoveryPanel').style.display = 'block';
+  const workouts = await fetchWorkouts();
+  renderRecoveryProgress(workouts);
+  renderProgressComplianceSummary();
+  renderProgressArchetypeSpotlight({
+    workouts: applyDateRange(workouts),
+    workoutHistory: applyDateRange(await fetchWorkoutHistory()),
+    cardioHistory: applyDateRange(await fetchCardioHistory()),
+    bodyweightHistory: applyDateRange(await fetchBodyweightHistory())
+  });
+}
+
 function refreshProgress() {
   // Re-render whichever progress sub-tab is currently active
   const activeBtn = document.querySelector('.progress-nav button.active');
@@ -13458,6 +13658,8 @@ function refreshProgress() {
     const picker = document.querySelector('#exPicker');
     const metric = document.querySelector('.ex-metric-btn.active')?.dataset.metric || 'weight';
     if (picker) renderExerciseChart(picker.value || null, metric);
+  } else if (id === 'recoveryProgressBtn') {
+    showRecoveryProgress();
   } else if (id === 'cardioProgressBtn') {
     showCardioProgress();
   } else if (id === 'bodyweightProgressBtn') {
@@ -13601,6 +13803,88 @@ async function submitSmartGoalForm(event) {
   renderGoalBar();
   if (typeof renderGoalProgressList === 'function') {
     renderGoalProgressList();
+  }
+}
+
+function getMuscleTargetsStorageKey() {
+  return `muscleWeeklyTargets_${currentUser}`;
+}
+
+function getMuscleTargetKeys() {
+  if (typeof DEFAULT_WEEKLY_MUSCLE_TARGETS === 'object' && DEFAULT_WEEKLY_MUSCLE_TARGETS) {
+    return Object.keys(DEFAULT_WEEKLY_MUSCLE_TARGETS);
+  }
+  return ['chest', 'back', 'shoulders', 'traps', 'biceps', 'triceps', 'forearms', 'quads', 'hamstrings', 'glutes', 'calves', 'adductors', 'abductors', 'abs'];
+}
+
+function loadMuscleTargetsIntoForm() {
+  const defaults = (typeof DEFAULT_WEEKLY_MUSCLE_TARGETS === 'object' && DEFAULT_WEEKLY_MUSCLE_TARGETS) || {};
+  let saved = null;
+  try {
+    saved = JSON.parse(localStorage.getItem(getMuscleTargetsStorageKey()));
+  } catch {
+    saved = null;
+  }
+  getMuscleTargetKeys().forEach((key) => {
+    const input = document.getElementById(`muscleTarget_${key}`);
+    if (!input) return;
+    const raw = (saved && Number.isFinite(saved[key])) ? saved[key] : defaults[key];
+    const value = typeof clampMuscleTarget === 'function' ? clampMuscleTarget(key, raw) : raw;
+    input.value = Number.isFinite(value) ? value : '';
+  });
+}
+
+function saveMuscleWeeklyTargets() {
+  const targets = {};
+  let clampedAny = false;
+  getMuscleTargetKeys().forEach((key) => {
+    const input = document.getElementById(`muscleTarget_${key}`);
+    if (!input || input.value === '') return;
+    const rawValue = Number(input.value);
+    if (!Number.isFinite(rawValue)) return;
+    const clampedValue = typeof clampMuscleTarget === 'function' ? clampMuscleTarget(key, rawValue) : rawValue;
+    if (clampedValue !== rawValue) clampedAny = true;
+    targets[key] = clampedValue;
+    input.value = clampedValue;
+  });
+  localStorage.setItem(getMuscleTargetsStorageKey(), JSON.stringify(targets));
+
+  const feedback = document.getElementById('muscleTargetsFeedback');
+  if (feedback) {
+    feedback.textContent = clampedAny
+      ? 'Weekly targets saved (some values were adjusted to stay within a sane range).'
+      : 'Weekly targets saved.';
+  }
+  if (typeof showToast === 'function') showToast('Weekly muscle targets saved');
+
+  // Keep the Recovery Map in sync if it's the tab currently on screen
+  const recoveryPanel = document.getElementById('recoveryPanel');
+  if (recoveryPanel && recoveryPanel.style.display !== 'none' && typeof showRecoveryProgress === 'function') {
+    showRecoveryProgress();
+  }
+}
+
+function resetMuscleWeeklyTargets() {
+  localStorage.removeItem(getMuscleTargetsStorageKey());
+  loadMuscleTargetsIntoForm();
+  const feedback = document.getElementById('muscleTargetsFeedback');
+  if (feedback) feedback.textContent = 'Reset to defaults.';
+}
+
+function initMuscleTargetsForm() {
+  const grid = document.getElementById('muscleTargetsGrid');
+  if (!grid) return;
+  loadMuscleTargetsIntoForm();
+
+  const saveBtn = document.getElementById('saveMuscleTargetsButton');
+  if (saveBtn && saveBtn.dataset.bound !== '1') {
+    saveBtn.addEventListener('click', saveMuscleWeeklyTargets);
+    saveBtn.dataset.bound = '1';
+  }
+  const resetBtn = document.getElementById('resetMuscleTargetsButton');
+  if (resetBtn && resetBtn.dataset.bound !== '1') {
+    resetBtn.addEventListener('click', resetMuscleWeeklyTargets);
+    resetBtn.dataset.bound = '1';
   }
 }
 

--- a/recoveryMap.js
+++ b/recoveryMap.js
@@ -1,0 +1,170 @@
+// Weekly per-muscle set volume + estimated fatigue for the Recovery Map.
+// Requires exerciseMuscleMap.js to be loaded first (see getMuscleGroup).
+const DEFAULT_WEEKLY_MUSCLE_TARGETS = {
+  chest: 14, back: 16, shoulders: 12, traps: 8, biceps: 10, triceps: 10,
+  forearms: 8, quads: 14, hamstrings: 10, glutes: 10, calves: 8,
+  adductors: 6, abductors: 6, abs: 8
+};
+
+// Sane min/max for weekly set targets, roughly bracketing published MEV-MRV
+// volume landmarks per muscle group. Larger muscle groups (back, quads) can
+// sustain more weekly sets than small stabilizers (traps, forearms, abs).
+const MUSCLE_TARGET_BOUNDS = {
+  chest: { min: 0, max: 24 }, back: { min: 0, max: 28 }, shoulders: { min: 0, max: 24 },
+  traps: { min: 0, max: 18 }, biceps: { min: 0, max: 22 }, triceps: { min: 0, max: 20 },
+  forearms: { min: 0, max: 18 }, quads: { min: 0, max: 24 }, hamstrings: { min: 0, max: 20 },
+  glutes: { min: 0, max: 20 }, calves: { min: 0, max: 22 },
+  adductors: { min: 0, max: 14 }, abductors: { min: 0, max: 14 }, abs: { min: 0, max: 22 }
+};
+
+function clampMuscleTarget(muscle, value) {
+  const bounds = MUSCLE_TARGET_BOUNDS[muscle] || { min: 0, max: 30 };
+  const n = toNumber(value);
+  return Math.min(bounds.max, Math.max(bounds.min, n));
+}
+
+// Rough recovery half-life in days: smaller muscles bounce back faster.
+const RECOVERY_HALF_LIFE_DAYS = {
+  chest: 2, back: 3, shoulders: 2, traps: 1.5, biceps: 1.5, triceps: 1.5,
+  forearms: 1, quads: 3, hamstrings: 2.5, glutes: 2.5, calves: 1,
+  adductors: 1.5, abductors: 1.5, abs: 1
+};
+
+const FATIGUE_COLOR_STOPS = [
+  { score: 0, rgb: [242, 236, 224] },   // fresh — ivory
+  { score: 33, rgb: [243, 211, 107] },  // moderate — yellow
+  { score: 66, rgb: [232, 134, 63] },   // fatigued — orange
+  { score: 100, rgb: [220, 53, 69] }    // overreached — red
+];
+
+// In the browser, exerciseMuscleMap.js (loaded first via <script>) puts
+// getMuscleGroup on window, so the bare reference resolves at call time.
+// Under Node/Jest, requiring a sibling module doesn't do that, so fall
+// back to require() explicitly.
+const resolvedGetMuscleGroup = (typeof getMuscleGroup === 'function')
+  ? getMuscleGroup
+  : (typeof require === 'function' ? require('./exerciseMuscleMap').getMuscleGroup : null);
+
+function toNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function daysBetween(laterMs, earlierMs) {
+  return Math.floor((laterMs - earlierMs) / 86400000);
+}
+
+function getEntrySetCount(entry) {
+  const reps = Array.isArray(entry?.repsArray) ? entry.repsArray.length : 0;
+  const weights = Array.isArray(entry?.weightsArray) ? entry.weightsArray.length : 0;
+  return Math.max(reps, weights, toNumber(entry?.sets));
+}
+
+function fatigueToColor(score) {
+  const s = Math.max(0, Math.min(100, toNumber(score)));
+  for (let i = 0; i < FATIGUE_COLOR_STOPS.length - 1; i++) {
+    const a = FATIGUE_COLOR_STOPS[i];
+    const b = FATIGUE_COLOR_STOPS[i + 1];
+    if (s >= a.score && s <= b.score) {
+      const t = (s - a.score) / (b.score - a.score);
+      const rgb = a.rgb.map((v, idx) => Math.round(v + (b.rgb[idx] - v) * t));
+      return `rgb(${rgb.join(',')})`;
+    }
+  }
+  const last = FATIGUE_COLOR_STOPS[FATIGUE_COLOR_STOPS.length - 1];
+  return `rgb(${last.rgb.join(',')})`;
+}
+
+function fatigueStatus(score) {
+  if (score < 25) return 'Fresh';
+  if (score < 55) return 'Moderate';
+  if (score < 80) return 'Fatigued';
+  return 'Overreached';
+}
+
+// options.now: reference date (defaults to current time; pass explicitly in tests)
+// options.weeklyTargets: overrides for DEFAULT_WEEKLY_MUSCLE_TARGETS
+// options.soreness: today's whole-body soreness rating, 1 (very sore) - 5 (none), or null if not logged
+function computeMuscleRecoverySummary(workouts, options = {}) {
+  const source = Array.isArray(workouts) ? workouts : [];
+  const now = options.now instanceof Date ? options.now : new Date();
+  const rawTargets = Object.assign({}, DEFAULT_WEEKLY_MUSCLE_TARGETS, options.weeklyTargets || {});
+  const targets = Object.fromEntries(
+    Object.entries(rawTargets).map(([muscle, value]) => [muscle, clampMuscleTarget(muscle, value)])
+  );
+  const soreness = Number.isFinite(options.soreness) ? options.soreness : null;
+  const windowStartMs = now.getTime() - 7 * 86400000;
+
+  const weekSets = {};
+  const lastTrainedMs = {};
+
+  source.forEach((workout) => {
+    const date = new Date(workout?.date);
+    if (Number.isNaN(date.getTime()) || !Array.isArray(workout?.log)) return;
+    const dateMs = date.getTime();
+
+    workout.log.forEach((entry) => {
+      const muscle = typeof resolvedGetMuscleGroup === 'function' ? resolvedGetMuscleGroup(entry?.exercise) : 'other';
+      if (!(muscle in targets)) return;
+
+      const setCount = getEntrySetCount(entry);
+      if (dateMs >= windowStartMs && dateMs <= now.getTime()) {
+        weekSets[muscle] = (weekSets[muscle] || 0) + setCount;
+      }
+      if (!lastTrainedMs[muscle] || dateMs > lastTrainedMs[muscle]) {
+        lastTrainedMs[muscle] = dateMs;
+      }
+    });
+  });
+
+  // Whole-body soreness is a coarse signal (not muscle-specific), so it only
+  // ever contributes a small nudge — see globalSorenessAdj weight below.
+  const globalSorenessAdj = soreness === null ? 50 : (5 - soreness) * 25;
+
+  return Object.keys(targets).map((muscle) => {
+    const sets = weekSets[muscle] || 0;
+    const target = targets[muscle];
+    const ratio = target > 0 ? sets / target : 0;
+    const volumeScore = Math.min(100, ratio * 100);
+
+    const lastMs = lastTrainedMs[muscle];
+    const daysSinceTrained = lastMs === undefined ? null : daysBetween(now.getTime(), lastMs);
+    const halfLife = RECOVERY_HALF_LIFE_DAYS[muscle] || 2;
+    const recencyScore = daysSinceTrained === null ? 0 : 100 * Math.pow(0.5, daysSinceTrained / halfLife);
+
+    const fatigueScore = Math.max(0, Math.min(100,
+      volumeScore * 0.55 + recencyScore * 0.35 + globalSorenessAdj * 0.10
+    ));
+
+    return {
+      muscle,
+      sets,
+      target,
+      ratio,
+      daysSinceTrained,
+      fatigueScore,
+      status: fatigueStatus(fatigueScore),
+      color: fatigueToColor(fatigueScore)
+    };
+  }).sort((a, b) => b.fatigueScore - a.fatigueScore);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    DEFAULT_WEEKLY_MUSCLE_TARGETS,
+    RECOVERY_HALF_LIFE_DAYS,
+    MUSCLE_TARGET_BOUNDS,
+    clampMuscleTarget,
+    fatigueToColor,
+    fatigueStatus,
+    computeMuscleRecoverySummary
+  };
+}
+if (typeof window !== 'undefined') {
+  window.DEFAULT_WEEKLY_MUSCLE_TARGETS = DEFAULT_WEEKLY_MUSCLE_TARGETS;
+  window.MUSCLE_TARGET_BOUNDS = MUSCLE_TARGET_BOUNDS;
+  window.clampMuscleTarget = clampMuscleTarget;
+  window.fatigueToColor = fatigueToColor;
+  window.fatigueStatus = fatigueStatus;
+  window.computeMuscleRecoverySummary = computeMuscleRecoverySummary;
+}

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -222,6 +222,32 @@
         </label>
 
         <button type="submit" style="width:100%;margin-top:8px;">Save SMART Goal</button>
+    <section class="panel profile-section" aria-labelledby="sMuscleTargetsHeading">
+      <h3 id="sMuscleTargetsHeading">Weekly Muscle Set Targets</h3>
+      <p style="font-size:0.83rem;color:var(--secondary-text);margin:0 0 10px;">Sets per week used by the Recovery Map on the Progress tab. Leave the defaults if you're not sure.</p>
+      <div class="profile-field-grid" id="muscleTargetsGrid">
+        <label>Chest<input type="number" id="muscleTarget_chest" min="0" max="24" step="1"></label>
+        <label>Back<input type="number" id="muscleTarget_back" min="0" max="28" step="1"></label>
+        <label>Shoulders<input type="number" id="muscleTarget_shoulders" min="0" max="24" step="1"></label>
+        <label>Traps<input type="number" id="muscleTarget_traps" min="0" max="18" step="1"></label>
+        <label>Biceps<input type="number" id="muscleTarget_biceps" min="0" max="22" step="1"></label>
+        <label>Triceps<input type="number" id="muscleTarget_triceps" min="0" max="20" step="1"></label>
+        <label>Forearms<input type="number" id="muscleTarget_forearms" min="0" max="18" step="1"></label>
+        <label>Quads<input type="number" id="muscleTarget_quads" min="0" max="24" step="1"></label>
+        <label>Hamstrings<input type="number" id="muscleTarget_hamstrings" min="0" max="20" step="1"></label>
+        <label>Glutes<input type="number" id="muscleTarget_glutes" min="0" max="20" step="1"></label>
+        <label>Calves<input type="number" id="muscleTarget_calves" min="0" max="22" step="1"></label>
+        <label>Adductors<input type="number" id="muscleTarget_adductors" min="0" max="14" step="1"></label>
+        <label>Abductors<input type="number" id="muscleTarget_abductors" min="0" max="14" step="1"></label>
+        <label>Abs<input type="number" id="muscleTarget_abs" min="0" max="22" step="1"></label>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center;margin-top:10px;">
+        <button type="button" id="saveMuscleTargetsButton">Save Weekly Targets</button>
+        <button type="button" id="resetMuscleTargetsButton" class="secondary">Reset to Defaults</button>
+      </div>
+      <div id="muscleTargetsFeedback" style="font-size:0.85rem;margin-top:8px;"></div>
+    </section>
+
       </form>
       <div id="smartGoalFeedback" style="font-size:0.9rem;margin-top:8px;"></div>
     </section>

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -856,6 +856,7 @@ function injectSettingsMarkup() {
       applySettingsToUI(hydrated);
       renderProfileGamificationSummary(container);
       if (typeof initSmartGoalForm === 'function') initSmartGoalForm();
+      if (typeof initMuscleTargetsForm === 'function') initMuscleTargetsForm();
       if (typeof applyTrainingModeClasses === 'function') applyTrainingModeClasses(localStorage.getItem('trainingMode') || 'bodybuilding');
       // Wire up appModeSelect and coachModeToggle here — settings.html is
       // fetched async so these elements don't exist at DOMContentLoaded.

--- a/tests/recoveryMap.test.js
+++ b/tests/recoveryMap.test.js
@@ -1,0 +1,113 @@
+require('../exerciseMuscleMap');
+const {
+  DEFAULT_WEEKLY_MUSCLE_TARGETS,
+  MUSCLE_TARGET_BOUNDS,
+  clampMuscleTarget,
+  fatigueToColor,
+  fatigueStatus,
+  computeMuscleRecoverySummary
+} = require('../recoveryMap');
+
+describe('fatigueToColor / fatigueStatus', () => {
+  test('interpolates across the fresh -> overreached scale', () => {
+    expect(fatigueToColor(0)).toBe('rgb(242,236,224)');
+    expect(fatigueToColor(100)).toBe('rgb(220,53,69)');
+    expect(fatigueToColor(-20)).toBe(fatigueToColor(0));
+    expect(fatigueToColor(150)).toBe(fatigueToColor(100));
+  });
+
+  test('labels status tiers', () => {
+    expect(fatigueStatus(10)).toBe('Fresh');
+    expect(fatigueStatus(40)).toBe('Moderate');
+    expect(fatigueStatus(70)).toBe('Fatigued');
+    expect(fatigueStatus(90)).toBe('Overreached');
+  });
+});
+
+describe('computeMuscleRecoverySummary', () => {
+  const now = new Date('2026-07-16T12:00:00Z');
+
+  test('counts sets in the trailing 7-day window per muscle', () => {
+    const workouts = [
+      {
+        date: '2026-07-15',
+        log: [
+          { exercise: 'Bench Press', repsArray: [8, 8, 8], weightsArray: [100, 100, 100] }
+        ]
+      },
+      {
+        date: '2026-07-01', // outside the 7-day window
+        log: [
+          { exercise: 'Bench Press', repsArray: [8, 8], weightsArray: [90, 90] }
+        ]
+      }
+    ];
+
+    const summary = computeMuscleRecoverySummary(workouts, { now });
+    const chest = summary.find((row) => row.muscle === 'chest');
+    expect(chest.sets).toBe(3);
+    expect(chest.target).toBe(DEFAULT_WEEKLY_MUSCLE_TARGETS.chest);
+    expect(chest.daysSinceTrained).toBe(1);
+  });
+
+  test('gives muscles trained today a higher fatigue score than untouched ones', () => {
+    const workouts = [
+      {
+        date: '2026-07-16',
+        log: [
+          { exercise: 'Back Squat', repsArray: [5, 5, 5, 5], weightsArray: [140, 140, 140, 140] }
+        ]
+      }
+    ];
+
+    const summary = computeMuscleRecoverySummary(workouts, { now });
+    const quads = summary.find((row) => row.muscle === 'quads');
+    const calves = summary.find((row) => row.muscle === 'calves');
+    expect(quads.fatigueScore).toBeGreaterThan(calves.fatigueScore);
+    expect(calves.daysSinceTrained).toBeNull();
+  });
+
+  test('applies whole-body soreness as a small uniform nudge', () => {
+    const workouts = [];
+    const sore = computeMuscleRecoverySummary(workouts, { now, soreness: 1 });
+    const fresh = computeMuscleRecoverySummary(workouts, { now, soreness: 5 });
+    const soreChest = sore.find((row) => row.muscle === 'chest');
+    const freshChest = fresh.find((row) => row.muscle === 'chest');
+    expect(soreChest.fatigueScore).toBeGreaterThan(freshChest.fatigueScore);
+  });
+
+  test('respects custom weekly targets', () => {
+    const summary = computeMuscleRecoverySummary([], { now, weeklyTargets: { chest: 20 } });
+    const chest = summary.find((row) => row.muscle === 'chest');
+    expect(chest.target).toBe(20);
+  });
+
+  test('clamps out-of-range custom targets to the muscle bounds', () => {
+    const summary = computeMuscleRecoverySummary([], {
+      now,
+      weeklyTargets: { chest: 999, adductors: -5 }
+    });
+    const chest = summary.find((row) => row.muscle === 'chest');
+    const adductors = summary.find((row) => row.muscle === 'adductors');
+    expect(chest.target).toBe(MUSCLE_TARGET_BOUNDS.chest.max);
+    expect(adductors.target).toBe(MUSCLE_TARGET_BOUNDS.adductors.min);
+  });
+});
+
+describe('MUSCLE_TARGET_BOUNDS / clampMuscleTarget', () => {
+  test('every default target falls within its own bounds', () => {
+    Object.entries(DEFAULT_WEEKLY_MUSCLE_TARGETS).forEach(([muscle, value]) => {
+      const bounds = MUSCLE_TARGET_BOUNDS[muscle];
+      expect(bounds).toBeDefined();
+      expect(value).toBeGreaterThanOrEqual(bounds.min);
+      expect(value).toBeLessThanOrEqual(bounds.max);
+    });
+  });
+
+  test('clampMuscleTarget clamps to [min, max] and falls back for unknown muscles', () => {
+    expect(clampMuscleTarget('chest', -10)).toBe(0);
+    expect(clampMuscleTarget('chest', 999)).toBe(MUSCLE_TARGET_BOUNDS.chest.max);
+    expect(clampMuscleTarget('chest', 12)).toBe(12);
+    expect(clampMuscleTarget('unknownMuscle', 999)).toBe(30);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **Recovery** sub-tab under Progress showing a front/back body heatmap (fresh -> overreached color scale) plus a per-muscle table, driven by real trailing-7-day set volume and a fatigue score that blends weekly volume ratio, per-muscle recency decay, and today's whole-body soreness from the readiness check-in.
- Weekly set targets are configurable from **Settings > Goals > Weekly Muscle Set Targets**, with sane min/max bounds (roughly bracketing MEV-MRV volume landmarks) enforced both in the UI and in `computeMuscleRecoverySummary` itself.
- New pure-logic module `recoveryMap.js` (fatigue scoring, color scale, bounds/clamping) is fully unit tested independently of the DOM.

## Notes for reviewers
- This branch was rebased onto the current `origin/main` (which already includes the `fix/program-builder-crash-pdf-export` work and a newer Progress-tab mini-nav redesign that didn't exist when this feature was originally built). The Recovery button/panel and the `initMuscleTargetsForm()` wiring were manually re-merged into that newer structure — worth a careful look at `index.html` around the Progress tab's `pSub_charts` section and the `showTab('settingsTab')` case, since a first-pass auto-merge there silently produced broken/misplaced code that had to be hand-fixed (verified via a Node syntax check across every inline `<script>` block, plus live browser testing of the full Recovery flow with seeded workout data).
- v1 simplification (flagged, not a gap to silently ship around): muscle attribution is still primary-only (uses the existing single-primary `exerciseMuscleMap.js`), not the secondary/tertiary contribution model discussed for a future pass.

## Test plan
- [x] `npx jest tests/recoveryMap.test.js tests/exerciseMuscleMap.test.js tests/bodybuildingProgress.test.js` — 29/29 passing
- [x] Verified live: seeded `workouts_<user>` in localStorage, drove the actual UI (button click, not just function calls) to confirm the Recovery panel renders 14 muscle rows with correct set counts/day labels/fatigue-sorted order and correctly interpolated heatmap colors
- [x] Verified the Settings > Goals weekly-targets form: prefill from defaults, save with clamping (999 -> max, -50 -> min), reset-to-defaults, and confirmed a saved target flows through to the Recovery table
- [x] Confirmed no JS syntax errors across all 9 inline `<script>` blocks in `index.html` after the manual re-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)