### PR TITLE
feat: forgot-password link on coach login

### DIFF
--- a/coach/coach.css
+++ b/coach/coach.css
@@ -137,6 +137,29 @@ body {
   min-height: 1.2em;
 }
 
+.login-error.info { color: var(--text-muted); }
+.login-error.success { color: var(--primary); }
+
+/* .login-card button (below) targets every button in the card, including
+   this one, with higher specificity (class + element vs. just class) — so
+   this needs the same "class scoped to .login-card" shape to actually win. */
+.login-card .login-forgot-btn {
+  width: 100%;
+  margin-top: 6px;
+  padding: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 400;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.login-card .login-forgot-btn:hover { color: var(--text-sec); }
+.login-card .login-forgot-btn:disabled { cursor: default; opacity: 0.6; }
+
 /* ── App shell grid ────────────────────────────────────────── */
 
 .app-shell {

--- a/coach/coach.js
+++ b/coach/coach.js
@@ -5,6 +5,12 @@
    ============================================================= */
 
 const SERVER_URL = 'https://us-central1-pocketcoach-280c4.cloudfunctions.net/api';
+// Firebase's public Web API key (safe to ship client-side — it just
+// identifies the project, real access control is server-side rules/auth).
+// Used only for the "Forgot password?" flow below, which calls Google's
+// Identity Toolkit REST API directly rather than pulling in the whole
+// Firebase client SDK for one endpoint.
+const FIREBASE_API_KEY = 'AIzaSyCgZTztfMhwQdRfc4no_ZduDEfOv30gMcY';
 
 let _token = localStorage.getItem('coachToken') || null;
 let _username = localStorage.getItem('coachUser') || null;
@@ -73,6 +79,61 @@ async function doCoachLogin() {
   } finally {
     btn.disabled = false;
     btn.textContent = 'Sign In';
+  }
+}
+
+// Resolves the typed username to an email via the backend (login here is by
+// username, but Firebase's password-reset flow is email-based), then asks
+// Google's Identity Toolkit directly to send the reset link — no dedicated
+// backend route needed for that second step, it's the same public REST call
+// the Firebase client SDK's sendPasswordResetEmail() makes under the hood.
+async function doForgotPassword() {
+  const username = document.getElementById('loginUsername').value.trim();
+  const errorEl = document.getElementById('loginError');
+  const btn = document.getElementById('forgotPasswordBtn');
+
+  if (!username) {
+    errorEl.className = 'login-error';
+    errorEl.textContent = 'Enter your username above first, then click "Forgot password?".';
+    return;
+  }
+
+  btn.disabled = true;
+  errorEl.className = 'login-error info';
+  errorEl.textContent = 'Sending reset link…';
+
+  try {
+    const resolveRes = await fetch(SERVER_URL + '/auth/email-for-username', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username }),
+    });
+    const resolveData = await resolveRes.json();
+    if (!resolveRes.ok || !resolveData.success || !resolveData.email) {
+      errorEl.className = 'login-error';
+      errorEl.textContent = resolveData.error?.message || 'No account found for that username.';
+      return;
+    }
+
+    const resetRes = await fetch('https://identitytoolkit.googleapis.com/v1/accounts:sendOobCode?key=' + FIREBASE_API_KEY, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requestType: 'PASSWORD_RESET', email: resolveData.email }),
+    });
+    if (!resetRes.ok) {
+      const resetData = await resetRes.json().catch(() => ({}));
+      errorEl.className = 'login-error';
+      errorEl.textContent = resetData.error?.message || 'Could not send reset email.';
+      return;
+    }
+
+    errorEl.className = 'login-error success';
+    errorEl.textContent = 'Reset link sent to ' + resolveData.email + ' — check your inbox.';
+  } catch {
+    errorEl.className = 'login-error';
+    errorEl.textContent = 'Connection error — could not send reset link.';
+  } finally {
+    btn.disabled = false;
   }
 }
 

--- a/coach/index.html
+++ b/coach/index.html
@@ -27,6 +27,7 @@
       <input type="password" id="loginPassword" placeholder="Password" autocomplete="current-password">
       <button id="loginBtn" onclick="doCoachLogin()">Sign In</button>
       <div id="loginError" class="login-error"></div>
+      <button type="button" id="forgotPasswordBtn" class="login-forgot-btn" onclick="doForgotPassword()">Forgot password?</button>
     </div>
   </div>
 


### PR DESCRIPTION
Adds a "Forgot password?" link below Sign In on the coach dashboard's login gate. Login here is by username, but Firebase's password reset is email-based, so this resolves username -> email first via the existing POST /auth/email-for-username route, then calls Google's Identity Toolkit REST API directly (accounts:sendOobCode, requestType: PASSWORD_RESET) to actually send the reset email — the same public endpoint the Firebase client SDK's sendPasswordResetEmail() wraps, called directly here so the dashboard doesn't need to pull in the whole SDK for one action.

Reuses the existing #loginError element for status text (info while sending, success once sent, the existing danger styling on failure) rather than adding a new UI element.

Verified in the browser preview: empty-username guard, unknown-username error path, and the full success path (mocked fetch, confirmed the exact request body sent to Identity Toolkit) all behave correctly. Also caught and fixed a CSS specificity bug along the way — the new .login-forgot-btn class was losing to the existing .login-card button rule (class+element beats class alone), needed scoping to .login-card .login-forgot-btn.