### PR TITLE
fix: SW navigate fetch bypasses HTTP cache, not just SW cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -121,10 +121,14 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Navigation requests (HTML pages): network-first so users always get latest
+  // Navigation requests (HTML pages): network-first so users always get latest.
+  // Use cache: 'reload' to bypass the browser/CDN HTTP cache (GitHub Pages
+  // sends Cache-Control: max-age=600 on index.html) - otherwise a plain
+  // fetch(request) can still return a stale response for up to 10 minutes
+  // after a deploy, even though this handler is "network-first".
   if (request.mode === 'navigate' || url.pathname === '/' || url.pathname.endsWith('.html')) {
     event.respondWith(
-      fetch(request).then((response) => {
+      fetch(request.url, { cache: 'reload' }).then((response) => {
         if (response.ok) {
           const clone = response.clone();
           caches.open(CACHE_STATIC).then((c) => c.put(request, clone));


### PR DESCRIPTION
## Summary
- `sw.js`'s "network-first" strategy for HTML/navigation requests used a plain `fetch(request)`, which still honors the browser/CDN HTTP cache (`Cache-Control: max-age=600` on GitHub Pages' `index.html`).
- That meant a real network round-trip wasn't guaranteed even under "network-first" — a stale cached response could still be served for up to 10 minutes after a deploy.
- Switched to `fetch(request.url, { cache: 'reload' })`, which forces the browser to revalidate/bypass its HTTP cache and hit the network.

## Context
Found this while verifying the previous login-breaking syntax error fix (see the prior PR). The fix was confirmed live and correct via `curl` and an in-page `fetch(..., {cache:'no-store'})`, but a plain page reload in the same tab still rendered the old broken version — traced to the `max-age=600` cache header being honored inside the SW's own fetch call.

## Test plan
- [ ] Deploy, then immediately reload the site in a browser that already cached the previous version — confirm it gets the new content right away instead of waiting out the cache window

🤖 Generated with [Claude Code](https://claude.com/claude-code)