### PR TITLE
Session rating popup + Maxed Out flag for machine exercises

### DIFF
--- a/archiveOldWorkouts.js
+++ b/archiveOldWorkouts.js
@@ -21,7 +21,8 @@ function toResistanceLog(workout, currentUser) {
     title: (workout && (workout.title || workout.name)) || 'Resistance Workout',
     userId: (workout && (workout.userId || workout.username || workout.user)) || currentUser || null,
     exercises,
-    prEvents: Array.isArray(workout && workout.prEvents) ? workout.prEvents.slice() : []
+    prEvents: Array.isArray(workout && workout.prEvents) ? workout.prEvents.slice() : [],
+    sessionRating: (workout && workout.sessionRating) || null
   };
 }
 
@@ -61,12 +62,14 @@ function appendToLegacyHistoryStore(key, workout, log) {
     name: log.title,
     userId: log.userId,
     username: log.userId,
+    sessionRating: log.sessionRating || null,
     workout: {
       id: (workout && workout.id) || log.id || `archived-${log.date}`,
       date: log.date,
       title: log.title,
       name: log.title,
       userId: log.userId,
+      sessionRating: log.sessionRating || null,
       exercises: log.exercises.map(ex => ({
         name: ex.name,
         sets: Array.from(

--- a/css/log.css
+++ b/css/log.css
@@ -698,3 +698,68 @@
 .hist-subview.active {
   display: block;
 }
+
+/* ── Session rating (End Workout feedback) ───────────────────── */
+
+.session-rating-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 8px;
+}
+
+.rating-question label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--secondary-text);
+  margin-bottom: 6px;
+}
+
+.rating-scale {
+  display: flex;
+  gap: 6px;
+}
+
+.rating-scale-btn {
+  flex: 1;
+  padding: 8px 0;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--secondary-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.rating-scale-btn.selected {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.rating-scale-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.session-rating-summary {
+  font-size: 0.78rem;
+  color: var(--secondary-text);
+  margin: 4px 0 0;
+}
+
+.rate-session-btn {
+  margin-top: 6px;
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 0.78rem;
+  color: var(--secondary-text);
+  cursor: pointer;
+}

--- a/css/log.css
+++ b/css/log.css
@@ -270,6 +270,16 @@
   color: var(--primary, #5fa87e);
 }
 
+.maxed-out-pill {
+  margin: 8px 0;
+}
+
+.maxed-out-pill:has(input:checked) {
+  background: rgba(230, 168, 23, 0.14);
+  border-color: #e6a817;
+  color: #e6a817;
+}
+
 .set-remove-btn {
   width: 28px;
   height: 28px;

--- a/history.js
+++ b/history.js
@@ -485,6 +485,7 @@ function normalizeHistoryItem(item) {
     title: item?.title || workout?.title || workout?.name || 'Workout',
     date: item?.date || workout?.date || workout?.createdAt,
     exercises,
+    sessionRating: item?.sessionRating || workout?.sessionRating || null,
     workout
   };
 }
@@ -511,15 +512,32 @@ function renderHistoryList(containerEl) {
   containerEl.appendChild(list);
 }
 
+const SESSION_RATING_LABELS = {
+  progressive: 'Progressive',
+  fatigue: 'Fatigue',
+  missedWeightGoal: 'Weight goal',
+  missedRepGoal: 'Rep goal'
+};
+
+function formatSessionRatingSummary(sessionRating) {
+  if (!sessionRating) return '';
+  return Object.keys(SESSION_RATING_LABELS)
+    .filter(key => sessionRating[key] != null)
+    .map(key => `${SESSION_RATING_LABELS[key]} ${sessionRating[key]}/5`)
+    .join(' · ');
+}
+
 function renderHistoryDetail(containerEl, log) {
   const title = log?.title || 'Resistance Workout';
   const dateLabel = formatWorkoutDate(log?.date);
   const exercises = Array.isArray(log?.exercises) ? log.exercises : [];
+  const ratingSummary = formatSessionRatingSummary(log?.sessionRating);
 
   containerEl.innerHTML = `
     <button class="adv-btn history-back-btn" id="historyBackBtn">← Back</button>
     <h3 style="margin-top:12px;">${title}</h3>
     <div class="meta">${dateLabel}</div>
+    ${ratingSummary ? `<div class="session-rating-summary">${ratingSummary}</div>` : ''}
     <div class="history-detail-list">
       ${exercises.map(ex => {
         const reps = Array.isArray(ex?.repsArray) ? ex.repsArray : [];

--- a/index.html
+++ b/index.html
@@ -5972,6 +5972,101 @@ if (typeof window !== 'undefined' && window.addEventListener) {
 }
 document.addEventListener('scroll', closeContextMenu, true);
 
+/* ── Session rating (End Workout feedback) ───────────────────── */
+
+const SESSION_RATING_QUESTIONS = [
+  { key: 'progressive', label: 'Progressive overload', low: 'No, same or less', high: 'Yes, clearly more' },
+  { key: 'fatigue', label: 'Fatigue', low: 'Fresh', high: 'Extremely fatigued' },
+  { key: 'missedWeightGoal', label: 'Weight goal', low: 'Hit it', high: 'Missed it badly' },
+  { key: 'missedRepGoal', label: 'Rep goal', low: 'Hit it', high: 'Missed it badly' }
+];
+
+let _sessionRatingWorkoutIndex = null;
+let _sessionRatingDraft = {};
+
+function _findWorkoutIndexForRating(workouts) {
+  const today = new Date().toISOString().split('T')[0];
+  const todayIdx = workouts.findIndex(w => w?.date === today && Array.isArray(w.log) && w.log.length);
+  if (todayIdx !== -1) return todayIdx;
+  for (let i = workouts.length - 1; i >= 0; i--) {
+    if (Array.isArray(workouts[i]?.log) && workouts[i].log.length) return i;
+  }
+  return -1;
+}
+
+function closeSessionRatingModal() {
+  document.getElementById('sessionRatingModalOverlay')?.remove();
+  _sessionRatingWorkoutIndex = null;
+  _sessionRatingDraft = {};
+}
+
+function openSessionRatingModal(workoutIndex) {
+  const _logUser = window.coachLoggingClient || currentUser;
+  const workouts = JSON.parse(localStorage.getItem(`workouts_${_logUser}`)) || [];
+  const workout = workouts[workoutIndex];
+  if (!workout) return;
+
+  closeSessionRatingModal();
+  _sessionRatingWorkoutIndex = workoutIndex;
+  _sessionRatingDraft = { ...(workout.sessionRating || {}) };
+
+  const modal = document.createElement('div');
+  modal.className = 'gdpr-modal-overlay';
+  modal.id = 'sessionRatingModalOverlay';
+  modal.innerHTML = `
+    <div class="gdpr-modal">
+      <h3>How did that session go?</h3>
+      <p>Rate each 1–5. Optional — skip if you'd rather not.</p>
+      <div class="session-rating-form">
+        ${SESSION_RATING_QUESTIONS.map(q => `
+          <div class="rating-question">
+            <label>${q.label}</label>
+            <div class="rating-scale" data-question="${q.key}">
+              ${[1, 2, 3, 4, 5].map(v => `<button type="button" class="rating-scale-btn${_sessionRatingDraft[q.key] === v ? ' selected' : ''}" data-question="${q.key}" data-value="${v}">${v}</button>`).join('')}
+            </div>
+            <div class="rating-scale-labels"><span>${q.low}</span><span>${q.high}</span></div>
+          </div>
+        `).join('')}
+      </div>
+      <div class="gdpr-modal-actions">
+        <button class="gdpr-export-btn" onclick="closeSessionRatingModal()">Skip</button>
+        <button class="gdpr-save-btn" onclick="submitSessionRating()">Save</button>
+      </div>
+    </div>`;
+  document.body.appendChild(modal);
+
+  modal.querySelectorAll('.rating-scale-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const { question, value } = btn.dataset;
+      _sessionRatingDraft[question] = Number(value);
+      modal.querySelectorAll(`.rating-scale-btn[data-question="${question}"]`).forEach(b => {
+        b.classList.toggle('selected', b.dataset.value === value);
+      });
+    });
+  });
+}
+
+function submitSessionRating() {
+  const workoutIndex = _sessionRatingWorkoutIndex;
+  const draft = _sessionRatingDraft;
+  closeSessionRatingModal();
+  if (workoutIndex === null) return;
+
+  const _logUser = window.coachLoggingClient || currentUser;
+  const workouts = JSON.parse(localStorage.getItem(`workouts_${_logUser}`)) || [];
+  const workout = workouts[workoutIndex];
+  if (!workout || !Object.keys(draft).length) return;
+
+  workout.sessionRating = { ...draft, ratedAt: new Date().toISOString() };
+  localStorage.setItem(`workouts_${_logUser}`, JSON.stringify(workouts));
+  renderWorkouts();
+  if (typeof showToast === 'function') showToast('Session rating saved.');
+}
+
+window.openSessionRatingModal = openSessionRatingModal;
+window.closeSessionRatingModal = closeSessionRatingModal;
+window.submitSessionRating = submitSessionRating;
+
 function renderWorkouts() {
   const _logUser = window.coachLoggingClient || currentUser;
   archiveOldWorkouts(_logUser);
@@ -6065,6 +6160,26 @@ function renderWorkouts() {
       rest.textContent = `Rest Breaks: ${workout.restBreaks.join(', ')} minutes`;
       meta.appendChild(rest);
     }
+
+    if (workout.sessionRating) {
+      const ratingLabels = { progressive: 'Progressive', fatigue: 'Fatigue', missedWeightGoal: 'Weight goal', missedRepGoal: 'Rep goal' };
+      const parts = Object.keys(ratingLabels)
+        .filter(key => workout.sessionRating[key] != null)
+        .map(key => `${ratingLabels[key]} ${workout.sessionRating[key]}/5`);
+      if (parts.length) {
+        const ratingSummary = document.createElement('p');
+        ratingSummary.className = 'session-rating-summary';
+        ratingSummary.textContent = parts.join(' · ');
+        meta.appendChild(ratingSummary);
+      }
+    }
+
+    const rateSessionButton = document.createElement('button');
+    rateSessionButton.type = 'button';
+    rateSessionButton.className = 'rate-session-btn';
+    rateSessionButton.textContent = workout.sessionRating ? 'Edit Rating' : 'Rate Session';
+    rateSessionButton.addEventListener('click', () => openSessionRatingModal(workoutIndex));
+    meta.appendChild(rateSessionButton);
 
     const shareWorkoutButton = document.createElement('button');
     shareWorkoutButton.type = 'button';
@@ -15045,6 +15160,13 @@ function showHistoryMiniTab(type) {
         // stay visible in the Log tab until archiveOldWorkouts() ages it out.
         renderWorkouts();
         if (typeof renderWorkoutHistory === 'function') renderWorkoutHistory();
+
+        if (typeof openSessionRatingModal === 'function') {
+          const _logUser = window.coachLoggingClient || currentUser;
+          const _workoutsForRating = JSON.parse(localStorage.getItem(`workouts_${_logUser}`)) || [];
+          const _ratingIdx = _findWorkoutIndexForRating(_workoutsForRating);
+          if (_ratingIdx !== -1) openSessionRatingModal(_ratingIdx);
+        }
       });
     }
 

--- a/index.html
+++ b/index.html
@@ -681,6 +681,12 @@
             </select>
           </div>
 
+          <!-- Machine at its weight ceiling — can't add more load next time -->
+          <label class="set-opt-pill maxed-out-pill" title="This machine/exercise is at its weight limit — progression suggestions will focus on reps instead of weight.">
+            <input type="checkbox" id="maxedOutToggle" />
+            <span>🔒 Maxed Out</span>
+          </label>
+
           <!-- Dynamically generated set inputs -->
           <div id="setInputsContainer"></div>
 
@@ -4791,6 +4797,7 @@ function addLogEntry() {
   const repGoal = +document.getElementById("repGoal").value;
   const targetRPE = parseFloat(document.getElementById("targetRPE")?.value) || null;
   const targetRIR = document.getElementById("targetRIR")?.value !== '' ? parseInt(document.getElementById("targetRIR")?.value, 10) : null;
+  const maxedOut = document.getElementById("maxedOutToggle")?.checked || false;
   const unit = document.getElementById("weightUnit").value || 'kg';
   const dateInput = document.getElementById("entryDate");
   const date = dateInput && dateInput.value ? dateInput.value : new Date().toISOString().split('T')[0];
@@ -4878,6 +4885,7 @@ function addLogEntry() {
     repGoal,
     targetRPE: Number.isFinite(targetRPE) ? targetRPE : null,
     targetRIR: Number.isFinite(targetRIR) ? targetRIR : null,
+    maxedOut,
   };
   const activeWorkoutIndex = workouts.findIndex(w => w.date === date);
   workouts[activeWorkoutIndex].log.push(newEntry);
@@ -4891,6 +4899,7 @@ function addLogEntry() {
   }
 
   const activeWorkout = workouts[activeWorkoutIndex];
+  if (typeof window.applySessionContext === 'function') window.applySessionContext(activeWorkout);
   const computedMetrics = typeof calculateWorkoutMetrics === 'function'
     ? calculateWorkoutMetrics(activeWorkout)
     : {
@@ -4942,6 +4951,8 @@ function addLogEntry() {
   document.getElementById("goal").value = '';
   document.getElementById("repGoal").value = '';
   document.getElementById("setInputsContainer").innerHTML = '';
+  const maxedOutToggleEl = document.getElementById("maxedOutToggle");
+  if (maxedOutToggleEl) maxedOutToggleEl.checked = false;
   if (dateInput) {
     dateInput.value = new Date().toISOString().split('T')[0];
   }
@@ -5401,6 +5412,14 @@ function createExerciseCard(workoutIndex, entryIndex, entry) {
   const title = document.createElement('h3');
   title.textContent = entry.exercise || 'Exercise';
   titleRow.appendChild(title);
+
+  if (entry.maxedOut) {
+    const maxedBadge = document.createElement('span');
+    maxedBadge.className = 'maxed-out-badge';
+    maxedBadge.title = "At this machine's weight limit — try more reps next time instead of more weight.";
+    maxedBadge.textContent = '🔒 Maxed Out';
+    titleRow.appendChild(maxedBadge);
+  }
 
   const previous = getPreviousExerciseEntry(entry.exercise, workoutIndex);
   const trend = getExerciseTrend(entry, previous?.exercise);
@@ -5925,7 +5944,12 @@ function openContextMenu(event, workoutIndex, entryIndex, setIndex = null) {
     addButton('Backoff', () => changeSetType(workoutIndex, entryIndex, setIndex, 'backoff'));
     addButton('Top Set', () => changeSetType(workoutIndex, entryIndex, setIndex, 'top-set'));
   } else {
+    const _logUserForMenu = window.coachLoggingClient || currentUser;
+    const _workoutsForMenu = JSON.parse(localStorage.getItem(`workouts_${_logUserForMenu}`)) || [];
+    const _entryForMenu = _workoutsForMenu[workoutIndex]?.log?.[entryIndex];
+
     addButton('Add Set', () => addSetToLog(workoutIndex, entryIndex));
+    addButton(_entryForMenu?.maxedOut ? 'Un-mark Maxed Out' : 'Mark as Maxed Out', () => toggleMaxedOut(workoutIndex, entryIndex));
     addButton('Delete Exercise', () => removeLogEntry(workoutIndex, entryIndex));
   }
 
@@ -6332,6 +6356,18 @@ function changeSetType(workoutIndex, entryIndex, setIndex, type) {
   localStorage.setItem(`workouts_${currentUser}`, JSON.stringify(workouts));
   renderWorkouts();
 }
+
+function toggleMaxedOut(workoutIndex, entryIndex) {
+  const _logUser = window.coachLoggingClient || currentUser;
+  const workouts = JSON.parse(localStorage.getItem(`workouts_${_logUser}`)) || [];
+  const entry = workouts[workoutIndex]?.log?.[entryIndex];
+  if (!entry) return;
+
+  entry.maxedOut = !entry.maxedOut;
+  localStorage.setItem(`workouts_${_logUser}`, JSON.stringify(workouts));
+  renderWorkouts();
+}
+window.toggleMaxedOut = toggleMaxedOut;
 
 let restInterval;
 function _updateRestBanner(remaining, total) {
@@ -15142,6 +15178,12 @@ function showHistoryMiniTab(type) {
     // Fetch technique videos shared by this user's coach
     if (typeof loadExerciseVideosForClient === 'function') loadExerciseVideosForClient();
 
+    // Session context (Alt Machine / Alt Gym chips, Vacation/Sick banners) —
+    // was only ever initialized from the login success handlers, so a
+    // returning user restoring a session from localStorage (the normal
+    // day-to-day flow) never saw it rendered. Init it unconditionally here too.
+    if (typeof window.initSessionContext === 'function') window.initSessionContext();
+
     const endWorkoutBtn = document.getElementById('endWorkoutBtn');
     if (endWorkoutBtn) {
       endWorkoutBtn.addEventListener('click', () => {
@@ -15167,6 +15209,10 @@ function showHistoryMiniTab(type) {
           const _ratingIdx = _findWorkoutIndexForRating(_workoutsForRating);
           if (_ratingIdx !== -1) openSessionRatingModal(_ratingIdx);
         }
+
+        // Alt Machine/Alt Gym flags are single-session — reset them once the
+        // workout they were tagging is actually done.
+        if (typeof window.clearSessionContextAfterSave === 'function') window.clearSessionContextAfterSave();
       });
     }
 

--- a/progressiveOverload.js
+++ b/progressiveOverload.js
@@ -143,6 +143,21 @@ function suggestNextSession(exercise, workouts = []) {
   const baselineWeightStep = Math.max(1.25, Math.abs(averageRate.weightDelta) || 2.5);
   const baselineRepStep = Math.max(1, Math.round(Math.abs(averageRate.repDelta) || 1));
 
+  if (lastEntry.maxedOut) {
+    suggestedSets.forEach(set => {
+      set.reps += baselineRepStep;
+    });
+    return {
+      exercise: targetName,
+      unit,
+      strategy: 'maxed-out',
+      averageRate,
+      basedOnSessions: history.length,
+      sets: suggestedSets,
+      message: `Marked as maxed out — this equipment has no more weight to give. Add ${baselineRepStep} rep(s) per set instead, or switch to a harder variation.`
+    };
+  }
+
   if (rpeStatus.failedSets || rpeStatus.anyHighRpe) {
     strategy = 'reduce';
     const dropAmount = roundToIncrement(Math.max(1.25, baselineWeightStep * 0.5), 0.5);

--- a/style.css
+++ b/style.css
@@ -450,6 +450,17 @@ header, .dark-bg, .coach-only {
   opacity: 0.6;
 }
 
+.maxed-out-badge {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #e6a817;
+  background: rgba(230, 168, 23, 0.12);
+  border: 1px solid rgba(230, 168, 23, 0.35);
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+
 .exercise-tag {
   background: var(--highlight);
   color: var(--card-bg);

--- a/tests/archiveOldWorkouts.test.js
+++ b/tests/archiveOldWorkouts.test.js
@@ -32,4 +32,23 @@ describe('archiveOldWorkouts', () => {
     expect(savedHistory).toHaveLength(1);
     expect(savedHistory[0].title).toBe('Old');
   });
+
+  test('carries sessionRating through to the Log History stores', () => {
+    const user = 'u1';
+    const oldDate = new Date(Date.now() - 8 * 86400000).toISOString().split('T')[0];
+    const sessionRating = { progressive: 4, fatigue: 3, missedWeightGoal: 1, missedRepGoal: 2, ratedAt: oldDate };
+    const workouts = [
+      { id: 'w-old', title: 'Old', date: oldDate, log: [{ exercise: 'Squat', repsArray: [5], weightsArray: [100] }], sessionRating }
+    ];
+    localStorage.setItem(`workouts_${user}`, JSON.stringify(workouts));
+
+    archiveOldWorkouts(user, Date.now());
+
+    const genericHistory = JSON.parse(localStorage.getItem('workoutHistory'));
+    const legacyHistory = JSON.parse(localStorage.getItem('tl_workout_history_v1'));
+
+    expect(genericHistory[0].sessionRating).toEqual(sessionRating);
+    expect(legacyHistory[0].sessionRating).toEqual(sessionRating);
+    expect(legacyHistory[0].workout.sessionRating).toEqual(sessionRating);
+  });
 });

--- a/tests/progressiveOverload.test.js
+++ b/tests/progressiveOverload.test.js
@@ -56,4 +56,28 @@ describe('getProgressiveOverloadSuggestion', () => {
     expect(recommendation.averageRate.weightDelta).toBeGreaterThan(2);
     expect(recommendation.sets[0].weight).toBeGreaterThan(55);
   });
+
+  test('suggests more reps instead of more weight when marked maxed out', () => {
+    const workouts = [
+      {
+        log: [
+          {
+            exercise: 'Leg Press',
+            weightsArray: [200, 200],
+            repsArray: [10, 10],
+            unit: 'kg',
+            targetRPE: 8,
+            rpeArray: [7, 7],
+            maxedOut: true
+          }
+        ]
+      }
+    ];
+
+    const recommendation = suggestNextSession('Leg Press', workouts);
+    expect(recommendation.strategy).toBe('maxed-out');
+    expect(recommendation.sets[0].weight).toBe(200);
+    expect(recommendation.sets[0].reps).toBeGreaterThan(10);
+    expect(recommendation.message).toMatch(/maxed out/i);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a skippable post-workout session-rating popup on End Workout (4 quick 1-5 ratings: progressive overload, fatigue, missed weight goal, missed rep goal), also reachable via a "Rate Session"/"Edit Rating" button on each Log tab card. Saved as `workout.sessionRating` and carried through `archiveOldWorkouts()`'s 7-day move into Log History.
- Adds a "Maxed Out" flag for machine exercises (hard weight ceiling) — a checkbox when logging, shown as a badge, toggleable later via the exercise menu, and read by `progressiveOverload.js`'s `suggestNextSession()` to recommend more reps instead of more weight once flagged.
- Fixes the Alt Machine/Alt Gym chip bar never appearing for a returning user (`initSessionContext()` was only wired into the login-form success handlers, not the session-restore boot path), and wires the previously-orphaned `applySessionContext()`/`clearSessionContextAfterSave()` into `addLogEntry()` and the End Workout handler so toggling the chips actually affects saved data.

## Note for reviewer
This branch (`feat/client-intake-leads`) was originally created for the client-intake/coach-dashboard merge work — that work is already merged into `main` (confirmed: the merge commit is an ancestor of `origin/main`, and `intake/` already exists there). It's since been reused across separate sessions for the two unrelated features above, which is the entirety of what's actually ahead of `main` now. Nothing in this PR touches intake/coach-dashboard code.

## Test plan
- [ ] End a workout, confirm the rating popup appears and is skippable
- [ ] Rate a session, confirm it persists after the workout ages into Log History (7-day archive)
- [ ] Log an exercise, flag it "Maxed Out", confirm the badge shows and `suggestNextSession()` recommends reps over weight
- [ ] Log out and back in (or reload a restored session) and confirm the Alt Machine/Alt Gym chip bar renders
- [ ] Toggle a chip and confirm it's reflected in the saved log entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)