### PR TITLE
feat: forgot-password link on the main app's login screen

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -249,6 +249,36 @@
   display: none !important;
 }
 
+/* ── Forgot password ────────────────────────────────────────── */
+
+.login-forgot-link {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 4px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.78rem;
+  font-family: 'Poppins', sans-serif;
+  text-decoration: underline;
+  cursor: pointer;
+  text-align: center;
+}
+
+.login-forgot-link:hover {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.login-forgot-link:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.login-error--success {
+  color: var(--primary, #5fa87e);
+}
+
 /* ── Pricing link ───────────────────────────────────────────── */
 
 .login-pricing-link {

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
     <button id="signupButton" class="login-cta login-cta--hidden loading-btn" onclick="startSignup()">
       <span>Create Account</span><span class="spinner"></span>
     </button>
+    <button type="button" id="forgotPasswordLink" class="login-forgot-link" onclick="startForgotPassword()">Forgot password?</button>
 
     <a href="pricing.html" class="login-pricing-link">See pricing &amp; plans →</a>
   </div>
@@ -4097,7 +4098,46 @@ async function startLogin() {
     setLoading(btn, false);
   }
 }
-  
+
+// Reuses the same username field the login form already has — Firebase's
+// reset flow is email-based, but firebaseAuth.resetPassword() resolves that
+// server-side the same way login() does, so the user never needs to know
+// their email if they signed up before that field existed.
+async function startForgotPassword() {
+  const username = document.getElementById('username').value.trim();
+  const errorEl = document.getElementById('loginError');
+  const link = document.getElementById('forgotPasswordLink');
+
+  if (!username) {
+    if (errorEl) errorEl.textContent = 'Enter your username above first, then tap "Forgot password?".';
+    return;
+  }
+  if (!window.firebaseAuth?.isAvailable()) {
+    if (errorEl) errorEl.textContent = 'Password reset isn\'t available for this account yet — contact support.';
+    return;
+  }
+
+  if (link) link.disabled = true;
+  if (errorEl) { errorEl.textContent = 'Sending reset link…'; errorEl.classList.remove('login-error--success'); }
+
+  try {
+    const { email } = await window.firebaseAuth.resetPassword(username);
+    if (errorEl) {
+      errorEl.textContent = `Reset link sent to ${email} — check your inbox.`;
+      errorEl.classList.add('login-error--success');
+    }
+  } catch (err) {
+    if (errorEl) {
+      errorEl.classList.remove('login-error--success');
+      errorEl.textContent = err.tryLegacy
+        ? 'This account hasn\'t been migrated yet — enter your username and existing password on the Sign Up tab to migrate it first.'
+        : (err.message || 'Could not send reset link.');
+    }
+  } finally {
+    if (link) link.disabled = false;
+  }
+}
+
 function showTab(tabName) {
   // Redirect legacy coachingTab references to the new split tabs
   if (tabName === 'coachingTab') {
@@ -15622,6 +15662,8 @@ function _switchLoginTab(mode) {
   const signupBtn = document.getElementById('signupButton');
   if (loginBtn)  loginBtn.classList.toggle('login-cta--hidden', !isLogin);
   if (signupBtn) signupBtn.classList.toggle('login-cta--hidden', isLogin);
+  const forgotLink = document.getElementById('forgotPasswordLink');
+  if (forgotLink) forgotLink.style.display = isLogin ? '' : 'none';
   // Firebase signups collect email (new field — legacy accounts have none)
   const emailField = document.getElementById('signupEmailField');
   if (emailField) {

--- a/src/js/firebase-auth.js
+++ b/src/js/firebase-auth.js
@@ -204,6 +204,36 @@
     };
   }
 
+  // Sends a password-reset email. Same username→email resolution as login()
+  // since Firebase's reset flow is email-based but this app logs in by
+  // username. Throws err.tryLegacy (matching login()'s convention) when the
+  // username isn't a Firebase account at all, so the caller can point the
+  // user at the migration flow instead of a dead-end "email sent" message.
+  async function resetPassword(usernameOrEmail) {
+    if (!available()) throw new Error('Firebase is not configured.');
+
+    let email = usernameOrEmail;
+    if (!usernameOrEmail.includes('@')) {
+      const resolved = await postJson('/auth/email-for-username', { username: usernameOrEmail });
+      if (!resolved.ok) {
+        if (resolved.status === 404) {
+          const err = new Error('No account found for that username.');
+          err.tryLegacy = true;
+          throw err;
+        }
+        throw new Error(resolved.data?.error?.message || 'Could not look up username.');
+      }
+      email = resolved.data.email;
+    }
+
+    try {
+      await firebase.auth().sendPasswordResetEmail(email);
+    } catch (err) {
+      throw new Error(friendlyAuthError(err));
+    }
+    return { email };
+  }
+
   async function resendVerification() {
     const user = firebase.auth().currentUser;
     if (!user) throw new Error('Not signed in.');
@@ -234,6 +264,7 @@
     signup,
     completeSignup,
     login,
+    resetPassword,
     resendVerification,
     reloadAndGetToken,
     logout


### PR DESCRIPTION
Same feature as the coach dashboard's forgot-password link, added there earlier — this fills the gap on the actual main app login screen, which is where the user reported not seeing it.

Resolves username → email via the existing `/auth/email-for-username`, then calls `firebase.auth().sendPasswordResetEmail()`. Hidden on the Sign Up tab. Verified in the browser preview: empty-username guard, success path, not-yet-migrated error path, and Log In/Sign Up tab visibility all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)