### PR TITLE
fix: bump service worker CACHE_VERSION to actually ship today's deploys

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
    Version bump to force cache refresh on each deploy.
    ============================================================= */
 
-const CACHE_VERSION = 'pocket-coach-v4';
+const CACHE_VERSION = 'pocket-coach-v5';
 const CACHE_STATIC  = `${CACHE_VERSION}-static`;
 const CACHE_API     = `${CACHE_VERSION}-api`;
 


### PR DESCRIPTION
sw.js's own header says "Version bump to force cache refresh on each deploy" — but none of today's deploys touched sw.js, so browsers with it already installed kept serving stale cached assets under the cache-first strategy regardless of what was actually live on the server. Confirmed via direct curl that the server has been serving the new code correctly the whole time; this was purely a client-side stale-cache issue.

v4 → v5. Already calls skipWaiting()/clients.claim(), so this takes effect on next reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)