### PR TITLE
fix: progress mini-tab switching bug and vertical layout

### DIFF
--- a/css/progress.css
+++ b/css/progress.css
@@ -5,31 +5,53 @@
    Depends on: tokens.css
    ============================================================= */
 
-/* ── Three-column layout ────────────────────────────────────── */
+/* ── Layout: horizontal mini-tab nav on top, chart panel below ── */
 
 .progress-layout {
-  display: grid;
-  grid-template-columns: 200px 1fr 300px;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 
+.progress-nav {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding-bottom: 2px;
+}
+
+.progress-nav::-webkit-scrollbar {
+  display: none;
+}
+
 .progress-nav button {
-  display: block;
-  margin-bottom: 0.5rem;
-  width: 100%;
+  flex: none;
+  margin: 0;
+  padding: 8px 14px;
+  border-radius: 20px;
+  border: 1.5px solid var(--border-color);
+  background: var(--elevated-bg);
+  color: var(--secondary-text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .progress-nav button.active {
   background-color: var(--primary);
-  color: var(--text-color);
+  border-color: var(--primary);
+  color: #fff;
 }
 
-/* Stack columns on mobile */
-@media (max-width: 600px) {
-  .progress-layout {
-    display: block;
-  }
+.progress-nav input[type="date"] {
+  flex: none;
+  width: 132px;
+  margin: 0 0 0 4px;
+}
 
+@media (max-width: 600px) {
   #progressCanvas {
     height: 300px;
   }

--- a/index.html
+++ b/index.html
@@ -13742,8 +13742,6 @@ function refreshProgress() {
   const id = activeBtn.id;
   if (id === 'exerciseProgressBtn') {
     // Re-run the chart with the updated date range
-  } else if (id === 'recoveryProgressBtn') {
-    showRecoveryProgress();
     const picker = document.querySelector('#exPicker');
     const metric = document.querySelector('.ex-metric-btn.active')?.dataset.metric || 'weight';
     if (picker) renderExerciseChart(picker.value || null, metric);


### PR DESCRIPTION
## Summary
- Fixed `refreshProgress()` in `index.html`: changing the date range while on the **Exercise** progress sub-tab was a no-op (dead branch with only a leftover comment), while the **Recovery** branch carried stray exercise-chart-refresh code that never applied. Moved the logic to the correct branch and removed the dead duplicate `recoveryProgressBtn` condition.
- Restyled the Workout / Cardio / Bodyweight / Recovery / Exercise progress nav (`css/progress.css`) from a full-width vertical button stack (sitting in an unused 3-column grid) into a horizontal, scrollable pill-tab row on top — consistent with the app's other mini-tab nav styling (`.log-subtabs`). Each mini tab still shows only its own content; verified no overlap and no console errors.

## Test plan
- [x] Loaded the app locally, forced the Progress tab active, and exercised the outer (Charts/PRs/XP/Tools) and inner (Workout/Cardio/Bodyweight/Recovery/Exercise) mini-tab nav via DOM/JS checks — exactly one panel active at a time, no console errors.
- [x] Confirmed the date-range input now triggers `renderExerciseChart` when the Exercise sub-tab is active.
- [x] Verified the inner nav renders as a single horizontal scrollable row at both desktop (1280px) and mobile (375px) widths, instead of the previous ~384px-tall vertical stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)