### PR TITLE
Fix overlapping/dense layout in Share Workout as Story image

### DIFF
--- a/index.html
+++ b/index.html
@@ -18255,72 +18255,117 @@ window.renderMeetPrep = renderMeetPrep;
     /* ── 9. Exercise list ── */
     const log = workout.log || [];
     const unit = log[0]?.unit || 'kg';
-    let curY = em(218);
-    const rowH = em(80);
-    const maxExercises = Math.min(log.length, Math.floor((H * 0.55) / rowH));
 
-    log.slice(0, maxExercises).forEach((entry, idx) => {
+    // Reserve space for the stats/quote/branding block FIRST, so the list
+    // below is always laid out to end above it — this is what previously let
+    // 3+ exercises draw on top of the stats box (info bleeding together).
+    const statsY = H - em(250);
+    const listTop = em(218);
+    const listBottomLimit = (statsY - em(24)) - em(20); // top of stats box, minus a clear gap
+    const availableListH = Math.max(0, listBottomLimit - listTop);
+
+    // Full 3-line cards only when they actually fit; otherwise fall back to a
+    // compact single-line summary row so more exercises can be shown without
+    // overlapping anything below.
+    const detailedRowH = em(80);
+    const compactRowH  = em(38);
+    const useDetailed = log.length * detailedRowH <= availableListH;
+    const rowH = useDetailed ? detailedRowH : compactRowH;
+    const maxExercises = Math.max(0, Math.min(log.length, Math.floor(availableListH / rowH)));
+
+    let curY = listTop;
+
+    log.slice(0, maxExercises).forEach((entry) => {
       const weights = entry.weightsArray || [];
       const reps   = entry.repsArray || [];
       const maxW   = Math.max(...weights.map(Number), 0);
       const totalR = reps.reduce((s, r) => s + Number(r || 0), 0);
       const totalS = reps.length;
-
-      /* row background */
-      const rowBg = ctx.createLinearGradient(em(24), 0, W - em(24), 0);
-      rowBg.addColorStop(0, 'rgba(45,125,91,0.12)');
-      rowBg.addColorStop(1, 'rgba(45,125,91,0.04)');
-      ctx.fillStyle = rowBg;
-      roundRect(em(24), curY - em(16), W - em(48), rowH - em(8), em(14));
-      ctx.fill();
-
-      /* left accent stripe */
-      ctx.fillStyle = '#2d7d5b';
-      roundRect(em(24), curY - em(16), em(4), rowH - em(8), em(2));
-      ctx.fill();
-
-      /* exercise name */
-      ctx.font = `700 ${em(20)}px -apple-system, sans-serif`;
-      ctx.fillStyle = '#ffffff';
       const exName = entry.exercise || 'Exercise';
-      // truncate if too long
-      let displayName = exName;
-      while (ctx.measureText(displayName).width > em(380) && displayName.length > 4) {
-        displayName = displayName.slice(0, -1);
-      }
-      if (displayName !== exName) displayName += '…';
-      ctx.fillText(displayName, em(42), curY + em(10));
 
-      /* set chips */
-      const setStr = weights.slice(0, 5).map((w, i) => `${reps[i] || 0}×${w}${unit}`).join('  ·  ');
-      ctx.font = `500 ${em(15)}px -apple-system, sans-serif`;
-      ctx.fillStyle = 'rgba(82,214,138,0.85)';
-      ctx.fillText(setStr, em(42), curY + em(34));
-
-      /* stat pills: max weight + total reps */
-      const pillY = curY + em(52);
-      [[`🏆 ${maxW}${unit}`, em(42)], [`🔁 ${totalR} reps`, em(180)], [`${totalS} sets`, em(310)]].forEach(([txt, px]) => {
-        ctx.font = `600 ${em(13)}px -apple-system, sans-serif`;
-        const tw = ctx.measureText(txt).width + em(18);
-        ctx.fillStyle = 'rgba(255,255,255,0.08)';
-        roundRect(px, pillY - em(12), tw, em(20), em(10));
+      if (useDetailed) {
+        /* row background */
+        const rowBg = ctx.createLinearGradient(em(24), 0, W - em(24), 0);
+        rowBg.addColorStop(0, 'rgba(45,125,91,0.12)');
+        rowBg.addColorStop(1, 'rgba(45,125,91,0.04)');
+        ctx.fillStyle = rowBg;
+        roundRect(em(24), curY - em(16), W - em(48), rowH - em(8), em(14));
         ctx.fill();
-        ctx.fillStyle = 'rgba(255,255,255,0.6)';
-        ctx.fillText(txt, px + em(9), pillY + em(5));
-      });
+
+        /* left accent stripe */
+        ctx.fillStyle = '#2d7d5b';
+        roundRect(em(24), curY - em(16), em(4), rowH - em(8), em(2));
+        ctx.fill();
+
+        /* exercise name */
+        ctx.font = `700 ${em(20)}px -apple-system, sans-serif`;
+        ctx.fillStyle = '#ffffff';
+        // truncate if too long
+        let displayName = exName;
+        while (ctx.measureText(displayName).width > em(380) && displayName.length > 4) {
+          displayName = displayName.slice(0, -1);
+        }
+        if (displayName !== exName) displayName += '…';
+        ctx.fillText(displayName, em(42), curY + em(10));
+
+        /* set chips */
+        const setStr = weights.slice(0, 5).map((w, i) => `${reps[i] || 0}×${w}${unit}`).join('  ·  ');
+        ctx.font = `500 ${em(15)}px -apple-system, sans-serif`;
+        ctx.fillStyle = 'rgba(82,214,138,0.85)';
+        ctx.fillText(setStr, em(42), curY + em(34));
+
+        /* stat pills: max weight + total reps */
+        const pillY = curY + em(52);
+        [[`🏆 ${maxW}${unit}`, em(42)], [`🔁 ${totalR} reps`, em(180)], [`${totalS} sets`, em(310)]].forEach(([txt, px]) => {
+          ctx.font = `600 ${em(13)}px -apple-system, sans-serif`;
+          const tw = ctx.measureText(txt).width + em(18);
+          ctx.fillStyle = 'rgba(255,255,255,0.08)';
+          roundRect(px, pillY - em(12), tw, em(20), em(10));
+          ctx.fill();
+          ctx.fillStyle = 'rgba(255,255,255,0.6)';
+          ctx.fillText(txt, px + em(9), pillY + em(5));
+        });
+      } else {
+        /* compact single-line summary row */
+        const rowTop = curY - em(11);
+        const rowBg = ctx.createLinearGradient(em(24), 0, W - em(24), 0);
+        rowBg.addColorStop(0, 'rgba(45,125,91,0.12)');
+        rowBg.addColorStop(1, 'rgba(45,125,91,0.04)');
+        ctx.fillStyle = rowBg;
+        roundRect(em(24), rowTop, W - em(48), rowH - em(8), em(10));
+        ctx.fill();
+
+        ctx.fillStyle = '#2d7d5b';
+        roundRect(em(24), rowTop, em(4), rowH - em(8), em(2));
+        ctx.fill();
+
+        ctx.font = `700 ${em(15)}px -apple-system, sans-serif`;
+        ctx.fillStyle = '#ffffff';
+        let displayName = exName;
+        while (ctx.measureText(displayName).width > em(220) && displayName.length > 4) {
+          displayName = displayName.slice(0, -1);
+        }
+        if (displayName !== exName) displayName += '…';
+        ctx.fillText(displayName, em(42), curY + em(6));
+
+        const summary = `${totalS}× · 🏆${maxW}${unit} · 🔁${totalR}`;
+        ctx.font = `500 ${em(13)}px -apple-system, sans-serif`;
+        ctx.fillStyle = 'rgba(82,214,138,0.85)';
+        ctx.textAlign = 'right';
+        ctx.fillText(summary, W - em(42), curY + em(6));
+        ctx.textAlign = 'left';
+      }
 
       curY += rowH;
     });
 
     if (log.length > maxExercises) {
-      ctx.font = `500 ${em(15)}px -apple-system, sans-serif`;
+      ctx.font = `500 ${em(14)}px -apple-system, sans-serif`;
       ctx.fillStyle = 'rgba(255,255,255,0.35)';
-      ctx.fillText(`+ ${log.length - maxExercises} more exercise${log.length - maxExercises > 1 ? 's' : ''}…`, em(42), curY + em(10));
-      curY += em(36);
+      ctx.fillText(`+ ${log.length - maxExercises} more exercise${log.length - maxExercises > 1 ? 's' : ''}…`, em(42), curY + em(6));
     }
 
     /* ── 10. Stats row ── */
-    const statsY = H - em(280);
     const totalVol = (() => {
       let v = 0;
       log.forEach(e => {


### PR DESCRIPTION
## Problem

The **Share as Story** feature (`drawWorkoutStory()` in `index.html`) renders a canvas image of the workout to share/save. For any workout with 3+ exercises, the exercise-list rows visually overlapped the stats box, motivational quote, and branding footer at the bottom of the image — producing the "too densely populated" / jumbled look reported.

## Root cause

The number of exercise rows drawn was computed from an arbitrary `H * 0.55` budget that had no relationship to where the bottom block (stats box / quote / branding) actually sits on the canvas, and didn't account for the list's own starting Y offset. The two layouts were computed independently and collided.

## Fix

- Reserve the bottom block's space **first**, then size the exercise list to fit exactly above it, so rows can no longer draw underneath the stats/quote/branding section.
- Add a compact single-line row style (`Exercise — 4× · 🏆85kg · 🔁38`) used automatically once the full 3-line detail cards won't fit, so more exercises render as a condensed summary instead of overflowing.
- Keep the `"+N more exercises…"` fallback for very long workouts, now positioned safely above the stats box instead of colliding with it.

## Verification

Screenshot-based verification wasn't available in this environment, so I extracted `drawWorkoutStory()` into a standalone harness and ran it against mock workouts of 1 / 3 / 6 / 10 / 15 exercises:

- Confirmed programmatically that the list's content bottom edge never overlaps the stats box top, across all sizes (margins of 67–273px).
- Confirmed all canvases render real content (no blank/broken output).
- Confirmed 6+ exercise workouts correctly fall back to the compact style and truncate with "+N more" instead of overlapping.

Only `index.html` is touched — no other files changed.