### PR TITLE
Modernist redesign: full app visual + nav overhaul

### DIFF
--- a/ProgramTab.css
+++ b/ProgramTab.css
@@ -53,26 +53,29 @@
 
 .prog-top-nav {
   display: flex;
-  border-bottom: 1px solid var(--border, #2a3a2e);
+  gap: 6px;
+  padding: 10px 10px 0;
+  border-bottom: none;
 }
 
 .prog-top-btn {
   flex: 1;
-  padding: 14px 10px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  background: transparent;
+  padding: 9px 10px;
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius-pill);
+  background: var(--pill-bg);
   color: var(--text-muted, #7a8f7d);
+  font-family: var(--font-label);
   font-size: 0.88rem;
-  font-weight: 600;
-  font-family: 'Poppins', sans-serif;
+  font-weight: 700;
   cursor: pointer;
-  transition: color 0.2s, border-color 0.2s;
+  transition: color 0.2s, background 0.2s, border-color 0.2s;
 }
 
 .prog-top-btn.active {
-  color: var(--primary, #5fa87e);
-  border-bottom-color: var(--primary, #5fa87e);
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 /* ── Root wrapper ─────────────────────────────────────────────── */
@@ -197,9 +200,10 @@
 
 .pbv2-goal-card {
   padding: 16px 12px;
-  border: 2px solid var(--border, #2a3a2e);
-  border-radius: 14px;
-  background: var(--card-bg, #0f1510);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  background: var(--pod-bg);
+  box-shadow: var(--pod-bevel);
   cursor: pointer;
   text-align: left;
   transition: border-color 0.18s, background 0.18s;
@@ -887,11 +891,12 @@
 }
 
 .prog-card {
-  border: 1px solid var(--border, #2a3a2e);
-  border-radius: 12px;
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 14px;
   margin: 10px 14px;
-  background: var(--card-bg, #0f1510);
+  background: var(--pod-bg);
 }
 
 .prog-card-title {

--- a/coach/coach.css
+++ b/coach/coach.css
@@ -309,14 +309,14 @@ body {
 .mode-tab {
   flex: 1;
   padding: 7px 10px;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  background: transparent;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
   color: var(--text-muted);
+  font-family: var(--font-label);
   font-size: 0.78rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  font-family: inherit;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -324,9 +324,9 @@ body {
 }
 
 .mode-tab.active {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: #fff;
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 .mode-tab-badge {
@@ -353,21 +353,21 @@ body {
 
 .filter-tab {
   padding: 5px 12px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: transparent;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
   color: var(--text-muted);
+  font-family: var(--font-label);
   font-size: 0.7rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
   white-space: nowrap;
-  font-family: inherit;
 }
 
 .filter-tab.active {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: #fff;
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 /* Client list */
@@ -389,14 +389,14 @@ body {
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: background 0.15s;
   margin-bottom: 2px;
 }
 
-.client-row:hover { background: var(--card); }
-.client-row.active { background: var(--primary-glow); border: 1px solid rgba(45,125,91,0.3); }
+.client-row:hover { background: var(--pod-bg); }
+.client-row.active { background: var(--primary-glow); border: 1px solid rgba(74,132,102,0.3); }
 
 .client-avatar {
   width: 36px;
@@ -503,9 +503,10 @@ body {
   align-items: center;
   gap: 16px;
   padding: 16px 20px;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
+  background: var(--pod-bg-hero);
+  border: 1px solid rgba(74, 132, 102, 0.3);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-shadow-hero);
   margin-bottom: 16px;
 }
 
@@ -539,7 +540,8 @@ body {
 
 .detail-status {
   padding: 4px 12px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-label);
   font-size: 0.68rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -555,30 +557,31 @@ body {
 
 .detail-tabs {
   display: flex;
-  gap: 4px;
+  gap: 6px;
   margin-bottom: 16px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: none;
   padding-bottom: 0;
 }
 
 .detail-tab {
-  padding: 10px 18px;
-  border: none;
-  background: transparent;
+  padding: 8px 16px;
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius-pill);
+  background: var(--pill-bg);
   color: var(--text-muted);
+  font-family: var(--font-label);
   font-size: 0.82rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  border-bottom: 2px solid transparent;
-  font-family: inherit;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
 
-.detail-tab:hover { color: var(--text-sec); }
+.detail-tab:hover { color: var(--text-sec); background: var(--elevated-bg); }
 
 .detail-tab.active {
-  color: var(--primary);
-  border-bottom-color: var(--primary);
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 .detail-panel { display: none; }
@@ -587,9 +590,10 @@ body {
 /* ── Detail cards ──────────────────────────────────────────── */
 
 .d-card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 12px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 16px;
   margin-bottom: 12px;
 }
@@ -721,3 +725,167 @@ body {
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+
+/* =============================================================
+   COACH WORKSPACE (Modernist redesign, Phase 12)
+   Triage-first landing view shown until a client is selected.
+   See renderWorkspace() in coach.js.
+   ============================================================= */
+
+.workspace-view {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.ws-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.ws-header-sub {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.ws-stat-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.ws-stat-tile { padding: 12px 14px; }
+.ws-stat-tile.ws-stat-danger .stat-tile-value { color: var(--danger); }
+.ws-stat-tile.ws-stat-warn .stat-tile-value { color: var(--highlight); }
+
+.ws-grid {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  gap: 16px;
+  align-items: start;
+}
+
+.ws-col-main,
+.ws-col-side {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+/* Priority client hero */
+.ws-priority-card { display: flex; flex-direction: column; gap: 12px; }
+
+.ws-priority-tag {
+  border-radius: var(--radius-pill);
+  padding: 4px 11px;
+  font-family: var(--font-label);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.ws-priority-tag.ok { background: rgba(45,125,91,0.15); color: var(--primary); }
+.ws-priority-tag.watch { background: rgba(198,148,79,0.15); color: var(--highlight); }
+.ws-priority-tag.action { background: rgba(192,80,96,0.15); color: var(--danger); }
+
+.ws-priority-main { display: flex; flex-direction: column; gap: 3px; }
+
+.ws-priority-name {
+  font-family: var(--font-display);
+  font-size: 22px;
+  text-transform: uppercase;
+}
+
+.ws-priority-meta { font-size: 12px; color: var(--text-muted); }
+
+.ws-priority-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.ws-priority-cta { justify-content: center; }
+
+/* Roster table */
+.ws-roster-card { padding: 14px 16px; }
+.ws-roster-count { font-size: 9.5px; color: var(--text-muted); }
+
+.ws-roster-table { display: flex; flex-direction: column; }
+
+.ws-roster-row {
+  display: grid;
+  grid-template-columns: 1.4fr 0.9fr 1.2fr 0.6fr 0.9fr;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 4px;
+  border-bottom: 1px solid rgba(116,138,126,0.09);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.ws-roster-row:last-child { border-bottom: none; }
+.ws-roster-row:hover { background: var(--elevated-bg); }
+
+.ws-roster-name { font-weight: 600; }
+.ws-roster-cell { color: var(--text-muted); font-size: 11.5px; }
+.ws-roster-cell--right { text-align: right; }
+
+.ws-roster-alert {
+  justify-self: end;
+  border-radius: var(--radius-pill);
+  padding: 2px 9px;
+  font-family: var(--font-label);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+}
+.ws-roster-alert.ok { background: rgba(45,125,91,0.15); color: var(--primary); }
+.ws-roster-alert.watch { background: rgba(198,148,79,0.15); color: var(--highlight); }
+.ws-roster-alert.action { background: rgba(192,80,96,0.15); color: var(--danger); }
+
+/* Side column: review queue / templates / messages */
+.ws-side-card { padding: 12px 15px; }
+.ws-side-note { font-size: 9.5px; color: var(--text-muted); }
+
+.ws-empty-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 6px 0 0;
+  line-height: 1.5;
+}
+
+.ws-list-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid rgba(116,138,126,0.09);
+  font-size: 12.5px;
+}
+.ws-list-row:last-child { border-bottom: none; }
+.ws-list-name { font-weight: 600; }
+.ws-list-count { color: var(--text-muted); font-size: 11px; }
+
+/* Breadcrumb back-link on the client-file view */
+.ws-breadcrumb {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  padding: 0 0 10px;
+  margin: 0;
+}
+.ws-breadcrumb:hover { color: var(--text); }
+
+@media (max-width: 900px) {
+  .ws-grid { grid-template-columns: 1fr; }
+  .ws-stat-row { grid-template-columns: repeat(2, 1fr); }
+}

--- a/coach/coach.css
+++ b/coach/coach.css
@@ -5,16 +5,22 @@
    ============================================================= */
 
 :root {
-  --bg: #080b0a;
-  --surface: #0f1510;
-  --card: #121b17;
-  --border: rgba(132,157,144,0.22);
-  --primary: #2d7d5b;
+  /* Aliased to css/tokens.css (loaded before this file) so the coach
+     console shares the same design tokens as the main app instead of
+     hand-duplicating them. Values that were already identical just
+     point at the shared var; --danger/--primary-glow/--sidebar-w/
+     --header-h have no main-app equivalent and stay coach-specific. */
+  --bg: var(--bg-color);
+  --surface: var(--surface-bg);
+  --card: var(--card-bg);
+  --border: var(--border-color);
+  /* --primary, --highlight and --text-muted share the exact same name
+     in tokens.css, so they inherit straight through from the :root
+     there — redeclaring them here as var(--primary) etc. would be a
+     circular self-reference and resolve to nothing. */
   --primary-glow: rgba(45,125,91,0.15);
-  --highlight: #c6944f;
-  --text: #f4f7f5;
-  --text-sec: #b8c2bc;
-  --text-muted: #8c9891;
+  --text: var(--text-color);
+  --text-sec: var(--secondary-text);
   --danger: #c05060;
   --sidebar-w: 320px;
   --header-h: 56px;

--- a/coach/coach.js
+++ b/coach/coach.js
@@ -165,6 +165,7 @@ async function loadClients() {
   }
 
   renderClientList();
+  renderWorkspace();
 }
 
 function getDemoClients() {
@@ -240,6 +241,94 @@ document.getElementById('sidebarModeToggle')?.addEventListener('click', e => {
   if (tab) switchSidebarMode(tab.dataset.mode);
 });
 
+// ── Workspace (triage-first landing view) ───────────────────────
+// Stat row / priority client / roster table are derived from the real
+// _clients array already loaded by loadClients(). Review-queue and
+// messages panels are static shells (see TODO(coach-workspace) markers
+// in coach/index.html) since no backing data model exists for those yet.
+
+function renderWorkspace() {
+  const view = document.getElementById('workspaceView');
+  if (!view) return;
+
+  const counts = { all: _clients.length, action: 0, watch: 0, ok: 0 };
+  _clients.forEach(c => { if (counts[c.alertStatus] !== undefined) counts[c.alertStatus]++; });
+
+  document.getElementById('wsHeaderSub').textContent =
+    _clients.length + ' client' + (_clients.length === 1 ? '' : 's') +
+    (counts.action ? ' · ' + counts.action + ' need attention' : '');
+
+  document.getElementById('wsStatRow').innerHTML = [
+    ['Total clients', counts.all, ''],
+    ['Needs action', counts.action, counts.action ? 'ws-stat-danger' : ''],
+    ['Watch', counts.watch, counts.watch ? 'ws-stat-warn' : ''],
+    ['Stable', counts.ok, ''],
+  ].map(([label, val, cls]) =>
+    '<div class="pod ws-stat-tile ' + cls + '"><div class="stat-tile-label">' + label + '</div>' +
+    '<div class="stat-tile-value">' + val + '</div></div>'
+  ).join('');
+
+  // Priority client: first "needs action", else first "watch", else none.
+  const priority = _clients.find(c => c.alertStatus === 'action') || _clients.find(c => c.alertStatus === 'watch');
+  const priorityEl = document.getElementById('wsPriorityCard');
+  if (priority) {
+    const ci = priority.latestCheckInData || {};
+    const daysSince = priority.lastCheckIn
+      ? Math.floor((Date.now() - new Date(priority.lastCheckIn).getTime()) / 86400000) + 'd ago'
+      : 'no check-in';
+    priorityEl.innerHTML =
+      '<div class="pod pod--hero ws-priority-card">' +
+      '<div class="pod-row"><span class="pod-kicker">Needs attention</span>' +
+      '<span class="ws-priority-tag ' + (priority.alertStatus || 'ok') + '">' + (priority.alertStatus || 'ok') + '</span></div>' +
+      '<div class="ws-priority-main">' +
+      '<span class="ws-priority-name">' + escapeHtml(priority.clientName || 'Unknown') + '</span>' +
+      '<span class="ws-priority-meta">' + escapeHtml(priority.currentProgram || 'No program') + ' &middot; last check-in ' + daysSince + '</span>' +
+      '</div>' +
+      '<div class="ws-priority-stats">' +
+      stat('Sleep', ci.sleep != null ? ci.sleep + '/10' : '—') +
+      stat('Energy', ci.energy != null ? ci.energy + '/10' : '—') +
+      stat('Stress', ci.stress != null ? ci.stress + '/10' : '—') +
+      stat('Bodyweight', ci.bodyweight ? ci.bodyweight + ' kg' : '—') +
+      '</div>' +
+      '<button class="cta-capsule ws-priority-cta" onclick="selectClient(\'' + priority.id + '\')">Open client file</button>' +
+      '</div>';
+  } else {
+    priorityEl.innerHTML = '<div class="pod pod--hero ws-priority-card"><p class="ws-empty-note">Everyone\'s on track — no flagged clients right now.</p></div>';
+  }
+
+  // Roster table — every client, sorted by alert severity then name.
+  const severity = { action: 0, watch: 1, ok: 2 };
+  const sorted = _clients.slice().sort((a, b) =>
+    (severity[a.alertStatus] ?? 3) - (severity[b.alertStatus] ?? 3) ||
+    (a.clientName || '').localeCompare(b.clientName || '')
+  );
+  document.getElementById('wsRosterCount').textContent = _clients.length;
+  document.getElementById('wsRosterTable').innerHTML = sorted.map(c => {
+    const daysSince = c.lastCheckIn ? Math.floor((Date.now() - new Date(c.lastCheckIn).getTime()) / 86400000) + 'd' : '—';
+    return '<div class="ws-roster-row" onclick="selectClient(\'' + c.id + '\')">' +
+      '<span class="ws-roster-name">' + escapeHtml(c.clientName || 'Unknown') + '</span>' +
+      '<span class="ws-roster-cell">' + escapeHtml(c.trainingMode || '—') + '</span>' +
+      '<span class="ws-roster-cell">' + escapeHtml(c.currentProgram || '—') + '</span>' +
+      '<span class="ws-roster-cell ws-roster-cell--right">' + daysSince + '</span>' +
+      '<span class="ws-roster-alert ' + (c.alertStatus || 'ok') + '">' + (c.alertStatus || 'ok') + '</span>' +
+      '</div>';
+  }).join('') || '<p class="ws-empty-note">No clients yet.</p>';
+
+  // Templates — real data via getCoachPrograms(), with a count of clients
+  // currently assigned to each (also real, derived from _clients).
+  const programs = getCoachPrograms();
+  const templatesEl = document.getElementById('wsTemplatesList');
+  if (!programs.length) {
+    templatesEl.innerHTML = '<p class="ws-empty-note">No saved program templates yet.</p>';
+  } else {
+    templatesEl.innerHTML = programs.map(p => {
+      const assigned = _clients.filter(c => c.currentProgram === p.name).length;
+      return '<div class="ws-list-row"><span class="ws-list-name">' + escapeHtml(p.name) + '</span>' +
+        '<span class="ws-list-count">' + assigned + '</span></div>';
+    }).join('');
+  }
+}
+
 function toggleBulk(id) {
   if (_bulkSelected.has(id)) _bulkSelected.delete(id);
   else _bulkSelected.add(id);
@@ -263,12 +352,21 @@ function bulkMessage() {
 
 // ── Select client ─────────────────────────────────────────────
 
+function backToWorkspace() {
+  _selectedClientId = null;
+  renderClientList();
+  document.getElementById('clientDetail').style.display = 'none';
+  document.getElementById('emptyState').style.display = 'none';
+  document.getElementById('workspaceView').style.display = '';
+}
+
 function selectClient(id) {
   _selectedClientId = id;
   renderClientList();
   const client = _clients.find(c => c.id === id);
   if (!client) return;
 
+  document.getElementById('workspaceView').style.display = 'none';
   document.getElementById('emptyState').style.display = 'none';
   document.getElementById('clientDetail').style.display = '';
 

--- a/coach/index.html
+++ b/coach/index.html
@@ -91,7 +91,65 @@
 
     <!-- Main panel: Client Detail -->
     <main class="main-panel" id="mainPanel">
-      <div class="empty-state" id="emptyState">
+      <!-- Workspace: triage-first landing view shown until a client is
+           selected (renderWorkspace() in coach.js). Stat row and priority
+           client/roster table are real data from _clients; review-queue/
+           templates/messages panels are a visual shell only — no backing
+           data model exists yet for those, per the redesign plan. -->
+      <div class="workspace-view" id="workspaceView">
+        <div class="ws-header">
+          <span class="pod-title" style="font-size:22px;">Coaching</span>
+          <span class="ws-header-sub" id="wsHeaderSub"></span>
+        </div>
+
+        <div class="ws-stat-row" id="wsStatRow"></div>
+
+        <div class="ws-grid">
+          <div class="ws-col-main">
+            <div id="wsPriorityCard"></div>
+
+            <div class="pod ws-roster-card">
+              <div class="pod-row">
+                <span class="pod-kicker">Client roster</span>
+                <span class="ws-roster-count" id="wsRosterCount"></span>
+              </div>
+              <div class="ws-roster-table" id="wsRosterTable"></div>
+            </div>
+          </div>
+
+          <div class="ws-col-side">
+            <div class="pod ws-side-card">
+              <div class="pod-row">
+                <span class="pod-kicker">Review queue</span>
+                <span class="ws-side-note">phase · due</span>
+              </div>
+              <!-- TODO(coach-workspace): no meso/review-cycle data model
+                   exists yet — this is a visual shell until that's built. -->
+              <p class="ws-empty-note">No reviews tracked yet.</p>
+            </div>
+
+            <div class="pod ws-side-card">
+              <div class="pod-row">
+                <span class="pod-kicker">Program templates</span>
+                <span class="ws-side-note">assigned to</span>
+              </div>
+              <div id="wsTemplatesList"></div>
+            </div>
+
+            <div class="pod ws-side-card ws-messages-card">
+              <div class="pod-row">
+                <span class="pod-kicker">Messages</span>
+                <span class="ws-side-note">TODO(coach-workspace)</span>
+              </div>
+              <!-- TODO(coach-workspace): no messaging/thread data model
+                   exists yet — this is a visual shell until that's built. -->
+              <p class="ws-empty-note">Messaging isn't wired up yet — use a client's Notes tab for now.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="empty-state" id="emptyState" style="display:none;">
         <div class="empty-icon">👈</div>
         <h2>Select a client</h2>
         <p>Choose a client from the roster to view their details, check-ins, and program.</p>
@@ -99,6 +157,9 @@
 
       <!-- Client detail (hidden until selected) -->
       <div id="clientDetail" style="display:none;">
+
+        <!-- Breadcrumb back to the workspace -->
+        <button class="ws-breadcrumb" onclick="backToWorkspace()">&larr; Clients</button>
 
         <!-- Athlete header -->
         <div class="detail-header" id="detailHeader"></div>

--- a/coach/index.html
+++ b/coach/index.html
@@ -4,7 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pocket Coach — Coach Dashboard</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Poppins:wght@400;500;600;700&family=Anton&family=Barlow+Condensed:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/design-system.css">
   <link rel="stylesheet" href="coach.css">
 </head>
 <body>

--- a/css/archetype-features.css
+++ b/css/archetype-features.css
@@ -15,9 +15,10 @@
 }
 
 .macro-card {
-  background: var(--surface-bg, #141e17);
-  border: 1px solid var(--border, #2a3a2e);
-  border-radius: 14px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 14px 16px 12px;
 }
 

--- a/css/base.css
+++ b/css/base.css
@@ -13,7 +13,7 @@ body {
 }
 
 body {
-  font-family: 'Poppins', sans-serif;
+  font-family: var(--font-body);
   color: var(--text-color);
   padding: 8px 12px 16px;
   margin: 0;

--- a/css/base.css
+++ b/css/base.css
@@ -219,8 +219,8 @@ th {
 /*
  * IMPORTANT: do NOT use transform on .section/.section.active.
  * Any transform value (even scale(1)) creates a CSS stacking context
- * which traps position:fixed descendants (like #bottomNav, #moreDrawer)
- * and makes them position relative to the container instead of the viewport.
+ * which traps position:fixed descendants (like #bottomNav) and makes
+ * them position relative to the container instead of the viewport.
  * Fade with opacity only.
  */
 .section {

--- a/css/cardio.css
+++ b/css/cardio.css
@@ -21,9 +21,10 @@
 }
 
 .cardio-stat-chip {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--pod-bevel);
   padding: 10px 8px;
   text-align: center;
 }
@@ -47,9 +48,10 @@
 
 /* ── Form card ──────────────────────────────────────────────── */
 .cardio-form-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 16px;
+  background: var(--pod-bg-hero);
+  border: 1px solid rgba(74, 132, 102, 0.3);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-shadow-hero);
   padding: 16px;
   margin-bottom: 20px;
 }
@@ -87,12 +89,14 @@
 }
 
 .cardio-type-btn {
-  padding: 6px 13px;
-  border-radius: 20px;
-  border: 1.5px solid var(--border-color);
-  background: var(--elevated-bg);
+  padding: 7px 13px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
   color: var(--secondary-text);
-  font-size: 0.82rem;
+  font-family: var(--font-label);
+  font-size: 13px;
+  font-weight: 700;
   cursor: pointer;
   transition: all 0.15s;
   white-space: nowrap;
@@ -104,10 +108,10 @@
 }
 
 .cardio-type-btn.active {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: #fff;
-  font-weight: 600;
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
+  font-weight: 700;
 }
 
 /* ── Custom type input (shown when Other is selected) ───────── */
@@ -229,9 +233,9 @@
   flex: 1;
   min-width: 64px;
   padding: 8px 6px;
-  border-radius: 10px;
-  border: 1.5px solid var(--border-color);
-  background: var(--elevated-bg);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
   color: var(--secondary-text);
   font-size: 0.78rem;
   font-weight: 600;

--- a/css/checkin.css
+++ b/css/checkin.css
@@ -14,10 +14,10 @@
 /* ── Sub-tab nav strip ──────────────────────────────────────── */
 .ci-nav {
   display: flex;
-  gap: 4px;
+  gap: 6px;
   padding: 10px 12px 0;
-  border-bottom: 1px solid var(--border-color);
-  background: var(--surface-bg);
+  border-bottom: none;
+  background: transparent;
   position: sticky;
   top: 0;
   z-index: 30;
@@ -29,34 +29,35 @@
 
 .ci-nav-btn {
   flex-shrink: 0;
-  padding: 8px 16px 10px;
-  background: none;
-  border: none;
-  border-bottom: 3px solid transparent;
+  padding: 7px 14px;
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius-pill);
   color: var(--text-muted);
-  font-size: 0.82rem;
-  font-weight: 600;
+  font-family: var(--font-label);
+  font-size: 13px;
+  font-weight: 700;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
   white-space: nowrap;
   -webkit-tap-highlight-color: transparent;
-  margin-bottom: -1px; /* overlap the border-bottom of .ci-nav */
 }
 
 .ci-nav-btn.active {
-  color: var(--primary);
-  border-bottom-color: var(--primary);
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 /* ── Phase banner ───────────────────────────────────────────── */
 .ci-phase-banner {
   margin: 14px 12px 0;
   padding: 10px 14px;
-  background: linear-gradient(135deg, rgba(45,125,91,0.15), rgba(45,125,91,0.06));
-  border: 1px solid rgba(45,125,91,0.3);
-  border-radius: 12px;
+  background: rgba(38, 92, 68, 0.16);
+  border: 1px solid rgba(74, 132, 102, 0.38);
+  border-radius: var(--radius-pill);
   font-size: 0.82rem;
-  color: var(--primary);
+  color: #8ec2a4;
   font-weight: 500;
 }
 
@@ -67,9 +68,10 @@
 
 /* ── Card container ─────────────────────────────────────────── */
 .ci-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 16px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 16px;
   margin-bottom: 12px;
 }
@@ -291,10 +293,13 @@
 .ci-save-btn {
   width: 100%;
   padding: 14px;
-  border-radius: 12px;
+  border-radius: var(--radius-pill);
   border: none;
-  background: var(--primary);
-  color: #fff;
+  background: var(--pill-bg-active);
+  box-shadow: var(--cta-shadow);
+  color: var(--pill-text-active);
+  font-family: var(--font-display);
+  text-transform: uppercase;
   font-size: 1rem;
   font-weight: 700;
   cursor: pointer;

--- a/css/coaching.css
+++ b/css/coaching.css
@@ -12,10 +12,10 @@
   gap: 6px;
   flex-wrap: wrap;
   margin-bottom: 18px;
-  padding: 4px;
-  background: var(--surface-bg);
-  border-radius: 12px;
-  border: 1px solid var(--border-color);
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  border: none;
 }
 
 .coach-subtab {
@@ -23,14 +23,14 @@
   min-width: 70px;
   height: 36px;
   padding: 8px 10px;
-  border-radius: 8px;
-  border: none;
-  background: transparent;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
   color: var(--secondary-text);
-  font-family: 'Poppins', 'Segoe UI Emoji', 'Noto Color Emoji', 'Apple Color Emoji', sans-serif;
+  font-family: var(--font-label), 'Segoe UI Emoji', 'Noto Color Emoji', 'Apple Color Emoji';
   font-size: 0.75rem;
   line-height: 1.3;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   text-align: center;
@@ -41,8 +41,9 @@
 }
 
 .coach-subtab.active {
-  background: var(--primary);
-  color: var(--text-color);
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 .coach-subview { display: none; }
@@ -59,9 +60,10 @@
 
 .coach-stat-chip {
   flex: 1 1 100px;
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--pod-bevel);
   padding: 12px 14px;
   text-align: center;
 }

--- a/css/design-system.css
+++ b/css/design-system.css
@@ -1,0 +1,187 @@
+/* =============================================================
+   DESIGN SYSTEM — "Modernist" redesign
+   Depends on: tokens.css
+   Shared structural classes only — no page-specific selectors.
+   Component files (home.css, log.css, ...) consume these classes
+   and layer their own page-specific rules on top.
+   ============================================================= */
+
+/* ── App background wash ───────────────────────────────────── */
+.bg-textured {
+  position: relative;
+  background: var(--bg-hero-gradient);
+}
+.bg-textured::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.11;
+  mix-blend-mode: overlay;
+  background-image: var(--bg-noise-overlay);
+}
+
+/* ── Pods (cards) ───────────────────────────────────────────── */
+.pod {
+  border-radius: var(--radius-pod);
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  box-shadow: var(--pod-bevel);
+  padding: var(--space-4);
+}
+.pod--alt { background: var(--pod-bg-alt); }
+.pod--hero {
+  background: var(--pod-bg-hero);
+  border-color: rgba(74, 132, 102, 0.3);
+  box-shadow: var(--pod-shadow-hero);
+}
+.pod--flat {
+  box-shadow: none;
+  border-color: rgba(116, 138, 126, 0.14);
+}
+.pod--warning { border-color: var(--warning-border); }
+.pod--danger { border-color: rgba(158, 50, 65, 0.4); }
+
+.pod-kicker {
+  font-family: var(--font-label);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+.pod-title {
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  line-height: 1.05;
+}
+.pod-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: var(--space-2);
+}
+
+/* ── Pills / segmented sub-nav ──────────────────────────────── */
+.pill-nav {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3);
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  padding: 7px 13px;
+  font-family: var(--font-label);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.pill.active,
+.pill[aria-selected="true"] {
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
+}
+.pill--warning {
+  border-color: var(--warning-border);
+  color: var(--warning-gold);
+}
+
+/* ── Stat tiles ─────────────────────────────────────────────── */
+.stat-tile {
+  flex: 1;
+  border-radius: var(--radius-md);
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  box-shadow: var(--pod-bevel);
+  padding: 9px 11px;
+}
+.stat-tile-label {
+  font-family: var(--font-label);
+  font-size: 8.5px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+.stat-tile-value {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+  margin-top: 1px;
+}
+
+/* ── Primary CTA capsule ────────────────────────────────────── */
+.cta-capsule {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 52px;
+  border-radius: var(--radius-pill);
+  padding: 0 8px 0 20px;
+  background: var(--pill-bg-active);
+  box-shadow: var(--cta-shadow);
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  color: var(--pill-text-active);
+  font-family: var(--font-display);
+  font-size: 17px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.cta-capsule--warning { background: linear-gradient(135deg, rgba(168, 124, 56, .9), rgba(109, 81, 36, .9)); }
+.cta-capsule--danger { background: var(--danger-grad); }
+.cta-capsule-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: rgba(6, 12, 9, 0.32);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+
+/* Secondary (outline) capsule used alongside a primary CTA */
+.cta-capsule-outline {
+  flex: 1;
+  text-align: center;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.038);
+  border: 1px solid var(--pod-border);
+  padding: 9px 0;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--secondary-text);
+  cursor: pointer;
+}
+
+/* ── Bottom-nav FAB ─────────────────────────────────────────── */
+.bn-fab {
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, #3d9d73, #236b4e 60%, #143c2b);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.55), inset 0 2px 0 rgba(255, 255, 255, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #050c08;
+  cursor: pointer;
+  flex: none;
+}
+.bn-fab svg { display: block; }
+
+/* ── Utility ────────────────────────────────────────────────── */
+.tabular-nums { font-variant-numeric: tabular-nums; }

--- a/css/features.css
+++ b/css/features.css
@@ -2536,31 +2536,35 @@
   display: flex;
   gap: 6px;
   padding: 4px 0 10px;
-  border-bottom: 1px solid var(--border, #2a3a2e);
+  border-bottom: none;
   margin-bottom: 14px;
 }
 
 .comm-nav-btn {
   flex: 1;
-  padding: 8px 6px;
-  background: var(--card-bg, #0f1510);
-  border: 1px solid var(--border, #2a3a2e);
+  padding: 7px 6px;
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
   color: var(--text-muted, #7a8f7d);
-  border-radius: 20px;
+  border-radius: var(--radius-pill);
   font-size: 0.78rem;
-  font-family: 'Poppins', sans-serif;
-  font-weight: 600;
+  font-family: var(--font-label);
+  font-weight: 700;
   cursor: pointer;
   transition: background 0.18s, color 0.18s, border-color 0.18s;
   text-align: center;
   white-space: nowrap;
 }
 
-.comm-nav-btn.active,
 .comm-nav-btn:hover {
-  background: var(--primary, #5fa87e);
-  border-color: var(--primary, #5fa87e);
-  color: #fff;
+  background: var(--elevated-bg);
+  color: var(--text-color);
+}
+
+.comm-nav-btn.active {
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 /* ── ⑦ Filter pills ─────────────────────────────────────────── */

--- a/css/features.css
+++ b/css/features.css
@@ -1709,12 +1709,14 @@
 }
 
 .wt-trend-badge {
+  font-family: var(--font-label);
   font-size: 0.75rem;
   font-weight: 700;
-  padding: 3px 10px;
-  border-radius: 20px;
-  background: rgba(95,168,126,0.15);
-  color: var(--primary, #5fa87e);
+  padding: 4px 11px;
+  border-radius: var(--radius-pill);
+  background: rgba(38, 92, 68, 0.22);
+  border: 1px solid rgba(74, 132, 102, 0.42);
+  color: #8ec2a4;
 }
 
 /* ── Stat strip ── */
@@ -1722,9 +1724,10 @@
   display: grid;
   grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr;
   align-items: center;
-  background: var(--card-bg, #0f1510);
-  border: 1px solid var(--border, #2a3a2e);
-  border-radius: 12px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 12px 10px;
   gap: 0;
 }
@@ -1763,9 +1766,10 @@
 
 /* ── Weekly breakdown card ── */
 .wt-weekly-card {
-  background: var(--card-bg, #0f1510);
-  border: 1px solid var(--border, #2a3a2e);
-  border-radius: 14px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 14px;
   margin-top: 10px;
 }
@@ -1861,10 +1865,11 @@
 
 /* ── Entry card ── */
 .wt-entry-card {
-  background: var(--card-bg, #0f1510);
-  border: 1px solid var(--border, #2a3a2e);
-  border-radius: 14px;
-  padding: 14px 14px 12px;
+  background: var(--pod-bg-hero);
+  border: 1px solid rgba(74, 132, 102, 0.3);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-shadow-hero);
+  padding: 15px 15px 13px;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/css/home.css
+++ b/css/home.css
@@ -8,10 +8,26 @@
 /* ── Home tab shell ─────────────────────────────────────────── */
 
 #homeTab {
-  background: radial-gradient(circle at top, rgba(34, 61, 49, 0.28) 0%, #0a0f0d 58%, #070909 100%);
+  position: relative;
+  background: var(--bg-hero-gradient);
   border: 1px solid rgba(94, 121, 109, 0.38);
   box-shadow: 0 16px 38px rgba(0, 0, 0, 0.45);
   padding-bottom: 12px;
+  overflow: hidden;
+}
+
+#homeTab::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.11;
+  mix-blend-mode: overlay;
+  background-image: var(--bg-noise-overlay);
+}
+
+#homeTab > * {
+  position: relative;
 }
 
 /* ── Visual zones ───────────────────────────────────────────── */
@@ -46,10 +62,11 @@
 /* ── Section labels ─────────────────────────────────────────── */
 
 .home-section-label {
+  font-family: var(--font-label);
   font-size: 0.68rem;
-  font-weight: 700;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.14em;
   color: var(--text-muted, #7a8f7d);
   margin-bottom: 8px;
   padding-left: 2px;
@@ -66,9 +83,10 @@
 
 /* Step card — replaces the heavy inline styles */
 .home-step-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 16px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 14px;
 }
 
@@ -125,27 +143,27 @@
 
 .home-dashboard-card {
   --home-accent: #1f7f59;
-  background: linear-gradient(180deg, rgba(15, 24, 20, 0.96), rgba(10, 16, 13, 0.98));
-  border: 1px solid rgba(96, 126, 113, 0.36);
-  border-radius: 16px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 14px;
   text-align: left;
-  color: #f4f7f5;
+  color: var(--text-color);
   transition: border-color 0.25s ease, transform 0.25s ease;
 }
 
 .home-dashboard-card:hover {
-  border-color: rgba(89, 156, 126, 0.5);
+  border-color: rgba(116, 138, 126, 0.4);
   transform: translateY(-1px);
 }
 
 /* ── Hero card ──────────────────────────────────────────────── */
 
 .home-hero-card {
-  background: radial-gradient(circle at top right, rgba(30, 109, 78, 0.18), transparent 48%),
-              linear-gradient(180deg, rgba(8, 17, 13, 0.98), rgba(7, 13, 10, 0.95));
-  border-color: rgba(63, 145, 108, 0.35);
+  background: var(--pod-bg-hero);
+  border-color: rgba(74, 132, 102, 0.3);
+  box-shadow: var(--pod-shadow-hero);
 }
 
 .home-hero-topline {
@@ -699,10 +717,11 @@
 /* ── Today's Program Card (today-program.js) ──────────────────── */
 
 .tpc-card {
-  background: var(--card-bg, #0f1510);
-  border: 1px solid var(--border, #2a3a2e);
-  border-radius: 16px;
-  padding: 14px 16px 12px;
+  background: var(--pod-bg-hero);
+  border: 1px solid rgba(74, 132, 102, 0.3);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-shadow-hero);
+  padding: 15px 16px 13px;
   margin: 0 0 10px;
 }
 
@@ -722,12 +741,15 @@
 }
 
 .tpc-week-badge {
+  font-family: var(--font-label);
   font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
   color: var(--text-muted, #7a8f7d);
-  background: var(--bg, #0b130d);
-  border: 1px solid var(--border, #2a3a2e);
-  border-radius: 20px;
-  padding: 2px 10px;
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius-pill);
+  padding: 3px 11px;
 }
 
 .tpc-main {
@@ -817,9 +839,10 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: var(--card-bg, #0f1510);
-  border: 1px solid var(--border, #2a3a2e);
-  border-radius: 16px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 14px 16px;
   margin: 0 0 10px;
   transition: border-color 0.2s;

--- a/css/home.css
+++ b/css/home.css
@@ -260,10 +260,10 @@
 }
 
 .coach-client-card {
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  box-shadow: var(--shadow);
-  background: var(--card-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
+  background: var(--pod-bg);
   padding: 14px;
   text-align: left;
 }

--- a/css/log.css
+++ b/css/log.css
@@ -11,6 +11,46 @@
   padding-bottom: 20px;
 }
 
+/* ── Session queue — today's planned exercises (session-queue.js) ── */
+
+.sq-card {
+  margin: 8px 0 10px;
+}
+
+.sq-count {
+  font-size: 9.5px;
+  color: var(--text-muted);
+}
+
+.sq-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid rgba(116, 138, 126, 0.1);
+  font-size: 12.5px;
+}
+
+.sq-row:last-child { border-bottom: none; }
+
+.sq-index {
+  width: 14px;
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--text-muted);
+}
+
+.sq-name {
+  flex: 1;
+  font-weight: 600;
+}
+
+.sq-summary {
+  font-size: 11px;
+  color: var(--secondary-text);
+  font-variant-numeric: tabular-nums;
+}
+
 /* ── Workout session timer banner ───────────────────────────── */
 
 .workout-timer {
@@ -18,11 +58,11 @@
   align-items: center;
   justify-content: space-between;
   margin: 8px 12px 12px;
-  padding: 10px 14px;
-  background: rgba(45, 125, 91, 0.08);
-  border: 1px solid rgba(45, 125, 91, 0.22);
-  border-left: 3px solid var(--primary);
-  border-radius: 0 10px 10px 0;
+  padding: 10px 16px 10px 14px;
+  background: rgba(38, 92, 68, 0.16);
+  border: 1px solid rgba(74, 132, 102, 0.38);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--pod-bevel);
 }
 
 .workout-timer-info {
@@ -137,11 +177,11 @@
   align-items: center;
   gap: 14px;
   margin: 8px 12px 4px;
-  padding: 10px 14px 10px 12px;
-  background: rgba(240, 160, 64, 0.07);
-  border: 1px solid rgba(240, 160, 64, 0.22);
-  border-left: 3px solid #f0a040;
-  border-radius: 0 10px 10px 0;
+  padding: 10px 16px 10px 14px;
+  background: rgba(168, 124, 56, 0.12);
+  border: 1px solid var(--warning-border);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--pod-bevel);
 }
 
 .rest-banner[hidden] { display: none !important; }
@@ -219,16 +259,60 @@
   font-weight: 700;
   background: transparent;
   border: 1px solid rgba(240, 160, 64, 0.35);
-  border-radius: 8px;
+  border-radius: var(--radius-pill);
   color: #f0a040;
   cursor: pointer;
   flex-shrink: 0;
-  font-family: 'Poppins', sans-serif;
+  font-family: var(--font-legacy);
   transition: background 0.15s;
 }
 
 .rest-banner-skip:hover {
   background: rgba(240, 160, 64, 0.1);
+}
+
+/* ── Set input row (per-set reps/weight/plate-calc/modifiers) ─── */
+
+.set-input-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.set-input-label {
+  min-width: 52px;
+  font-size: 0.85rem;
+}
+
+.set-input-reps-wrap {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.set-input-reps { width: 72px; }
+.set-input-weight { width: 90px; }
+
+.set-input-reps-note {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.set-plate-btn {
+  padding: 4px 8px;
+  border: 1px solid var(--pod-border);
+  border-radius: 8px;
+  background: var(--pod-bg);
+  color: var(--text-color);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.set-plate-btn:hover {
+  background: var(--elevated-bg);
 }
 
 /* ── Set option pills (Drop / RP / L/R) ──────────────────────── */
@@ -237,7 +321,7 @@
   display: inline-flex;
   align-items: center;
   padding: 6px 12px;
-  border-radius: 16px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border, #2a3a2e);
   background: transparent;
   color: var(--text-muted, #7a8f7d);
@@ -315,10 +399,11 @@
 /* ── Form card ──────────────────────────────────────────────── */
 
 .log-form-card {
-  background: var(--card-bg);
-  border: 1px solid rgba(96, 126, 113, 0.36);
-  border-radius: 16px;
-  padding: 14px;
+  background: var(--pod-bg-hero);
+  border: 1px solid rgba(74, 132, 102, 0.3);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-shadow-hero);
+  padding: 15px;
   display: flex;
   flex-direction: column;
   gap: 0;

--- a/css/log.css
+++ b/css/log.css
@@ -11,6 +11,62 @@
   padding-bottom: 20px;
 }
 
+/* ── History list (history.js renderHistoryList — previously unstyled,
+   fell back to bare <ul>/<li>) ────────────────────────────────── */
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.history-item {
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
+  padding: 12px 14px;
+}
+
+.history-item .row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 13.5px;
+}
+
+.history-item .row span {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.history-item .meta {
+  font-size: 11.5px;
+  color: var(--secondary-text);
+  margin-top: 4px;
+}
+
+.history-open-btn {
+  margin-top: 10px;
+  width: 100%;
+  padding: 8px 0;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
+  color: var(--text-color);
+  font-family: var(--font-label);
+  font-weight: 700;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.history-open-btn:hover { background: var(--elevated-bg); }
+
 /* ── Session queue — today's planned exercises (session-queue.js) ── */
 
 .sq-card {

--- a/css/nav.css
+++ b/css/nav.css
@@ -1,33 +1,32 @@
 /* =============================================================
    NAVIGATION
-   Bottom navigation bar, More drawer (secondary tabs), and the
-   workout focus bar that replaces the nav during active sessions.
-   Depends on: tokens.css
+   Bottom navigation bar (floating capsule + center FAB, Modernist
+   redesign), the "All" hub screen it links to, and the workout focus
+   bar that replaces the nav during active sessions.
+   Depends on: tokens.css, design-system.css
    ============================================================= */
 
 /* ── Bottom navigation bar ──────────────────────────────────── */
 
-/* One fixed bar, equal-width items — no horizontal scroll. */
+/* Floating capsule, inset from the screen edges, not edge-to-edge. */
 #bottomNav {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: calc(64px + env(safe-area-inset-bottom, 0px));
-  padding-bottom: env(safe-area-inset-bottom, 0px);
-  background: rgba(10, 15, 12, 0.92);
+  left: 14px;
+  right: 14px;
+  bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  height: 64px;
+  background: rgba(14, 20, 17, 0.95);
+  border: 1px solid rgba(116, 138, 126, 0.22);
+  border-radius: var(--radius-pill);
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
-  border-top: 1px solid rgba(132, 157, 144, 0.22);
   display: flex;
-  align-items: stretch;
+  align-items: center;
+  padding: 0 6px;
   z-index: 1000;
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.45);
-  overflow: hidden;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.045);
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
-
-/* Keep nav visible during workout — focus bar sits above it */
 
 /* ── Nav items ──────────────────────────────────────────────── */
 
@@ -42,7 +41,7 @@
   border: none;
   color: var(--secondary-text);
   font-size: 11px;
-  font-family: 'Poppins', sans-serif;
+  font-family: var(--font-legacy);
   cursor: pointer;
   padding: 0 6px;
   margin: 0;
@@ -57,30 +56,17 @@
   color: var(--text-color);
 }
 
+/* Active tab renders as a filled pill, not just a color change. */
 .bn-item.active {
-  color: var(--primary);
-}
-
-.bn-item {
-  position: relative; /* anchor the ::before indicator */
-}
-
-/* Top indicator pill — scales in when active */
-.bn-item::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%) scaleX(0);
-  width: 28px;
-  height: 3px;
-  background: var(--primary);
-  border-radius: 0 0 4px 4px;
-  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.bn-item.active::before {
-  transform: translateX(-50%) scaleX(1);
+  flex-direction: row;
+  gap: 6px;
+  color: var(--pill-text-active);
+  background: var(--pill-bg-active);
+  border-radius: var(--radius-pill);
+  height: 40px;
+  flex: 0 0 auto;
+  padding: 0 14px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
 .bn-item .bn-icon {
@@ -89,122 +75,99 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.2s ease, filter 0.2s ease;
+  transition: transform 0.2s ease;
 }
 
 /* SVG icon sizing */
 .bn-icon svg {
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   display: block;
 }
 
-.bn-item.active .bn-icon {
-  transform: translateY(-2px);
-  filter: drop-shadow(0 0 7px rgba(45, 125, 91, 0.7));
-}
-
 .bn-item .bn-label {
-  font-size: 10px;
-  letter-spacing: 0.02em;
+  font-size: 8.5px;
+  font-family: var(--font-label);
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   white-space: nowrap;
 }
 
-/* More button never highlights with the primary colour */
-.bn-item.bn-more.active {
-  color: var(--secondary-text);
+.bn-item.active .bn-label {
+  font-size: 10px;
 }
 
-/* ── More drawer ────────────────────────────────────────────── */
-
-/*
- * Full-screen overlay with a translucent scrim and a slide-up panel.
- * Toggle `.open` on #moreDrawer to show/hide.
- */
-.more-drawer {
-  position: fixed;
-  inset: 0;
-  z-index: 1200;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+/* Center FAB: base look (.bn-fab) is in design-system.css; this is just
+   its placement within the bottomNav flex row. */
+#bottomNav .bn-fab {
+  flex: none;
+  margin: 0 2px;
 }
 
-.more-drawer[hidden] {
-  display: none;
+/* ── "All" hub screen (replaces the old More drawer) ──────────── */
+
+.all-hub-header {
+  padding: 6px 6px 14px;
 }
 
-.more-drawer-scrim {
-  flex: 1;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(2px);
-  cursor: pointer;
+.all-hub-section {
+  margin-top: 12px;
 }
 
-.more-drawer-panel {
-  background: var(--card-bg, #0f1510);
-  border-top: 1px solid var(--border-color);
-  border-radius: 20px 20px 0 0;
-  padding: 8px 16px calc(80px + env(safe-area-inset-bottom, 0px));
-  transform: translateY(100%);
-  transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
+.all-hub-section:first-of-type {
+  margin-top: 0;
 }
 
-.more-drawer.open .more-drawer-panel {
-  transform: translateY(0);
+.all-hub-section-label {
+  font-family: var(--font-label);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin-bottom: 6px;
 }
 
-/* Drag handle pill */
-.more-drawer-handle {
-  width: 36px;
-  height: 4px;
-  background: var(--border-color);
-  border-radius: 2px;
-  margin: 0 auto 16px;
-}
-
-/* 4-column icon grid */
-.more-drawer-grid {
+.all-hub-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
 }
 
-.more-drawer-item {
+.all-hub-tile {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 12px 8px;
-  border: none;
-  background: var(--surface-bg, #141e17);
-  border-radius: 12px;
+  gap: 8px;
+  padding: 10px 12px;
   color: var(--text-color);
-  font-size: 12px;
+  font-size: 12.5px;
+  font-family: var(--font-body);
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s, transform 0.1s;
-  font-family: 'Poppins', sans-serif;
+  text-align: left;
+  transition: background 0.15s;
 }
 
-.more-drawer-item:active {
-  transform: scale(0.95);
-  background: var(--border-color);
+.all-hub-tile:active {
+  background: var(--elevated-bg);
 }
 
-.more-drawer-icon {
+.all-hub-tile .more-drawer-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
-  font-size: 20px;
+  width: 22px;
+  height: 22px;
+  font-size: 18px;
   line-height: 1;
   overflow: hidden;
-  font-family: 'Segoe UI Emoji', 'Noto Color Emoji', 'Apple Color Emoji', 'Poppins', sans-serif;
+  flex: none;
+  font-family: 'Segoe UI Emoji', 'Noto Color Emoji', 'Apple Color Emoji', var(--font-body);
 }
 
-.more-drawer-logout {
-  color: #c05060;
+.all-hub-logout {
+  color: var(--danger-text, #e0707f);
 }
 
 /* ── Workout focus bar ──────────────────────────────────────── */

--- a/css/progress.css
+++ b/css/progress.css
@@ -29,20 +29,21 @@
 .progress-nav button {
   flex: none;
   margin: 0;
-  padding: 8px 14px;
-  border-radius: 20px;
-  border: 1.5px solid var(--border-color);
-  background: var(--elevated-bg);
+  padding: 7px 13px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
   color: var(--secondary-text);
-  font-size: 0.82rem;
-  font-weight: 600;
+  font-family: var(--font-label);
+  font-size: 13px;
+  font-weight: 700;
   white-space: nowrap;
 }
 
 .progress-nav button.active {
-  background-color: var(--primary);
-  border-color: var(--primary);
-  color: #fff;
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 .progress-nav input[type="date"] {
@@ -71,11 +72,11 @@
 
 .progress-chart,
 .progress-calendar {
-  background: linear-gradient(180deg, rgba(18, 27, 23, 0.94), rgba(12, 18, 15, 0.97));
+  background: var(--pod-bg);
   padding: 1rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--border-color);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.32);
+  border-radius: var(--radius-pod);
+  border: 1px solid var(--pod-border);
+  box-shadow: var(--pod-bevel);
   color: var(--text-color);
 }
 

--- a/css/sleep.css
+++ b/css/sleep.css
@@ -14,9 +14,10 @@
 /* ── Log form card ─────────────────────────────────────────── */
 
 .sleep-log-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 16px;
+  background: var(--pod-bg-hero);
+  border: 1px solid rgba(74, 132, 102, 0.3);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-shadow-hero);
   padding: 16px;
   margin-bottom: 16px;
 }
@@ -106,12 +107,13 @@
 
 .sleep-tag {
   padding: 6px 14px;
-  border-radius: 999px;
-  border: 1px solid var(--border-color);
-  background: var(--surface-bg);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
   color: var(--secondary-text);
+  font-family: var(--font-label);
   font-size: 0.78rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
   transition: all 0.15s ease;
   margin: 0;
@@ -139,7 +141,9 @@
 .sleep-save-btn {
   width: 100%;
   padding: 13px;
-  border-radius: 12px;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-display);
+  text-transform: uppercase;
   font-size: 0.95rem;
   font-weight: 700;
   margin: 0;
@@ -155,9 +159,10 @@
 }
 
 .sleep-stat-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--pod-bevel);
   padding: 12px 10px;
   text-align: center;
 }
@@ -180,9 +185,10 @@
 /* ── Trend chart ───────────────────────────────────────────── */
 
 .sleep-chart-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 16px;
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  border-radius: var(--radius-pod);
+  box-shadow: var(--pod-bevel);
   padding: 16px;
   margin-bottom: 16px;
 }
@@ -201,21 +207,22 @@
 
 .sleep-period-btn {
   padding: 5px 14px;
-  border-radius: 999px;
-  border: 1px solid var(--border-color);
-  background: transparent;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--pill-border);
+  background: var(--pill-bg);
   color: var(--secondary-text);
+  font-family: var(--font-label);
   font-size: 0.78rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
   margin: 0;
   box-shadow: none;
 }
 
 .sleep-period-btn.active {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: #fff;
+  background: var(--pill-bg-active);
+  border-color: transparent;
+  color: var(--pill-text-active);
 }
 
 /* Bar chart */

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -21,6 +21,64 @@
   --highlight:      #c6944f;
   --shadow:         0 12px 28px rgba(0, 0, 0, 0.34);
   --shell-shadow:   0 16px 36px rgba(0, 0, 0, 0.42);
+
+  /* ── Modernist redesign — fonts ──────────────────────────────
+     --font-legacy keeps Poppins reachable for files not yet
+     migrated off it; new component CSS should use the three below. */
+  --font-display: 'Anton', 'Barlow Condensed', sans-serif;
+  --font-label:   'Barlow Condensed', 'Archivo', sans-serif;
+  --font-body:    'Archivo', 'Poppins', system-ui, sans-serif;
+  --font-legacy:  'Poppins', sans-serif;
+
+  /* ── Modernist redesign — spacing scale ──────────────────────── */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  /* ── Modernist redesign — radius scale ───────────────────────── */
+  --radius-sm:   12px;
+  --radius-md:   16px;
+  --radius-pod:  24px;
+  --radius-pill: 99px;
+
+  /* ── Modernist redesign — background wash ────────────────────── */
+  --bg-hero-gradient: radial-gradient(150% 92% at 50% -6%,
+    rgba(52, 122, 88, 0.55) 0%,
+    rgba(35, 84, 62, 0.42) 26%,
+    rgba(20, 44, 33, 0.5) 52%,
+    #0a120e 74%,
+    #050807 100%);
+  /* Fractal-noise SVG, inlined so no extra asset request is needed. */
+  --bg-noise-overlay: url('data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cfilter id=%22n%22%3E%3CfeTurbulence type=%22fractalNoise%22 baseFrequency=%22.85%22 numOctaves=%224%22 stitchTiles=%22stitch%22/%3E%3C/filter%3E%3Crect width=%22100%25%22 height=%22100%25%22 filter=%22url(%23n)%22/%3E%3C/svg%3E');
+
+  /* ── Modernist redesign — pod surfaces ────────────────────────── */
+  --pod-bg:          #101614;
+  --pod-bg-alt:      #121b17;
+  --pod-bg-hero:     linear-gradient(168deg, rgba(22, 36, 28, 0.94), rgba(12, 18, 15, 0.985));
+  --pod-border:      rgba(116, 138, 126, 0.22);
+  --pod-bevel:       inset 0 1px 0 rgba(255, 255, 255, 0.038);
+  --pod-shadow-hero: 0 16px 34px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+  /* ── Modernist redesign — pills ───────────────────────────────── */
+  --pill-bg-active: linear-gradient(135deg, #2f8a63, #236b4e 60%, #17472f);
+  --pill-bg:        #101614;
+  --pill-border:    rgba(116, 138, 126, 0.24);
+  --pill-text-active: #050c08;
+
+  /* ── Modernist redesign — CTA capsule ─────────────────────────── */
+  --cta-shadow: 0 10px 26px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+
+  /* ── Modernist redesign — status accents ──────────────────────── */
+  --danger-strong: #9e3241;
+  --danger-grad:   linear-gradient(150deg, #9e3241, #61202c);
+  --danger-text:   #e0707f;
+  --warning-gold:  #c79a54;
+  --warning-bg:    rgba(168, 124, 56, 0.16);
+  --warning-border: rgba(168, 124, 56, 0.4);
 }
 
 /* ── Alternate themes ───────────────────────────────────────── */

--- a/css/ui-declutter.css
+++ b/css/ui-declutter.css
@@ -4,14 +4,17 @@
 
 /* ── Log sub-tab nav ─────────────────────────────────────────── */
 
+/* Pill-style segmented nav (Modernist redesign) — shared by every
+   sub-tab strip built on this markup pattern: logSubtabNav, funcSubNav,
+   progressSubNav, historySubNav. */
 .log-subtabs {
   display: flex;
-  gap: 4px;
+  gap: 6px;
   padding: 10px 10px 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
-  border-bottom: 1px solid var(--border, #2a3a2e);
+  border-bottom: none;
   margin-bottom: 14px;
   flex-shrink: 0;
 }
@@ -21,18 +24,19 @@
 .log-subtab {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   flex-shrink: 0;
-  padding: 8px 14px;
-  border: none;
-  border-radius: 20px 20px 0 0;
-  background: transparent;
+  padding: 7px 13px;
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius-pill);
+  background: var(--pill-bg);
   color: var(--text-muted, #7a8f7d);
-  font-size: 0.82rem;
-  font-weight: 600;
-  font-family: 'Poppins', sans-serif;
+  font-family: var(--font-label);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   cursor: pointer;
-  transition: background 0.2s, color 0.2s;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
   white-space: nowrap;
 }
 
@@ -51,15 +55,14 @@
 }
 
 .log-subtab:hover {
-  background: var(--card-bg, #0f1510);
-  color: var(--primary, #5fa87e);
+  background: var(--elevated-bg);
+  color: var(--text-color);
 }
 
 .log-subtab.active {
-  background: var(--card-bg, #0f1510);
-  color: var(--primary, #5fa87e);
-  border: 1px solid var(--border, #2a3a2e);
-  border-bottom: 1px solid var(--card-bg, #0f1510);
+  background: var(--pill-bg-active);
+  color: var(--pill-text-active);
+  border-color: transparent;
 }
 
 /* ── Log sub-views ───────────────────────────────────────────── */

--- a/index.html
+++ b/index.html
@@ -3255,7 +3255,11 @@
           <span class="more-drawer-icon" data-icon="users"></span>
           <span>Community</span>
         </button>
-        <button class="pod all-hub-tile" data-tab="leaderboardTab" onclick="showTab('leaderboardTab')">
+        <!-- Leaderboard is reached through Community's own nav pill now
+             (#leaderboardTab/#exerciseLeaderboardTab still exist and work
+             if something else deep-links to them, they just lost their
+             separate All-hub tile). -->
+        <button class="pod all-hub-tile" data-tab="communityTab" onclick="showTab('communityTab'); if (window.showCommunitySection) showCommunitySection('competition')">
           <span class="more-drawer-icon" data-icon="award"></span>
           <span>Leaderboard</span>
         </button>

--- a/index.html
+++ b/index.html
@@ -4,12 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Pocket Coach</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Poppins:wght@400;500;600;700&family=Anton&family=Barlow+Condensed:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="ProgramTab.css">
   <link rel="stylesheet" href="style.css">
   <meta name="theme-color" content="#0b0f0d">
   <!-- ── Modular CSS files (extracted from inline styles) ──────── -->
   <link rel="stylesheet" href="css/tokens.css">
+  <link rel="stylesheet" href="css/design-system.css">
   <link rel="stylesheet" href="css/base.css">
   <link rel="stylesheet" href="css/nav.css">
   <link rel="stylesheet" href="css/onboarding.css">

--- a/index.html
+++ b/index.html
@@ -2935,7 +2935,7 @@
 </div><!-- /#progressTab -->
 
 <div id="logHistoryTab" class="tab-content">
-  <h2>Log History</h2>
+  <h2 class="pod-title" style="font-size:20px;">History</h2>
   <nav class="log-subtabs" id="historySubNav">
     <button class="log-subtab active" data-histsub="workout"><span class="ui-icon" data-icon="dumbbell"></span> Workouts</button>
     <button class="log-subtab" data-histsub="bodyweight"><span class="ui-icon" data-icon="scale"></span> Bodyweight</button>

--- a/index.html
+++ b/index.html
@@ -2703,7 +2703,7 @@
 
 
   <div id="progressTab" class="tab-content">
-    <h2>Progress Overview</h2>
+    <h2 class="pod-title" style="font-size:20px;">Insights</h2>
     <!-- Progress mini-tab nav -->
     <nav class="log-subtabs" id="progressSubNav">
       <button class="log-subtab active" data-psub="charts"><span class="ui-icon" data-icon="barChart"></span> Charts</button>
@@ -3203,7 +3203,7 @@
         </button>
         <button class="pod all-hub-tile" data-tab="progressTab" onclick="showTab('progressTab')">
           <span class="more-drawer-icon" data-icon="barChart"></span>
-          <span>Progress</span>
+          <span>Insights</span>
         </button>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -502,28 +502,29 @@
 
 <div id="pocketFitContainer" class="section" style="display:none;">
   
-  <!-- Bottom Navigation: Log, Progress, Weight, Macro + More -->
+  <!-- Bottom Navigation: Home / Train / [+ quick-log] / Body / All.
+       "Train"=logTab, "Body"=bodyTab (launcher into Weight/Macros/Sleep/
+       Cardio), "All"=allTab (former More drawer) — ids kept stable so
+       showTab()'s existing dispatcher needs no changes. -->
   <nav id="bottomNav" aria-label="Main navigation">
     <button class="bn-item" data-tab="homeTab" aria-label="Home">
       <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg></span>
       <span class="bn-label">Home</span>
     </button>
-    <button class="bn-item active" data-tab="logTab" aria-label="Log">
+    <button class="bn-item active" data-tab="logTab" aria-label="Train">
       <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></span>
-      <span class="bn-label">Log</span>
+      <span class="bn-label">Train</span>
     </button>
-    <button class="bn-item" data-tab="weightTab" aria-label="Weight">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="9" width="20" height="12" rx="2"/><path d="M8 9a4 4 0 0 1 8 0"/><line x1="12" y1="14" x2="12" y2="17"/><line x1="10" y1="17" x2="14" y2="17"/></svg></span>
-      <span class="bn-label">Weight</span>
+    <button class="bn-fab" id="bnFab" aria-label="Quick log" onclick="goToQuickLog()">
+      <svg viewBox="0 0 24 24" width="23" height="23" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
     </button>
-    <button class="bn-item" data-tab="macroTab" aria-label="Macros">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg></span>
-      <span class="bn-label">Macros</span>
+    <button class="bn-item" data-tab="bodyTab" aria-label="Body">
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="9" width="20" height="12" rx="2"/><path d="M8 9a4 4 0 0 1 8 0"/></svg></span>
+      <span class="bn-label">Body</span>
     </button>
-    <!-- More button opens the secondary-tabs drawer -->
-    <button class="bn-item bn-more" id="moreNavBtn" onclick="openMoreDrawer()" aria-label="More" aria-expanded="false" aria-controls="moreDrawer">
-      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg></span>
-      <span class="bn-label">More</span>
+    <button class="bn-item" data-tab="allTab" aria-label="All">
+      <span class="bn-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/></svg></span>
+      <span class="bn-label">All</span>
     </button>
   </nav>
 
@@ -883,6 +884,12 @@
   </div><!-- /logTab -->
 
   <div id="weightTab" class="tab-content">
+    <div class="pill-nav">
+      <button class="pill active" onclick="showTab('weightTab')">Weight</button>
+      <button class="pill" onclick="showTab('macroTab')">Macros</button>
+      <button class="pill" onclick="showTab('sleepTab')">Sleep</button>
+      <button class="pill" onclick="showTab('cardioTab')">Cardio</button>
+    </div>
     <div id="weightLogPanel" class="panel active wt-panel">
 
       <!-- ── Header ── -->
@@ -2084,6 +2091,12 @@
 </div>
 
   <div id="cardioTab" class="tab-content">
+    <div class="pill-nav">
+      <button class="pill" onclick="showTab('weightTab')">Weight</button>
+      <button class="pill" onclick="showTab('macroTab')">Macros</button>
+      <button class="pill" onclick="showTab('sleepTab')">Sleep</button>
+      <button class="pill active" onclick="showTab('cardioTab')">Cardio</button>
+    </div>
 
     <!-- Weekly summary chips -->
     <div id="cardioWeeklySummary" class="cardio-weekly-strip"></div>
@@ -2245,6 +2258,12 @@
   </div>
 
 <div id="macroTab" class="tab-content" style="position: relative; padding: 20px;">
+    <div class="pill-nav">
+      <button class="pill" onclick="showTab('weightTab')">Weight</button>
+      <button class="pill active" onclick="showTab('macroTab')">Macros</button>
+      <button class="pill" onclick="showTab('sleepTab')">Sleep</button>
+      <button class="pill" onclick="showTab('cardioTab')">Cardio</button>
+    </div>
   <div id="macrosTab">
     <div id="macrosSubTabs" class="macros-subtabs">
       <button type="button" class="macros-subtab active" data-macro-subtab="targets">Targets</button>
@@ -3044,6 +3063,12 @@
 
 <!-- ── Sleep Tab ──────────────────────────────────────────────── -->
 <div id="sleepTab" class="tab-content">
+    <div class="pill-nav">
+      <button class="pill" onclick="showTab('weightTab')">Weight</button>
+      <button class="pill" onclick="showTab('macroTab')">Macros</button>
+      <button class="pill active" onclick="showTab('sleepTab')">Sleep</button>
+      <button class="pill" onclick="showTab('cardioTab')">Cardio</button>
+    </div>
   <h2>Sleep</h2>
   <div id="sleepTabContent">
 
@@ -3143,99 +3168,121 @@
   <div id="mobilityTabContent"></div>
 </div>
 
-  </div> <!-- #appContainer -->
-</div> <!-- #pocketFitContainer -->
-
-<!-- More drawer — direct <body> child so position:fixed isn't clipped by
-     the ancestor's transform:scale() stacking context. -->
-<div id="moreDrawer" class="more-drawer" role="dialog" aria-modal="true" aria-label="More options" hidden>
-  <div class="more-drawer-scrim" id="moreDrawerScrim"></div>
-  <div class="more-drawer-panel">
-    <div class="more-drawer-handle"></div>
-    <div class="more-drawer-grid">
-      <button class="more-drawer-item" data-tab="progressTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('progressTab'), 220)">
-        <span class="more-drawer-icon" data-icon="barChart"></span>
-        <span>Progress</span>
-      </button>
-      <button class="more-drawer-item" data-tab="programTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('programTab'), 220)">
-        <span class="more-drawer-icon" data-icon="calendar"></span>
-        <span>Programs</span>
-      </button>
-      <button class="more-drawer-item" data-tab="checkInTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('checkInTab'), 220)">
-        <span class="more-drawer-icon" data-icon="clipboard"></span>
-        <span>Check-In</span>
-      </button>
-      <button class="more-drawer-item" data-tab="sleepTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('sleepTab'), 220)">
-        <span class="more-drawer-icon" data-icon="moon"></span>
-        <span>Sleep</span>
-      </button>
-      <button class="more-drawer-item" data-tab="cardioTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('cardioTab'), 220)">
-        <span class="more-drawer-icon" data-icon="activity"></span>
-        <span>Cardio</span>
-      </button>
-      <button class="more-drawer-item" data-tab="communityTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('communityTab'), 220)">
-        <span class="more-drawer-icon" data-icon="users"></span>
-        <span>Community</span>
-      </button>
-      <button class="more-drawer-item" data-tab="leaderboardTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('leaderboardTab'), 220)">
-        <span class="more-drawer-icon" data-icon="award"></span>
-        <span>Leaderboard</span>
-      </button>
-      <button class="more-drawer-item" data-tab="logHistoryTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('logHistoryTab'), 220)">
-        <span class="more-drawer-icon" data-icon="fileText"></span>
-        <span>History</span>
-      </button>
-      <button class="more-drawer-item bb-only" data-tab="posingTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('posingTab'), 220)">
-        <span class="more-drawer-icon" data-icon="award"></span>
-        <span>Posing</span>
-      </button>
-      <button class="more-drawer-item pl-only" data-tab="powerliftingTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('powerliftingTab'), 220)">
-        <span class="more-drawer-icon" data-icon="dumbbell"></span>
-        <span>Lifting</span>
-      </button>
-      <button class="more-drawer-item athlete-only" data-tab="functionalTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('functionalTab'), 220)">
-        <span class="more-drawer-icon" data-icon="zap"></span>
-        <span>Functional</span>
-      </button>
-      <button class="more-drawer-item coach-only" data-tab="clientsTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('clientsTab'), 220)">
-        <span class="more-drawer-icon" data-icon="users"></span>
-        <span>Clients</span>
-      </button>
-      <button class="more-drawer-item coach-only" data-tab="coachOpsTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('coachOpsTab'), 220)">
-        <span class="more-drawer-icon" data-icon="trophy"></span>
-        <span>Coach</span>
-      </button>
-      <button class="more-drawer-item" data-tab="mobilityTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('mobilityTab'), 220)">
-        <span class="more-drawer-icon" data-icon="flower"></span>
-        <span>Flexibility</span>
-      </button>
-      <button class="more-drawer-item" data-tab="settingsTab"
-              onclick="closeMoreDrawer(); setTimeout(()=>showTab('settingsTab'), 220)">
-        <span class="more-drawer-icon" data-icon="settings"></span>
-        <span>Settings</span>
-      </button>
-      <button class="more-drawer-item more-drawer-logout" id="moreDrawerLogoutBtn"
-              onclick="closeMoreDrawer(); setTimeout(()=>logout(), 220)">
-        <span class="more-drawer-icon" data-icon="arrowLeft"></span>
-        <span>Logout</span>
-      </button>
+  <!-- Body tab: launcher into Weight/Macros/Sleep/Cardio (each of those
+       keeps its own id/render function — this is a menu, not a merge). -->
+  <div id="bodyTab" class="tab-content">
+    <div class="all-hub-header"><span class="pod-title" style="font-size:20px;">Body</span></div>
+    <div class="pill-nav">
+      <button class="pill" onclick="showTab('weightTab')">Weight</button>
+      <button class="pill" onclick="showTab('macroTab')">Macros</button>
+      <button class="pill" onclick="showTab('sleepTab')">Sleep</button>
+      <button class="pill" onclick="showTab('cardioTab')">Cardio</button>
     </div>
   </div>
-</div>
+
+  <!-- All tab: replaces the old More bottom-sheet drawer with a normal
+       tab so it lives in the same nav pattern as every other screen.
+       Every item/onclick/conditional-visibility class below is carried
+       over unchanged from the old #moreDrawer. -->
+  <div id="allTab" class="tab-content all-hub">
+    <div class="all-hub-header"><span class="pod-title" style="font-size:20px;">Everything</span></div>
+
+    <div class="all-hub-section">
+      <div class="all-hub-section-label">Training</div>
+      <div class="all-hub-grid">
+        <button class="pod all-hub-tile" data-tab="programTab" onclick="showTab('programTab')">
+          <span class="more-drawer-icon" data-icon="calendar"></span>
+          <span>Programs</span>
+        </button>
+        <button class="pod all-hub-tile" data-tab="logHistoryTab" onclick="showTab('logHistoryTab')">
+          <span class="more-drawer-icon" data-icon="fileText"></span>
+          <span>History</span>
+        </button>
+        <button class="pod all-hub-tile" data-tab="progressTab" onclick="showTab('progressTab')">
+          <span class="more-drawer-icon" data-icon="barChart"></span>
+          <span>Progress</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="all-hub-section">
+      <div class="all-hub-section-label">Body</div>
+      <div class="all-hub-grid">
+        <button class="pod all-hub-tile" data-tab="checkInTab" onclick="showTab('checkInTab')">
+          <span class="more-drawer-icon" data-icon="clipboard"></span>
+          <span>Check-In</span>
+        </button>
+        <button class="pod all-hub-tile" data-tab="sleepTab" onclick="showTab('sleepTab')">
+          <span class="more-drawer-icon" data-icon="moon"></span>
+          <span>Sleep</span>
+        </button>
+        <button class="pod all-hub-tile" data-tab="cardioTab" onclick="showTab('cardioTab')">
+          <span class="more-drawer-icon" data-icon="activity"></span>
+          <span>Cardio</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="all-hub-section">
+      <div class="all-hub-section-label">Libraries</div>
+      <div class="all-hub-grid">
+        <button class="pod all-hub-tile bb-only" data-tab="posingTab" onclick="showTab('posingTab')">
+          <span class="more-drawer-icon" data-icon="award"></span>
+          <span>Posing</span>
+        </button>
+        <button class="pod all-hub-tile pl-only" data-tab="powerliftingTab" onclick="showTab('powerliftingTab')">
+          <span class="more-drawer-icon" data-icon="dumbbell"></span>
+          <span>Lifting</span>
+        </button>
+        <button class="pod all-hub-tile athlete-only" data-tab="functionalTab" onclick="showTab('functionalTab')">
+          <span class="more-drawer-icon" data-icon="zap"></span>
+          <span>Functional</span>
+        </button>
+        <button class="pod all-hub-tile" data-tab="mobilityTab" onclick="showTab('mobilityTab')">
+          <span class="more-drawer-icon" data-icon="flower"></span>
+          <span>Flexibility</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="all-hub-section">
+      <div class="all-hub-section-label">People &amp; coaching</div>
+      <div class="all-hub-grid">
+        <button class="pod all-hub-tile" data-tab="communityTab" onclick="showTab('communityTab')">
+          <span class="more-drawer-icon" data-icon="users"></span>
+          <span>Community</span>
+        </button>
+        <button class="pod all-hub-tile" data-tab="leaderboardTab" onclick="showTab('leaderboardTab')">
+          <span class="more-drawer-icon" data-icon="award"></span>
+          <span>Leaderboard</span>
+        </button>
+        <button class="pod all-hub-tile coach-only" data-tab="clientsTab" onclick="showTab('clientsTab')">
+          <span class="more-drawer-icon" data-icon="users"></span>
+          <span>Clients</span>
+        </button>
+        <button class="pod all-hub-tile coach-only" data-tab="coachOpsTab" onclick="showTab('coachOpsTab')">
+          <span class="more-drawer-icon" data-icon="trophy"></span>
+          <span>Coach</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="all-hub-section">
+      <div class="all-hub-section-label">System</div>
+      <div class="all-hub-grid">
+        <button class="pod all-hub-tile" data-tab="settingsTab" onclick="showTab('settingsTab')">
+          <span class="more-drawer-icon" data-icon="settings"></span>
+          <span>Settings</span>
+        </button>
+        <button class="pod all-hub-tile all-hub-logout" id="moreDrawerLogoutBtn" onclick="logout()">
+          <span class="more-drawer-icon" data-icon="arrowLeft"></span>
+          <span>Logout</span>
+        </button>
+      </div>
+    </div>
+  </div>
+  </div> <!-- #appContainer -->
+</div> <!-- #pocketFitContainer -->
 
 <!-- Workout focus bar removed — timer is already in the Log tab -->
 
@@ -16453,69 +16500,26 @@ window.setTrainingMode = setTrainingMode;
 window.getTrainingMode = getTrainingMode;
 
 // ─────────────────────────────────────────────
-// MORE DRAWER
+// QUICK LOG (bottom-nav FAB)
 // ─────────────────────────────────────────────
 
-function openMoreDrawer() {
-  const drawer = document.getElementById('moreDrawer');
-  const btn = document.getElementById('moreNavBtn');
-  if (!drawer) return;
-  drawer.removeAttribute('hidden');
-  // Double-RAF ensures the browser computes the initial style (translateY(100%))
-  // before adding .open, so the CSS transition actually animates.
-  requestAnimationFrame(() => requestAnimationFrame(() => drawer.classList.add('open')));
-  if (btn) btn.setAttribute('aria-expanded', 'true');
-  document.addEventListener('keydown', _onDrawerKeydown);
-}
+// The former More drawer is now the "All" tab (#allTab, see markup) and
+// its items are wired inline via onclick="showTab(...)" same as any other
+// nav destination, so no separate open/close drawer JS is needed anymore.
 
-function closeMoreDrawer() {
-  const drawer = document.getElementById('moreDrawer');
-  const btn = document.getElementById('moreNavBtn');
-  if (!drawer) return;
-  drawer.classList.remove('open');
-  const panel = drawer.querySelector('.more-drawer-panel');
-  if (panel) {
-    panel.addEventListener('transitionend', () => {
-      drawer.setAttribute('hidden', '');
-      if (btn) btn.setAttribute('aria-expanded', 'false');
-    }, { once: true });
-  } else {
-    drawer.setAttribute('hidden', '');
-    if (btn) btn.setAttribute('aria-expanded', 'false');
+function goToQuickLog() {
+  showTab('logTab');
+  if (typeof setActiveNavTab === 'function') setActiveNavTab('logTab');
+  // Land on the Log sub-tab specifically (not Rest/History/Templates/Streaks).
+  const logSubBtn = document.querySelector('#logSubtabNav .log-subtab[data-log-subtab="log"]');
+  if (logSubBtn && !logSubBtn.classList.contains('active')) logSubBtn.click();
+  const exerciseInput = document.getElementById('exercise');
+  if (exerciseInput) {
+    exerciseInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setTimeout(() => exerciseInput.focus(), 250);
   }
-  document.removeEventListener('keydown', _onDrawerKeydown);
 }
-
-function _onDrawerKeydown(e) {
-  if (e.key === 'Escape') closeMoreDrawer();
-}
-
-window.openMoreDrawer = openMoreDrawer;
-window.closeMoreDrawer = closeMoreDrawer;
-
-// Wire up More drawer after DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
-  const moreBtn = document.getElementById('moreNavBtn');
-  if (moreBtn) moreBtn.addEventListener('click', openMoreDrawer);
-
-  const scrim = document.getElementById('moreDrawerScrim');
-  if (scrim) scrim.addEventListener('click', closeMoreDrawer);
-
-  const logoutBtn = document.getElementById('moreDrawerLogoutBtn');
-  if (logoutBtn) logoutBtn.addEventListener('click', () => { closeMoreDrawer(); logout(); });
-
-  document.querySelectorAll('#moreDrawer .more-drawer-item[data-tab]').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const tabName = btn.dataset.tab;
-      closeMoreDrawer();
-      // Wait for drawer close animation before switching tab
-      setTimeout(() => showTab(tabName), 200);
-    });
-  });
-
-  // Apply coach-only visibility inside the drawer too
-  applyAppModeToNavigation();
-});
+window.goToQuickLog = goToQuickLog;
 
 // ─────────────────────────────────────────────
 // WORKOUT FOCUS MODE

--- a/index.html
+++ b/index.html
@@ -1807,7 +1807,7 @@
       <button class="prog-top-btn" onclick="showProgramView('list')"><span class="ui-icon" data-icon="clipboard"></span> My Programs</button>
     </nav>
     <div id="progAiGenBtnWrap" style="padding:10px 12px 0;">
-      <button id="progAiGenBtn" onclick="openProgAiGen()" style="width:100%;display:flex;align-items:center;justify-content:center;gap:8px;padding:13px 16px;border-radius:12px;border:none;background:linear-gradient(135deg,var(--primary,#5fa87e),#3a8c62);color:#fff;font-size:0.95rem;font-weight:700;cursor:pointer;box-shadow:0 2px 12px rgba(95,168,126,0.35);">
+      <button id="progAiGenBtn" onclick="openProgAiGen()" class="cta-capsule" style="justify-content:center;gap:8px;">
         <span class="ui-icon" data-icon="sparkles"></span><span>Generate with AI</span>
       </button>
       <div id="progAiGenLocked" style="display:none;opacity:0.65;font-size:0.85rem;color:var(--secondary-text);text-align:center;padding:8px 0;"><span class="ui-icon" data-icon="lock"></span> AI Program Generator — Pro feature</div>

--- a/index.html
+++ b/index.html
@@ -621,6 +621,9 @@
     <!-- ══ Sub-view: Log ══════════════════════════════════════════ -->
     <div id="logSub_log" class="log-subview active">
 
+      <!-- Today's planned exercises, read from the active program (session-queue.js) -->
+      <div id="sessionQueueCard" style="padding:0 12px;"></div>
+
       <!-- Session context flags: alt-machine / alt-gym -->
       <div id="sessionContextBar" style="padding:0 12px;"></div>
 
@@ -4241,6 +4244,7 @@ function showTab(tabName) {
       }
       break;
     case 'logTab':
+      if (typeof window.renderSessionQueue === 'function') window.renderSessionQueue();
       if (window.renderWorkouts) renderWorkouts();
       if (typeof window.renderGamificationUI === 'function' && currentUser) {
         window.renderGamificationUI(currentUser);
@@ -4778,14 +4782,14 @@ function addNewSet() {
 
 function getSetInputHTML(i) {
   return `
-    <div style="display: flex; gap: 8px; margin-bottom: 10px; align-items: center; flex-wrap: wrap;">
-      <label style="min-width: 52px; font-size: 0.85rem;">Set ${i + 1}</label>
-      <div style="display:flex;align-items:center;gap:4px;">
-        <input type="number" id="reps_${i}" placeholder="Reps" style="width: 72px;" oninput="updateAddButtonState(); updateRepsLabel(${i})" />
-        <span id="repsLabel_${i}" style="font-size:0.72rem;color:var(--text-muted);white-space:nowrap;"></span>
+    <div class="set-input-row">
+      <label class="set-input-label">Set ${i + 1}</label>
+      <div class="set-input-reps-wrap">
+        <input type="number" id="reps_${i}" placeholder="Reps" class="set-input-reps" oninput="updateAddButtonState(); updateRepsLabel(${i})" />
+        <span id="repsLabel_${i}" class="set-input-reps-note"></span>
       </div>
-      <input type="number" id="weight_${i}" placeholder="Weight" style="width: 90px;" oninput="updateAddButtonState()" />
-      <button type="button" onclick="openPlateCalculator(${i})" style="padding:4px 8px;border:1px solid #ccc;border-radius:4px;background:#f8f9fa;font-size:0.78rem;"><span class="ui-icon">${ICONS.dumbbell}</span></button>
+      <input type="number" id="weight_${i}" placeholder="Weight" class="set-input-weight" oninput="updateAddButtonState()" />
+      <button type="button" onclick="openPlateCalculator(${i})" class="set-plate-btn" title="Plate calculator"><span class="ui-icon">${ICONS.dumbbell}</span></button>
       <label class="set-opt-pill" title="Dropset"><input type="checkbox" id="dropset_${i}" /><span>Drop</span></label>
       <label class="set-opt-pill" title="Rest-pause"><input type="checkbox" id="restPause_${i}" /><span>RP</span></label>
       <label class="set-opt-pill" title="Unilateral — each side done separately (total reps × 2)"><input type="checkbox" id="unilateral_${i}" onchange="updateRepsLabel(${i})" /><span>L/R</span></label>
@@ -18129,6 +18133,7 @@ window.renderMeetPrep = renderMeetPrep;
   <script src="src/js/rehab.js"></script>
   <script src="src/js/reminders.js"></script>
   <script src="src/js/today-program.js"></script>
+  <script src="src/js/session-queue.js"></script>
   <script src="src/js/session-context.js"></script>
   <script>
     // Render PR board whenever the Streaks sub-tab becomes active

--- a/src/js/session-queue.js
+++ b/src/js/session-queue.js
@@ -1,0 +1,125 @@
+/**
+ * session-queue.js
+ * Renders a read-only "today's planned exercises" list at the top of the
+ * Train tab's Log sub-view, so the lifter can see the day's plan before/
+ * while logging sets manually below. Reuses the same activeProgram/
+ * programs_<user> localStorage read pattern as today-program.js (each
+ * home/train card file keeps its own small copy of these helpers rather
+ * than sharing a module system — matches the existing codebase pattern).
+ */
+(function (global) {
+  'use strict';
+
+  const WEEKDAY_MAP = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+
+  function _user() {
+    return global.currentUser || (typeof localStorage !== 'undefined' && localStorage.getItem('fitnessAppUser'));
+  }
+
+  function _getActiveRecord() {
+    const u = _user();
+    if (!u) return null;
+    try {
+      return JSON.parse(
+        localStorage.getItem(`activeProgram_${u}`) ||
+        localStorage.getItem('activeProgram') ||
+        'null'
+      );
+    } catch { return null; }
+  }
+
+  function _getPrograms() {
+    const u = _user();
+    if (!u) return [];
+    try {
+      return (
+        JSON.parse(localStorage.getItem(`programs_${u}`)) ||
+        JSON.parse(localStorage.getItem('programs') || '[]')
+      );
+    } catch { return []; }
+  }
+
+  function _parseLocalDate(str) {
+    if (!str) return null;
+    const [y, m, d] = str.split('-').map(Number);
+    if (!y) return null;
+    return new Date(y, m - 1, d);
+  }
+
+  function _countTrainingDaysBetween(from, until, trainingDayNums) {
+    let count = 0;
+    const cur = new Date(from);
+    while (cur < until) {
+      if (trainingDayNums.includes(cur.getDay())) count++;
+      cur.setDate(cur.getDate() + 1);
+    }
+    return count;
+  }
+
+  /** Resolve today's program day object ({ name, exercises: [...] }), or null. */
+  function getTodaysPlannedDay() {
+    const active = _getActiveRecord();
+    if (!active) return null;
+
+    const programs = _getPrograms();
+    const program = programs.find(p => p.id === active.programId);
+    if (!program || !Array.isArray(program.days) || !program.days.length) return null;
+
+    const rawFreq = program.frequency || program.weekdays || ['Mon', 'Wed', 'Fri'];
+    const trainingNums = rawFreq.map(d => WEEKDAY_MAP[d]).filter(n => n !== undefined);
+    if (!trainingNums.length) return null;
+
+    const startDate = _parseLocalDate(active.startDate || program.startDate);
+    if (!startDate) return null;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (!trainingNums.includes(today.getDay()) || today < startDate) return null; // rest day
+
+    const tdBefore = _countTrainingDaysBetween(startDate, today, trainingNums);
+    const idx = tdBefore % program.days.length;
+    return { ...program.days[idx], programName: program.name };
+  }
+
+  function _setSummary(ex) {
+    const sets = Array.isArray(ex.sets) ? ex.sets : [];
+    if (!sets.length) return '';
+    const first = sets[0];
+    const reps = first.reps != null ? first.reps : '?';
+    const weight = first.weight != null ? `${first.weight}` : null;
+    return weight ? `${sets.length}×${reps} · ${weight}` : `${sets.length}×${reps}`;
+  }
+
+  function renderSessionQueue() {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('sessionQueueCard');
+    if (!el) return;
+
+    const day = getTodaysPlannedDay();
+    const exercises = day && Array.isArray(day.exercises) ? day.exercises : [];
+    if (!day || !exercises.length) { el.innerHTML = ''; return; }
+
+    const rows = exercises.map((ex, i) => `
+      <div class="sq-row">
+        <span class="sq-index">${i + 1}</span>
+        <span class="sq-name">${ex.name}</span>
+        <span class="sq-summary">${_setSummary(ex)}</span>
+      </div>`).join('');
+
+    el.innerHTML = `
+      <div class="pod sq-card">
+        <div class="pod-row">
+          <span class="pod-kicker">Today's plan · ${day.name}</span>
+          <span class="sq-count">${exercises.length} exercise${exercises.length === 1 ? '' : 's'}</span>
+        </div>
+        ${rows}
+      </div>`;
+  }
+
+  const api = { getTodaysPlannedDay, renderSessionQueue };
+  global.getTodaysPlannedDay = getTodaysPlannedDay;
+  global.renderSessionQueue = renderSessionQueue;
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/sessionQueue.test.js
+++ b/tests/sessionQueue.test.js
@@ -1,0 +1,64 @@
+const { getTodaysPlannedDay } = require('../src/js/session-queue');
+
+describe('session-queue', () => {
+  beforeEach(() => {
+    const store = {};
+    global.localStorage = {
+      getItem: key => (Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null),
+      setItem: (key, value) => { store[key] = String(value); },
+      removeItem: key => { delete store[key]; }
+    };
+    global.currentUser = 'athleteA';
+  });
+
+  function seedProgram({ startDate, frequency, days }) {
+    localStorage.setItem('activeProgram_athleteA', JSON.stringify({ programId: 'p1', startDate }));
+    localStorage.setItem('programs_athleteA', JSON.stringify([
+      { id: 'p1', name: 'Push Pull Legs', frequency, startDate, days }
+    ]));
+  }
+
+  test('returns null when there is no active program', () => {
+    expect(getTodaysPlannedDay()).toBeNull();
+  });
+
+  test("returns today's day with its exercises when today is a training day", () => {
+    const today = new Date();
+    const dow = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][today.getDay()];
+    const startDate = today.toISOString().slice(0, 10);
+
+    seedProgram({
+      startDate,
+      frequency: [dow],
+      days: [
+        { name: 'Push A', exercises: [{ name: 'Bench press', sets: [{ reps: 8, weight: 95 }, { reps: 8, weight: 95 }] }] }
+      ]
+    });
+
+    const result = getTodaysPlannedDay();
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('Push A');
+    expect(result.exercises).toHaveLength(1);
+    expect(result.exercises[0].name).toBe('Bench press');
+  });
+
+  test('returns null on a rest day (today not in frequency)', () => {
+    const today = new Date();
+    const dow = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][today.getDay()];
+    const otherDay = dow === 'Mon' ? 'Tue' : 'Mon';
+    const startDate = today.toISOString().slice(0, 10);
+
+    seedProgram({
+      startDate,
+      frequency: [otherDay],
+      days: [{ name: 'Push A', exercises: [] }]
+    });
+
+    expect(getTodaysPlannedDay()).toBeNull();
+  });
+
+  test('returns null when the program has no days', () => {
+    seedProgram({ startDate: new Date().toISOString().slice(0, 10), frequency: ['Mon'], days: [] });
+    expect(getTodaysPlannedDay()).toBeNull();
+  });
+});

--- a/tests/settingsTab.test.js
+++ b/tests/settingsTab.test.js
@@ -15,25 +15,21 @@ beforeAll(() => {
     if (tab) tab.classList.add('active');
   };
 
-  // Settings navigation moved into the "More" drawer — the old #sideMenu
-  // a[data-target] pattern this test used to target no longer exists
-  // anywhere in index.html. Current markup:
-  // <button class="more-drawer-item" data-tab="settingsTab"
-  //   onclick="closeMoreDrawer(); setTimeout(()=>showTab('settingsTab'), 220)">
-  // Mimic that behavior synchronously (skip the animation delay — not what
-  // this test is checking) rather than relying on the inline onclick
-  // attribute, which doesn't execute under runScripts: 'outside-only'.
-  dom.window.closeMoreDrawer = function() {};
-  dom.window.document.querySelectorAll('.more-drawer-item[data-tab]').forEach(btn => {
+  // Settings navigation lives in the "All" hub tab (formerly the "More"
+  // drawer) as of the Modernist redesign. Current markup:
+  // <button class="pod all-hub-tile" data-tab="settingsTab"
+  //   onclick="showTab('settingsTab')">
+  // Mimic the onclick synchronously (the inline attribute doesn't execute
+  // under runScripts: 'outside-only') rather than relying on it directly.
+  dom.window.document.querySelectorAll('.all-hub-tile[data-tab]').forEach(btn => {
     btn.addEventListener('click', () => {
-      dom.window.closeMoreDrawer();
       dom.window.showTab(btn.getAttribute('data-tab'));
     });
   });
 });
 
 test('clicking Settings link shows settings tab', () => {
-  const settingsLink = dom.window.document.querySelector('.more-drawer-item[data-tab="settingsTab"]');
+  const settingsLink = dom.window.document.querySelector('.all-hub-tile[data-tab="settingsTab"]');
   const settingsTab = dom.window.document.getElementById('settingsTab');
 
   expect(settingsLink).not.toBeNull();


### PR DESCRIPTION
## Summary

Implements the "Modernist" redesign (Claude Design canvas `TrainingLog Redesign.dc.html`) across the whole app: every mobile tab plus a new desktop coach console view. This is a phased visual + IA pass — 12 commits, one per phase — built on top of the app's existing (already close) dark green/brass palette rather than a from-scratch reskin.

## What changed

- **Design system** (`css/tokens.css`, new `css/design-system.css`): pod/pill/CTA/FAB tokens, Anton/Barlow Condensed/Archivo fonts alongside the existing Poppins.
- **Bottom nav rebuilt**: Home / Train / **+ FAB** (quick-log) / Body / All, replacing Home / Log / Weight / Macros / More-drawer. Every existing tab id and `showTab()` case was kept as-is — the nav change is additive/markup-level, not a rename.
  - New `#bodyTab`: a pill launcher into Weight/Macros/Sleep/Cardio.
  - New `#allTab`: replaces the old `#moreDrawer` bottom sheet with a normal tab, same 16 destinations and `bb-only`/`pl-only`/`athlete-only`/`coach-only` conditional visibility, regrouped into sections.
- **Every mobile screen restyled** onto the pod/pill tokens: Home, Train/Log, Weight, Macros, Sleep, Cardio, Insights (renamed from Progress), Programs, Check-In, History, Community, Coach/Clients.
- **New feature**: a real (non-placeholder) "today's planned exercises" session-queue list on the Train tab, reading the active program the same way the existing home-tab card does. Covered by `tests/sessionQueue.test.js`.
- **New desktop Coach workspace** (`coach/index.html`) — a triage-first landing view (stat row, priority-client hero, full roster table, program-templates list) built from real `_clients` data, replacing the previous bare empty state. Review-queue and messaging panels are a marked visual shell (`TODO(coach-workspace):`) since no backing data model exists for either yet. Client-file detail view restyled onto the same tokens.
- Two incidental bugs fixed while touching the code: a circular CSS variable reference in `coach.css`, and a light-mode-only plate-calculator button that never got dark-themed.

## Explicitly out of scope / known gaps

- New metrics the mockup shows (tonnage-vs-target, e1RM trend, MEV/MAV/MRV volume landmarks, readiness score) are **not** computed anywhere — this was a visual-only pass for those, by design.
- Coach workspace's review-queue and messaging panels are shells, marked with `TODO(coach-workspace):` comments.
- A few judgment calls/deviations from the literal mockup are called out in individual commit messages (e.g. Insights keeps its real sub-tab content rather than relabeling to mismatched mockup labels; leaderboard access consolidates through Community instead of duplicating a tile).

## Verification

- `npm test`: 28/28 suites, 96/96 tests passing after every phase.
- Live browser checks throughout: computed-style assertions confirming actual pod radii/gradients/pill colors resolved correctly, full click-through of every nav destination with no console errors or "missing tab" warnings, and a jsdom smoke test for the new coach-workspace logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
