### PR TITLE
fix: wire exercise history lookup to real workout storage and add trend icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5225,95 +5225,71 @@ function formatLastTimeSets(exercise) {
   return summary.length ? summary.join(', ') : 'No sets recorded last time';
 }
 
-function getLastExerciseLogEntry(exerciseName) {
-  if (typeof loadLogsFromLocalStorage !== 'function') return null;
-  const targetName = (exerciseName || '').trim().toLowerCase();
+function _bestSetE1RM(exercise) {
+  const reps = Array.isArray(exercise?.repsArray) ? exercise.repsArray : [];
+  const weights = Array.isArray(exercise?.weightsArray) ? exercise.weightsArray : [];
+  let best = 0;
+  reps.forEach((r, i) => {
+    const rep = Number(r) || 0;
+    const weight = Number(weights[i]) || 0;
+    if (rep <= 0) return;
+    const e1rm = rep === 1 ? weight : weight * (1 + rep / 30);
+    if (e1rm > best) best = e1rm;
+  });
+  return Math.round(best * 10) / 10;
+}
+
+/**
+ * Find the most recent logged entry of `exerciseName` strictly before
+ * `workoutIndex`, so cards rendered for older workouts compare against
+ * what was actually logged before them (not just the globally latest).
+ */
+function getPreviousExerciseEntry(exerciseName, workoutIndex) {
+  const targetName = String(exerciseName || '').trim().toLowerCase();
   if (!targetName) return null;
 
-  const currentUserId = typeof currentUser !== 'undefined' ? currentUser : null;
-  const logs = loadLogsFromLocalStorage()
-    .slice()
-    .sort((a, b) => new Date(b.date) - new Date(a.date));
+  // Workouts older than 7 days are moved out of `workouts_${user}` into
+  // `workoutHistory_${user}` by archiveOldWorkouts() — both must be
+  // searched or anything logged more than a week ago is invisible here.
+  const active = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
+  const archived = JSON.parse(localStorage.getItem(`workoutHistory_${currentUser}`)) || [];
+  const currentDate = active[workoutIndex]?.date || '';
 
-  for (const log of logs) {
-    if (currentUserId && log?.userId && log.userId !== currentUserId) continue;
-    const exercises = Array.isArray(log?.exercises) ? log.exercises : [];
-    const match = exercises.find(ex => (ex?.name || '').trim().toLowerCase() === targetName);
-    if (match) {
-      return { log, exercise: match };
+  let best = null;
+  const consider = (w, activeIdx) => {
+    if (activeIdx === workoutIndex || !Array.isArray(w?.log)) return;
+    const wDate = w.date || '';
+    const isEarlier = currentDate
+      ? (wDate < currentDate || (wDate === currentDate && activeIdx !== undefined && activeIdx < workoutIndex))
+      : (activeIdx === undefined || activeIdx < workoutIndex);
+    if (!isEarlier) return;
+
+    const match = w.log.find(e => String(e?.exercise || '').trim().toLowerCase() === targetName);
+    if (!match) return;
+
+    if (!best || wDate > best.date) {
+      best = { date: wDate, title: w.title || w.name || 'Workout', exercise: match };
     }
-  }
+  };
 
-  return null;
+  archived.forEach(w => consider(w, undefined));
+  active.forEach((w, idx) => consider(w, idx));
+
+  return best;
 }
 
-function getCurrentHistoryUserId() {
-  return getActiveUsername();
-}
+/** Compare current entry's best-set e1RM against the previous session's. */
+function getExerciseTrend(entry, previousExercise) {
+  if (!previousExercise) return null;
 
-function loadResistanceHistoryForUser(userId) {
-  if (typeof loadLogsFromLocalStorage !== 'function') return [];
-  const logs = loadLogsFromLocalStorage();
-  return logs.filter(log => !log?.userId || !userId || log.userId === userId);
-}
+  const currentE1RM = _bestSetE1RM(entry);
+  const previousE1RM = _bestSetE1RM(previousExercise);
+  if (!currentE1RM || !previousE1RM) return null;
 
-function getLastExerciseHistory(exerciseName, userId) {
-  if (!exerciseName) return null;
-  const userHistory = loadResistanceHistoryForUser(userId)
-    .slice()
-    .sort((a, b) => new Date(b.date) - new Date(a.date));
-  const normalizedName = exerciseName.toLowerCase();
-  for (const log of userHistory) {
-    const exercise = (log.exercises || []).find(ex => (ex.name || '').toLowerCase() === normalizedName);
-    if (exercise) {
-      return { log, exercise };
-    }
-  }
-  return null;
-}
-
-function createLastTimeCard(exerciseName) {
-  const userId = getCurrentHistoryUserId();
-  const last = getLastExerciseHistory(exerciseName, userId);
-  if (!last) return null;
-
-  const card = document.createElement('div');
-  card.className = 'last-time-card';
-
-  const title = document.createElement('div');
-  title.className = 'last-time-title';
-  title.textContent = 'Last time';
-  card.appendChild(title);
-
-  const meta = document.createElement('div');
-  meta.className = 'last-time-meta';
-  const dateLabel = last.log?.date ? new Date(last.log.date).toLocaleDateString() : 'Unknown date';
-  const workoutTitle = last.log?.title || last.log?.name || 'Workout';
-  meta.textContent = `${dateLabel} • ${workoutTitle}`;
-  card.appendChild(meta);
-
-  const setsRow = document.createElement('div');
-  setsRow.className = 'last-time-sets';
-  const reps = Array.isArray(last.exercise?.repsArray) ? last.exercise.repsArray : [];
-  const weights = Array.isArray(last.exercise?.weightsArray) ? last.exercise.weightsArray : [];
-  const setCount = Math.max(reps.length, weights.length);
-  if (!setCount) {
-    const empty = document.createElement('span');
-    empty.textContent = 'No sets recorded.';
-    setsRow.appendChild(empty);
-  } else {
-    for (let i = 0; i < setCount; i += 1) {
-      const chip = document.createElement('span');
-      chip.className = 'last-time-chip';
-      const rep = reps[i] ?? '-';
-      const weight = weights[i] ?? '-';
-      chip.textContent = `${weight} × ${rep}`;
-      setsRow.appendChild(chip);
-    }
-  }
-
-  card.appendChild(setsRow);
-  return card;
+  const change = (currentE1RM - previousE1RM) / previousE1RM;
+  if (change > 0.02)  return { icon: '📈', label: 'Trending up vs last time', cls: 'trend-up' };
+  if (change < -0.02) return { icon: '📉', label: 'Trending down vs last time', cls: 'trend-down' };
+  return { icon: '➡️', label: 'Holding steady vs last time', cls: 'trend-flat' };
 }
 
 function createExerciseCard(workoutIndex, entryIndex, entry) {
@@ -5328,9 +5304,25 @@ function createExerciseCard(workoutIndex, entryIndex, entry) {
   tag.textContent = entry.muscleGroup || entry.primaryMuscle || 'Exercise';
   header.appendChild(tag);
 
+  const titleRow = document.createElement('div');
+  titleRow.className = 'exercise-title-row';
+
   const title = document.createElement('h3');
   title.textContent = entry.exercise || 'Exercise';
-  header.appendChild(title);
+  titleRow.appendChild(title);
+
+  const previous = getPreviousExerciseEntry(entry.exercise, workoutIndex);
+  const trend = getExerciseTrend(entry, previous?.exercise);
+  if (trend) {
+    const trendBadge = document.createElement('span');
+    trendBadge.className = `exercise-trend-badge ${trend.cls}`;
+    trendBadge.title = trend.label;
+    trendBadge.setAttribute('aria-label', trend.label);
+    trendBadge.textContent = trend.icon;
+    titleRow.appendChild(trendBadge);
+  }
+
+  header.appendChild(titleRow);
 
   const headerMenuButton = document.createElement('button');
   headerMenuButton.type = 'button';
@@ -5342,8 +5334,7 @@ function createExerciseCard(workoutIndex, entryIndex, entry) {
 
   card.appendChild(header);
 
-  const lastEntry = getLastExerciseLogEntry(entry.exercise || 'Exercise');
-  if (lastEntry) {
+  if (previous) {
     const lastPanel = document.createElement('div');
     lastPanel.className = 'last-time-card';
 
@@ -5354,22 +5345,16 @@ function createExerciseCard(workoutIndex, entryIndex, entry) {
 
     const lastMeta = document.createElement('div');
     lastMeta.className = 'last-time-meta';
-    const lastDate = lastEntry.log?.date ? new Date(lastEntry.log.date).toLocaleDateString() : 'Unknown date';
-    const lastWorkoutTitle = lastEntry.log?.title || 'Workout';
-    lastMeta.textContent = `${lastDate} • ${lastWorkoutTitle}`;
+    const lastDate = previous.date ? new Date(previous.date).toLocaleDateString() : 'Unknown date';
+    lastMeta.textContent = `${lastDate} • ${previous.title}`;
     lastPanel.appendChild(lastMeta);
 
     const lastSets = document.createElement('div');
     lastSets.className = 'last-time-sets';
-    lastSets.textContent = formatLastTimeSets(lastEntry.exercise);
+    lastSets.textContent = formatLastTimeSets(previous.exercise);
     lastPanel.appendChild(lastSets);
 
     card.appendChild(lastPanel);
-  }
-
-  const lastTimeCard = createLastTimeCard(entry.exercise || 'Exercise');
-  if (lastTimeCard) {
-    card.appendChild(lastTimeCard);
   }
 
   const goalData = [];

--- a/style.css
+++ b/style.css
@@ -434,6 +434,22 @@ header, .dark-bg, .coach-only {
   font-size: 1.1rem;
 }
 
+.exercise-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.exercise-trend-badge {
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: default;
+}
+
+.exercise-trend-badge.trend-flat {
+  opacity: 0.6;
+}
+
 .exercise-tag {
   background: var(--highlight);
   color: var(--card-bg);


### PR DESCRIPTION
## Summary
- The exercise card's "Last time" comparison depended on `resistanceLogs.js`'s `loadLogsFromLocalStorage()`, which was never `<script>`-included in `index.html` and read from an unrelated, unpopulated `workoutHistory` localStorage key — so the panel silently never rendered.
- Actual workout data lives under `workouts_${user}` (and `workoutHistory_${user}` once `archiveOldWorkouts` moves sessions older than 7 days out of the active list). Replaced the two dead duplicate lookups with a single one that searches both stores for the previous session of the same exercise.
- Added a small trend badge (📈 up / ➡️ flat / 📉 down) next to the exercise name, based on % change in best-set estimated 1RM vs the previous session.

## Test plan
- [x] Seeded `workouts_${user}` / `workoutHistory_${user}` in-browser with progression, stagnation, and regression cases for the same exercise; confirmed correct badge (📈/➡️/📉) and "Last time" panel in each case
- [x] Confirmed a session archived by `archiveOldWorkouts` (>7 days old) is still found and compared against
- [x] Confirmed header layout (exercise tag / title+badge / menu button) is unchanged for cards with no trend data

🤖 Generated with [Claude Code](https://claude.com/claude-code)