### PR TITLE
fix: null-check macroBmrFormula in calculateMacroTargets

### DIFF
--- a/index.html
+++ b/index.html
@@ -7571,7 +7571,7 @@ function calculateMacroTargets(goalOverride, rateOverride) {
   const activity = d.activityFactor;
   const goal = goalOverride || document.getElementById("macroGoal").value || "maintain";
   const rate = rateOverride || document.getElementById("macroRate").value || "moderate";
-  const formula = document.getElementById("macroBmrFormula").value || "mifflin";
+  const formula = document.getElementById("macroBmrFormula")?.value || "mifflin";
   const bodyFat = Number.isFinite(bodyFatValue) ? bodyFatValue : null;
   const heightM = heightCm / 100;
 


### PR DESCRIPTION
## Summary
- `calculateMacroTargets()` is called on page-load init (`macrosFeatures.js`'s `initTrainingToggle` → `applyDayPreset`) whenever `hasMacroInputs()` finds a saved `personalDetails` record in localStorage — regardless of which tab is actually active/mounted.
- `document.getElementById("macroBmrFormula").value` had no null-check, unlike the `?.checked` pattern already used a few lines below for `adjustVegetarian`/`adjustLowCarb`/`adjustHighFat`.
- Any user with saved personal details who wasn't on the Macros tab at load time got `Uncaught TypeError: Cannot read properties of null (reading 'value')`, aborting whatever init chain triggered it.

## Test plan
- [ ] With `personalDetails` saved in localStorage and a tab other than Macros active at load, confirm no console error fires
- [ ] Visit the Macros tab and confirm BMR formula selection still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)