### PR TITLE
Ironlog visual system: fidelity fixes, one-tap logging, real metrics, desktop rail nav

### DIFF
--- a/coach/coach.css
+++ b/coach/coach.css
@@ -311,7 +311,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 34px;
+  height: 44px;
   padding: 0 10px;
   border: none;
   border-radius: 10px;

--- a/coach/coach.css
+++ b/coach/coach.css
@@ -299,6 +299,53 @@ body {
   border-color: var(--primary);
 }
 
+/* Rail nav */
+.rail-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 12px 10px;
+}
+
+.rail-nav-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 34px;
+  padding: 0 10px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-sec);
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+
+.rail-nav-item:hover { background: var(--card); }
+
+.rail-nav-item.active {
+  background: linear-gradient(135deg, rgba(47,138,99,.9), rgba(23,71,47,.85));
+  color: #eafaf1;
+  font-weight: 700;
+}
+
+.rail-nav-count {
+  font-size: 10.5px;
+  font-weight: 800;
+  color: var(--text-muted);
+  background: rgba(5,12,8,.35);
+  border-radius: 99px;
+  padding: 1px 7px;
+}
+
+.rail-nav-item.active .rail-nav-count {
+  color: #eafaf1;
+  background: rgba(5,12,8,.35);
+}
+
 /* Roster / Leads toggle */
 .sidebar-mode-toggle {
   display: flex;

--- a/coach/coach.js
+++ b/coach/coach.js
@@ -327,6 +327,59 @@ function renderWorkspace() {
         '<span class="ws-list-count">' + assigned + '</span></div>';
     }).join('');
   }
+
+  railNavUpdateCounts(counts, programs.length);
+}
+
+// ── Rail nav (left sidebar) ──────────────────────────────────────
+// Queue/Clients/Templates/Check-ins all live on the one workspace page
+// (renderWorkspace() above) — "navigating" is a scroll-to, not a route
+// change. Programs has no view distinct from Templates yet, so it
+// targets the same section; Settings has no desktop view at all yet.
+
+function railNavUpdateCounts(counts, templateCount) {
+  const el = (id) => document.getElementById(id);
+  if (el('railCountQueue')) el('railCountQueue').textContent = counts.action;
+  if (el('railCountClients')) el('railCountClients').textContent = counts.all;
+  if (el('railCountTemplates')) el('railCountTemplates').textContent = templateCount;
+  // "Check-ins outstanding" = clients with no check-in, or none in 7+ days —
+  // real, derived from _clients.lastCheckIn, not a separate data model.
+  const staleCheckins = _clients.filter(c => {
+    if (!c.lastCheckIn) return true;
+    const days = (Date.now() - new Date(c.lastCheckIn).getTime()) / 86400000;
+    return days >= 7;
+  }).length;
+  if (el('railCountCheckins')) el('railCountCheckins').textContent = staleCheckins;
+}
+
+function railNavGo(section) {
+  document.querySelectorAll('.rail-nav-item').forEach(b => b.classList.toggle('active', b.dataset.rail === section));
+
+  const targets = {
+    queue: 'wsPriorityCard',
+    clients: 'wsRailTarget-clients',
+    programs: 'wsRailTarget-templates',
+    templates: 'wsRailTarget-templates',
+    messages: 'wsRailTarget-messages',
+    checkins: 'wsRailTarget-checkins',
+    analytics: 'wsStatRow',
+  };
+
+  if (section === 'settings') {
+    // No desktop settings view exists yet — say so rather than silently
+    // doing nothing or faking a page.
+    alert('Settings isn\'t available in the coach console yet — use the mobile app\'s Settings tab for now.');
+    return;
+  }
+
+  // Any rail destination returns to the workspace view first (in case a
+  // client file is currently open), then scrolls to that section.
+  if (typeof backToWorkspace === 'function' && document.getElementById('clientDetail').style.display !== 'none') {
+    backToWorkspace();
+  }
+  const targetId = targets[section];
+  const targetEl = targetId && document.getElementById(targetId);
+  if (targetEl) targetEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 function toggleBulk(id) {

--- a/coach/index.html
+++ b/coach/index.html
@@ -58,6 +58,33 @@
         <button class="sidebar-invite-btn" id="sidebarInviteBtn" onclick="showInviteModal()">+ Invite</button>
       </div>
 
+      <!-- Rail nav — jumps to the matching section of the workspace view
+           (renderWorkspace() builds Queue/Clients/Templates/Messages/
+           Check-ins/Analytics as one page, so "navigating" here is a
+           scroll-to, not a route change). Counts are real where the app
+           has the data (railNavUpdateCounts() in coach.js); Programs has
+           no view distinct from Templates yet so it routes there too;
+           Settings has no desktop view at all yet — flagged rather than
+           faked. -->
+      <nav class="rail-nav" id="railNav">
+        <button class="rail-nav-item active" data-rail="queue" onclick="railNavGo('queue')">
+          <span>Queue</span><span class="rail-nav-count" id="railCountQueue">0</span>
+        </button>
+        <button class="rail-nav-item" data-rail="clients" onclick="railNavGo('clients')">
+          <span>Clients</span><span class="rail-nav-count" id="railCountClients">0</span>
+        </button>
+        <button class="rail-nav-item" data-rail="programs" onclick="railNavGo('programs')"><span>Programs</span></button>
+        <button class="rail-nav-item" data-rail="templates" onclick="railNavGo('templates')">
+          <span>Templates</span><span class="rail-nav-count" id="railCountTemplates">0</span>
+        </button>
+        <button class="rail-nav-item" data-rail="messages" onclick="railNavGo('messages')"><span>Messages</span></button>
+        <button class="rail-nav-item" data-rail="checkins" onclick="railNavGo('checkins')">
+          <span>Check-ins</span><span class="rail-nav-count" id="railCountCheckins">0</span>
+        </button>
+        <button class="rail-nav-item" data-rail="analytics" onclick="railNavGo('analytics')"><span>Analytics</span></button>
+        <button class="rail-nav-item" data-rail="settings" onclick="railNavGo('settings')" title="Not available in the coach console yet"><span>Settings</span></button>
+      </nav>
+
       <!-- Roster / Leads toggle -->
       <div class="sidebar-mode-toggle" id="sidebarModeToggle">
         <button class="mode-tab active" data-mode="clients">Clients</button>
@@ -108,7 +135,7 @@
           <div class="ws-col-main">
             <div id="wsPriorityCard"></div>
 
-            <div class="pod ws-roster-card">
+            <div class="pod ws-roster-card" id="wsRailTarget-clients">
               <div class="pod-row">
                 <span class="pod-kicker">Client roster</span>
                 <span class="ws-roster-count" id="wsRosterCount"></span>
@@ -118,7 +145,7 @@
           </div>
 
           <div class="ws-col-side">
-            <div class="pod ws-side-card">
+            <div class="pod ws-side-card" id="wsRailTarget-checkins">
               <div class="pod-row">
                 <span class="pod-kicker">Review queue</span>
                 <span class="ws-side-note">phase · due</span>
@@ -128,7 +155,7 @@
               <p class="ws-empty-note">No reviews tracked yet.</p>
             </div>
 
-            <div class="pod ws-side-card">
+            <div class="pod ws-side-card" id="wsRailTarget-templates">
               <div class="pod-row">
                 <span class="pod-kicker">Program templates</span>
                 <span class="ws-side-note">assigned to</span>
@@ -136,7 +163,7 @@
               <div id="wsTemplatesList"></div>
             </div>
 
-            <div class="pod ws-side-card ws-messages-card">
+            <div class="pod ws-side-card ws-messages-card" id="wsRailTarget-messages">
               <div class="pod-row">
                 <span class="pod-kicker">Messages</span>
                 <span class="ws-side-note">TODO(coach-workspace)</span>

--- a/css/base.css
+++ b/css/base.css
@@ -81,6 +81,17 @@ textarea:focus {
   box-shadow: 0 0 0 3px rgba(45, 125, 91, 0.22), inset 0 1px 4px rgba(0, 0, 0, 0.12);
 }
 
+/* Keyboard-navigation focus ring — explicit per the redesign spec,
+   never the invisible/removed browser default. Layers on top of the
+   glow above; :focus-visible only fires for keyboard focus, so a
+   mouse click still gets the glow without the extra outline. */
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid #3d9d73;
+  outline-offset: 2px;
+}
+
 .form-error {
   color: var(--danger);
   margin: 4px 0 0;

--- a/css/design-system.css
+++ b/css/design-system.css
@@ -187,5 +187,76 @@
 #librariesContent { padding: 0 6px; }
 #librariesContent .pod-row { margin-bottom: 8px; }
 
+/* ── Interaction states (global) ──────────────────────────────
+   Applied broadly (pods, pills, capsules, tiles, plain buttons) so
+   every interactive surface gets a consistent hover/active/focus/
+   disabled treatment instead of one-off per-component rules. */
+
+:focus-visible {
+  outline: 2px solid #3d9d73;
+  outline-offset: 2px;
+}
+
+.pod, .pill, .cta-capsule, .stat-tile, .all-hub-tile, .bn-item, .bn-fab {
+  transition: background-color .15s ease, border-color .15s ease,
+              box-shadow .15s ease, transform .1s ease, opacity .15s ease;
+}
+
+@media (hover: hover) {
+  .pod:hover, .all-hub-tile:hover {
+    background: #141b18;
+    border-color: rgba(116, 138, 126, 0.28);
+  }
+  .pill:not(.active):hover {
+    background: var(--elevated-bg);
+    border-color: rgba(116, 138, 126, 0.28);
+  }
+  .cta-capsule:hover, .bn-fab:hover { filter: brightness(1.06); }
+}
+
+.cta-capsule:active,
+.pill:active,
+.all-hub-tile:active,
+.bn-fab:active,
+button:active {
+  transform: scale(0.985);
+  box-shadow: none;
+}
+
+button:disabled,
+.cta-capsule:disabled,
+.pill:disabled,
+[aria-disabled="true"] {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ── Utility ────────────────────────────────────────────────── */
 .tabular-nums { font-variant-numeric: tabular-nums; }
+
+/* Loading skeleton — same geometry as the content it stands in for,
+   so nothing shifts layout when real content replaces it. */
+.skeleton {
+  background: rgba(116, 138, 126, 0.12);
+  border-radius: inherit;
+  color: transparent !important;
+  pointer-events: none;
+}
+.skeleton * { visibility: hidden; }
+@media (prefers-reduced-motion: no-preference) {
+  .skeleton { animation: skeletonPulse 1.4s ease-in-out infinite; }
+}
+@keyframes skeletonPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}

--- a/css/design-system.css
+++ b/css/design-system.css
@@ -70,6 +70,7 @@
   margin-bottom: var(--space-3);
 }
 .pill {
+  position: relative;
   display: inline-flex;
   align-items: center;
   border-radius: var(--radius-pill);
@@ -84,6 +85,14 @@
   color: var(--text-muted);
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+/* Invisible hit-area expansion — keeps the mockup's visual pill height
+   (~29px) while meeting the 44px touch-target acceptance check. Doesn't
+   change layout since the pseudo-element is absolutely positioned. */
+.pill::before {
+  content: "";
+  position: absolute;
+  inset: -8px -2px;
 }
 .pill.active,
 .pill[aria-selected="true"] {
@@ -177,7 +186,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #050c08;
+  color: var(--pill-text-active);
   cursor: pointer;
   flex: none;
 }

--- a/css/design-system.css
+++ b/css/design-system.css
@@ -183,5 +183,9 @@
 }
 .bn-fab svg { display: block; }
 
+/* ── Libraries screen (libraries.js) ──────────────────────────── */
+#librariesContent { padding: 0 6px; }
+#librariesContent .pod-row { margin-bottom: 8px; }
+
 /* ── Utility ────────────────────────────────────────────────── */
 .tabular-nums { font-variant-numeric: tabular-nums; }

--- a/css/features.css
+++ b/css/features.css
@@ -1719,6 +1719,35 @@
   color: #8ec2a4;
 }
 
+/* ── Hero readout + sparkline (renderWeightHero) ── */
+.wt-hero { margin-bottom: 10px; }
+
+.wt-hero-num-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 3px;
+}
+
+.wt-hero-unit {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.wt-hero-avg {
+  font-size: 11px;
+  font-weight: 800;
+  color: #6fae8b;
+  margin-left: 3px;
+}
+
+.wt-hero-spark {
+  width: 100%;
+  height: 60px;
+  display: block;
+  margin-top: 8px;
+}
+
 /* ── Stat strip ── */
 .wt-stat-strip {
   display: grid;

--- a/css/home.css
+++ b/css/home.css
@@ -81,7 +81,7 @@
   justify-content: center;
   font-size: 10.5px;
   font-weight: 800;
-  color: #050c08;
+  color: var(--pill-text-active);
 }
 
 /* ── Visual zones ───────────────────────────────────────────── */

--- a/css/home.css
+++ b/css/home.css
@@ -30,6 +30,60 @@
   position: relative;
 }
 
+/* ── Greeting row ───────────────────────────────────────────── */
+
+.home-greeting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px 10px;
+}
+
+.home-greeting-name {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.home-greeting-meta {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+.home-greeting-icons {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.home-greeting-icon-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.038);
+  border: 1px solid var(--pod-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+}
+
+.home-greeting-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(150deg, #3d9d73, #1a5138);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10.5px;
+  font-weight: 800;
+  color: #050c08;
+}
+
 /* ── Visual zones ───────────────────────────────────────────── */
 
 .home-zone {
@@ -569,14 +623,67 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid transparent;
-  font-size: 0.75rem;
+  font-family: var(--font-label);
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 4px 10px;
-  font-weight: 600;
+  letter-spacing: 0.08em;
+  padding: 5px 11px;
+  font-weight: 800;
   white-space: nowrap;
+}
+
+/* ── Hero big-number row + micro stat grid (mockup pattern, reused
+   by renderHeroPhaseHeader for both the show-day and habit heroes) ── */
+
+.home-hero-num-row {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  margin: 8px 0 11px;
+}
+
+.home-hero-num {
+  font-family: var(--font-display);
+  font-size: 56px;
+  line-height: 0.92;
+}
+
+.home-hero-num-label {
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.home-hero-num-sub {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+.home-hero-statgrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(116, 138, 126, 0.14);
+}
+
+.home-hero-stat-lbl {
+  font-family: var(--font-label);
+  font-size: 8.5px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.home-hero-stat-val {
+  font-size: 13.5px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  margin-top: 1px;
 }
 
 .home-status-pill.is-good {

--- a/css/log.css
+++ b/css/log.css
@@ -67,6 +67,109 @@
 
 .history-open-btn:hover { background: var(--elevated-bg); }
 
+/* ── Train hero — today's session summary + tonnage bar + CTA
+   (session-queue.js renderTrainHero()) ────────────────────────── */
+
+.train-hero-card { margin-bottom: 10px; }
+
+.train-hero-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.train-hero-name {
+  font-family: var(--font-display);
+  font-size: 30px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.train-hero-meta {
+  font-size: 11.5px;
+  color: var(--secondary-text);
+  margin-top: 4px;
+}
+
+.train-hero-rpe { text-align: right; flex: none; }
+
+.train-hero-rpe-val {
+  font-family: var(--font-display);
+  font-size: 20px;
+  line-height: 1.1;
+}
+
+.train-hero-tonnage-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.train-hero-tonnage-track {
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: rgba(0, 0, 0, 0.45);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.55);
+  margin-top: 5px;
+  overflow: hidden;
+}
+
+.train-hero-tonnage-fill {
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(90deg, #236b4e, #6fae8b);
+  transition: width 0.4s ease;
+}
+
+.train-hero-cta {
+  width: 100%;
+  margin-top: 12px;
+  justify-content: center;
+  font-size: 17px;
+}
+
+/* ── Sleep/motivation/soreness/readiness strip ──────────────────── */
+
+.train-strip {
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  background: var(--pod-bg);
+  border: 1px solid var(--pod-border);
+  box-shadow: var(--pod-bevel);
+  padding: 9px 4px;
+}
+
+.train-strip-cell {
+  flex: 1;
+  text-align: center;
+  position: relative;
+}
+
+.train-strip-cell + .train-strip-cell::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1px;
+  height: 22px;
+  background: rgba(116, 138, 126, 0.18);
+}
+
+.train-strip-val {
+  font-size: 13px;
+  font-weight: 800;
+  margin-top: 1px;
+  font-variant-numeric: tabular-nums;
+}
+
 /* ── Session queue — today's planned exercises (session-queue.js) ── */
 
 .sq-card {

--- a/css/log.css
+++ b/css/log.css
@@ -123,7 +123,7 @@
 .train-hero-tonnage-fill {
   height: 8px;
   border-radius: var(--radius-pill);
-  background: linear-gradient(90deg, #236b4e, #6fae8b);
+  background: linear-gradient(90deg, #236b4e, var(--positive-text));
   transition: width 0.4s ease;
 }
 
@@ -227,7 +227,7 @@
 
 .ql-step--plus {
   background: linear-gradient(135deg, #2f8a63, #236b4e);
-  color: #050c08;
+  color: var(--pill-text-active);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
 }
 
@@ -328,7 +328,7 @@
   font-weight: 800;
   font-variant-numeric: tabular-nums;
 }
-.vl-count.is-high { color: #c79a54; }
+.vl-count.is-high { color: var(--warning-gold); }
 
 /* ── Session queue — today's planned exercises (session-queue.js) ── */
 
@@ -373,7 +373,7 @@
 .sq-e1rm {
   font-size: 11.5px;
   font-weight: 700;
-  color: #6fae8b;
+  color: var(--positive-text);
   font-variant-numeric: tabular-nums;
   min-width: 56px;
   text-align: right;
@@ -386,8 +386,8 @@
   min-width: 36px;
   text-align: right;
 }
-.sq-delta.is-up { color: #6fae8b; }
-.sq-delta.is-down { color: #e0707f; }
+.sq-delta.is-up { color: var(--positive-text); }
+.sq-delta.is-down { color: var(--danger-text); }
 .sq-delta.is-flat { color: var(--text-muted); }
 
 /* ── Workout session timer banner ───────────────────────────── */

--- a/css/log.css
+++ b/css/log.css
@@ -170,6 +170,112 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* ── Quick log — one-tap single-set logging (session-queue.js) ──── */
+
+.ql-panel { margin: 10px 0 12px; }
+
+.ql-row {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 9px;
+}
+
+.ql-field { flex: 1; }
+
+.ql-label {
+  font-size: 8.5px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin-bottom: 5px;
+}
+
+.ql-stepper {
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  background: rgba(0, 0, 0, 0.42);
+  border: 1px solid rgba(74, 132, 102, 0.34);
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.5);
+  height: 50px;
+}
+
+.ql-step {
+  width: 40px;
+  height: 40px;
+  margin: 0 4px;
+  flex: none;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--secondary-text);
+  font-size: 19px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* ≥44px touch target even though the visible circle is 40px */
+  position: relative;
+}
+.ql-step::before {
+  content: '';
+  position: absolute;
+  inset: -3px;
+}
+
+.ql-step--plus {
+  background: linear-gradient(135deg, #2f8a63, #236b4e);
+  color: #050c08;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.ql-val {
+  flex: 1;
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-variant-numeric: tabular-nums;
+}
+
+.ql-log-btn {
+  width: 100%;
+  justify-content: center;
+  gap: 10px;
+  font-size: 19px;
+}
+
+/* ── Manual / multi-set entry disclosure (de-emphasized, closed by
+   default now that quick-log is the primary one-tap path) ──────── */
+
+.log-manual-entry {
+  margin-top: 8px;
+  border-top: 1px solid rgba(116, 138, 126, 0.14);
+  padding-top: 4px;
+}
+
+.log-manual-entry-toggle {
+  list-style: none;
+  cursor: pointer;
+  padding: 8px 2px;
+  font-family: var(--font-label);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.log-manual-entry-toggle::-webkit-details-marker { display: none; }
+.log-manual-entry-toggle::before { content: '▸  '; }
+.log-manual-entry[open] .log-manual-entry-toggle::before { content: '▾  '; }
+
+.log-manual-entry-body { padding-top: 6px; }
+
+/* Tappable session-queue row (jumps into quick-log for that exercise) */
+.sq-row--tap { cursor: pointer; }
+.sq-row--tap:hover { background: rgba(255, 255, 255, 0.02); }
+
 /* ── Session queue — today's planned exercises (session-queue.js) ── */
 
 .sq-card {

--- a/css/log.css
+++ b/css/log.css
@@ -430,6 +430,18 @@
   background: rgba(240, 160, 64, 0.1);
 }
 
+/* ── Live exercise-name title (mirrors #exercise input) ─────────── */
+
+.log-exercise-title {
+  font-family: var(--font-display);
+  font-size: 24px;
+  line-height: 1.05;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.log-exercise-title[hidden] { display: none; }
+
 /* ── Set input row (per-set reps/weight/plate-calc/modifiers) ─── */
 
 .set-input-row {

--- a/css/log.css
+++ b/css/log.css
@@ -276,6 +276,60 @@
 .sq-row--tap { cursor: pointer; }
 .sq-row--tap:hover { background: rgba(255, 255, 255, 0.02); }
 
+/* ── Weekly volume landmarks (MEV/MAV/MRV) ──────────────────────── */
+
+.vl-card { margin-bottom: 10px; }
+
+.vl-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 7px;
+}
+.vl-row:last-child { margin-bottom: 0; }
+
+.vl-muscle {
+  width: 52px;
+  flex: none;
+  font-size: 11px;
+  color: var(--secondary-text);
+}
+
+.vl-track {
+  flex: 1;
+  height: 9px;
+  border-radius: var(--radius-pill);
+  background: rgba(0, 0, 0, 0.45);
+  position: relative;
+  overflow: hidden;
+}
+
+.vl-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: var(--radius-pill);
+  transition: width 0.4s ease;
+}
+
+.vl-tick {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1.5px;
+  background: rgba(255, 255, 255, 0.35);
+}
+.vl-tick--mav { background: rgba(199, 154, 84, 0.8); }
+
+.vl-count {
+  width: 44px;
+  flex: none;
+  text-align: right;
+  font-size: 11px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+.vl-count.is-high { color: #c79a54; }
+
 /* ── Session queue — today's planned exercises (session-queue.js) ── */
 
 .sq-card {
@@ -315,6 +369,26 @@
   color: var(--secondary-text);
   font-variant-numeric: tabular-nums;
 }
+
+.sq-e1rm {
+  font-size: 11.5px;
+  font-weight: 700;
+  color: #6fae8b;
+  font-variant-numeric: tabular-nums;
+  min-width: 56px;
+  text-align: right;
+}
+
+.sq-delta {
+  font-size: 10.5px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  min-width: 36px;
+  text-align: right;
+}
+.sq-delta.is-up { color: #6fae8b; }
+.sq-delta.is-down { color: #e0707f; }
+.sq-delta.is-flat { color: var(--text-muted); }
 
 /* ── Workout session timer banner ───────────────────────────── */
 
@@ -547,6 +621,13 @@
 }
 
 .log-exercise-title[hidden] { display: none; }
+
+.log-exercise-stats-line {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+.log-exercise-stats-line[hidden] { display: none; }
 
 /* ── Set input row (per-set reps/weight/plate-calc/modifiers) ─── */
 

--- a/css/settings-ui.css
+++ b/css/settings-ui.css
@@ -5,6 +5,86 @@
    Depends on: tokens.css
    ============================================================= */
 
+/* ── Settings hero summary (settings-hero.js) ────────────────── */
+
+.sh-profile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 10px;
+}
+
+.sh-profile-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(150deg, #3d9d73, #1a5138);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 800;
+  color: #050c08;
+  flex: none;
+}
+
+.sh-profile-name { font-size: 14px; font-weight: 800; }
+.sh-profile-meta { font-size: 10.5px; color: var(--text-muted); margin-top: 1px; }
+
+.sh-group { margin-bottom: 10px; padding: 11px 14px; }
+
+.sh-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid rgba(116, 138, 126, 0.09);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.sh-row:last-child { border-bottom: none; }
+.sh-row-label { flex: 1; }
+.sh-row-sub { font-size: 10.5px; color: var(--text-muted); font-weight: 400; }
+.sh-row-val {
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.sh-toggle {
+  border-radius: var(--radius-pill);
+  background: rgba(0, 0, 0, 0.45);
+  color: var(--text-muted);
+  font-family: var(--font-label);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  padding: 6px 10px;
+}
+
+.sh-toggle.is-on {
+  background: var(--pill-bg-active);
+  color: var(--pill-text-active);
+}
+
+.sh-logout {
+  width: 100%;
+  height: 46px;
+  border-radius: var(--radius-pill);
+  background: rgba(158, 50, 65, 0.14);
+  border: 1px solid rgba(158, 50, 65, 0.4);
+  color: #c9707c;
+  font-family: var(--font-label);
+  font-size: 12.5px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  margin-bottom: 12px;
+}
+
 /* ── Page container ────────────────────────────────────────── */
 
 .settings-page {

--- a/css/settings-ui.css
+++ b/css/settings-ui.css
@@ -24,7 +24,7 @@
   justify-content: center;
   font-size: 14px;
   font-weight: 800;
-  color: #050c08;
+  color: var(--pill-text-active);
   flex: none;
 }
 

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -79,6 +79,7 @@
   --warning-gold:  #c79a54;
   --warning-bg:    rgba(168, 124, 56, 0.16);
   --warning-border: rgba(168, 124, 56, 0.4);
+  --positive-text: #6fae8b;
 }
 
 /* ── Alternate themes ───────────────────────────────────────── */

--- a/index.html
+++ b/index.html
@@ -2986,9 +2986,13 @@
 <!-- ── CLIENTS TAB — roster & individual client management ── -->
 <div id="clientsTab" class="tab-content coach-only">
   <div class="coach-page-header">
-    <h2>Clients</h2>
+    <h2 class="pod-title" style="font-size:20px;">Coach</h2>
     <div class="coach-stats-bar" id="coachStatsBar"></div>
   </div>
+
+  <!-- Triage: priority client + review queue + templates, all real
+       data from coachDashboardState.clients (renderCoachQueue()) -->
+  <div id="coachQueueSection"></div>
 
   <!-- Bulk actions toolbar (hidden until clients are selected) -->
   <div class="coach-bulk-toolbar" id="coachBulkToolbar" hidden>
@@ -3055,6 +3059,14 @@
 <div id="coachingTab" class="tab-content coach-only" style="display:none;" aria-hidden="true"></div>
 
 <div id="settingsTab" class="tab-content">
+  <h2 class="pod-title" style="font-size:20px;padding:0 6px;">Settings</h2>
+
+  <!-- Profile hero + real preference summary (renderSettingsHero()).
+       The full settings form below (#settingsFormContainer) is where
+       everything actually gets changed — this is just the mockup's
+       top-of-screen summary, wired to the same real prefs. -->
+  <div id="settingsHero" style="padding:0 6px;"></div>
+
   <div id="settingsFormContainer" class="panel"></div>
 
   <!-- Knowledge Base Admin Section -->
@@ -3198,6 +3210,12 @@
   <div id="mobilityTabContent"></div>
 </div>
 
+<!-- Libraries: real exercise history grouped by muscle (libraries.js),
+     Functional/Flexibility/Posing route to their existing dedicated tabs. -->
+<div id="librariesTab" class="tab-content">
+  <div id="librariesContent"></div>
+</div>
+
   <!-- Body tab: launcher into Weight/Macros/Sleep/Cardio (each of those
        keeps its own id/render function — this is a menu, not a merge). -->
   <div id="bodyTab" class="tab-content">
@@ -3256,6 +3274,10 @@
     <div class="all-hub-section">
       <div class="all-hub-section-label">Libraries</div>
       <div class="all-hub-grid">
+        <button class="pod all-hub-tile" data-tab="librariesTab" onclick="showTab('librariesTab')">
+          <span class="more-drawer-icon" data-icon="dumbbell"></span>
+          <span>Libraries</span>
+        </button>
         <button class="pod all-hub-tile bb-only" data-tab="posingTab" onclick="showTab('posingTab')">
           <span class="more-drawer-icon" data-icon="award"></span>
           <span>Posing</span>
@@ -4294,6 +4316,9 @@ function showTab(tabName) {
     case 'weightTab':
       renderWeights();
       break;
+    case 'librariesTab':
+      if (typeof renderLibraries === 'function') renderLibraries();
+      break;
     case 'checkInTab':
       renderCheckInTab();
       break;
@@ -4397,6 +4422,7 @@ function showTab(tabName) {
       loadKnowledgeModules();
       renderSubscriptionPanel();
       loadReferralPanel();
+      if (typeof renderSettingsHero === 'function') renderSettingsHero();
 
       // Wire settings sub-tabs via delegation (idempotent)
       const stc = document.getElementById('settingsFormContainer');
@@ -11125,6 +11151,55 @@ async function renderCoachDashboard() {
     coachDashboardState.selectedClientId = null;
   }
   renderCoachDashboardView();
+  if (typeof renderCoachQueue === 'function') renderCoachQueue();
+}
+
+/** Mobile "Coach" triage view: stat row + priority client + review
+ * queue + roster snapshot, matching the mockup's Coach screen. All
+ * from coachDashboardState.clients — the same real roster data
+ * renderCoachDashboard() just loaded, just a different visual cut. */
+function renderCoachQueue() {
+  const el = document.getElementById('coachQueueSection');
+  if (!el) return;
+  const clients = coachDashboardState.clients || [];
+  if (!clients.length) { el.innerHTML = ''; return; }
+
+  const counts = { action: 0, watch: 0, ok: 0 };
+  clients.forEach(c => { if (counts[c.alertStatus] !== undefined) counts[c.alertStatus]++; });
+  const avgCompliance = Math.round(clients.reduce((s, c) => s + (c.compliancePercent || 0), 0) / clients.length);
+
+  const statRow = [
+    ['Reviews due', counts.action, counts.action ? 'ws-stat-danger' : ''],
+    ['Avg compliance', avgCompliance + '%', ''],
+    ['Flagged', counts.watch + counts.action, (counts.watch + counts.action) ? 'ws-stat-warn' : ''],
+  ].map(([label, val, cls]) =>
+    `<div class="pod ws-stat-tile ${cls}"><div class="stat-tile-label">${label}</div><div class="stat-tile-value">${val}</div></div>`
+  ).join('');
+
+  const priority = clients.find(c => c.alertStatus === 'action') || clients.find(c => c.alertStatus === 'watch');
+  const priorityHTML = priority ? `
+    <div class="pod pod--hero ws-priority-card">
+      <div class="pod-row"><span class="pod-kicker">Needs attention</span><span class="ws-priority-tag ${priority.alertStatus}">${priority.alertStatus}</span></div>
+      <div class="ws-priority-main">
+        <span class="ws-priority-name">${escapeCoachText(priority.name)}</span>
+        <span class="ws-priority-meta">${escapeCoachText(priority.currentPhase)} &middot; ${escapeCoachText(priority.primaryStatusMetric)}</span>
+      </div>
+      <button class="cta-capsule ws-priority-cta" onclick="coachDashboardState.selectedClientId='${priority.id}'; if(typeof renderCoachDashboardView==='function') renderCoachDashboardView(); document.getElementById('coachDashboardContent')?.scrollIntoView({behavior:'smooth'});">Open client</button>
+    </div>` : '';
+
+  const roster = clients.slice().sort((a, b) => (a.compliancePercent || 0) - (b.compliancePercent || 0)).slice(0, 5);
+  const rosterHTML = roster.map(c => `
+    <div class="sq-row"><span class="sq-name">${escapeCoachText(c.name)}</span><span class="sq-summary">${c.compliancePercent}%</span></div>
+  `).join('');
+
+  el.innerHTML = `
+    <div class="ws-stat-row" style="grid-template-columns:repeat(3,1fr);margin-bottom:10px;">${statRow}</div>
+    ${priorityHTML}
+    <div class="pod sq-card">
+      <div class="pod-row"><span class="pod-kicker">Roster snapshot</span><span class="sq-count">compliance</span></div>
+      ${rosterHTML}
+    </div>
+  `;
 }
 
 window.renderCoachDashboard = renderCoachDashboard;
@@ -18250,6 +18325,8 @@ window.renderMeetPrep = renderMeetPrep;
   <script src="src/js/reminders.js"></script>
   <script src="src/js/today-program.js"></script>
   <script src="src/js/session-queue.js"></script>
+  <script src="src/js/settings-hero.js"></script>
+  <script src="src/js/libraries.js"></script>
   <script src="src/js/session-context.js"></script>
   <script>
     // Render PR board whenever the Streaks sub-tab becomes active

--- a/index.html
+++ b/index.html
@@ -629,6 +629,10 @@
            Start-session CTA (session-queue.js renderTrainHero()) -->
       <div id="trainHeroCard" style="padding:6px 12px 0;"></div>
 
+      <!-- Weekly MEV/MAV/MRV volume landmarks per muscle, real weekly set
+           counts against published reference ranges (session-queue.js) -->
+      <div id="volumeLandmarksCard" style="padding:0 12px;"></div>
+
       <!-- Today's planned exercises, read from the active program (session-queue.js) -->
       <div id="sessionQueueCard" style="padding:0 12px;"></div>
 
@@ -684,6 +688,7 @@
         <div id="resistance-inputs" class="log-form-card">
 
           <div class="log-exercise-title" id="exerciseLiveTitle" hidden></div>
+          <div class="log-exercise-stats-line" id="exerciseStatsLine" hidden></div>
           <input type="text" id="exercise" placeholder="Exercise name…" list="exerciseSuggestions" oninput="updateAddButtonState(); if(typeof renderInjuryWarning==='function') renderInjuryWarning(this.value); if(typeof renderExerciseVideoHint==='function') renderExerciseVideoHint(this.value); (function(v){var t=document.getElementById('exerciseLiveTitle'); if(!t) return; t.hidden=!v; t.textContent=v;})(this.value); if(typeof initQuickLog==='function') initQuickLog(this.value);" />
           <datalist id="exerciseSuggestions"></datalist>
 
@@ -4340,6 +4345,7 @@ function showTab(tabName) {
       break;
     case 'logTab':
       if (typeof window.renderTrainHero === 'function') window.renderTrainHero();
+      if (typeof window.renderVolumeLandmarks === 'function') window.renderVolumeLandmarks();
       if (typeof window.renderSessionQueue === 'function') window.renderSessionQueue();
       if (typeof window.renderTrainReadinessStrip === 'function') window.renderTrainReadinessStrip();
       if (typeof window.renderSessionSoFar === 'function') window.renderSessionSoFar();

--- a/index.html
+++ b/index.html
@@ -550,15 +550,16 @@
       <span class="sm-since"></span>
     </div>
 
-    <!-- ── Zone 1: Hero — today's program ───────────────────────── -->
+    <!-- ── Greeting row: "Morning, {name}" + date/streak, search+avatar ── -->
+    <div class="home-greeting-row" id="homeGreetingRow"></div>
+
+    <!-- ── Zone 4: Dashboard (JS-rendered cards, archetype-ordered —
+         'hero' renders first, matching the mockup's hero-first layout) ── -->
+    <div id="homeDashboardContent" class="home-dashboard"></div>
+
+    <!-- ── Zone 1: Today's session — program day + split strip ──── -->
     <div class="home-zone home-zone--hero">
       <div id="todayProgramCard"></div>
-    </div>
-
-    <!-- ── Zone 2: Action — readiness + archetype prompt ─────────── -->
-    <div class="home-zone home-zone--action">
-      <div id="readinessHomeCard"></div>
-      <div id="archetypeProfileCard"></div>
     </div>
 
     <!-- ── Zone 3: Weekly glance — summary + steps (2-col) ─────── -->
@@ -592,8 +593,11 @@
       </div>
     </div>
 
-    <!-- ── Zone 4: Dashboard extras (JS-rendered cards) ──────────── -->
-    <div id="homeDashboardContent" class="home-dashboard"></div>
+    <!-- ── Zone 2: Action — readiness + archetype prompt ─────────── -->
+    <div class="home-zone home-zone--action">
+      <div id="readinessHomeCard"></div>
+      <div id="archetypeProfileCard"></div>
+    </div>
 
     <!-- ── Zone 5: Status modes (demoted — utility, not training) ── -->
     <div class="home-zone home-zone--modes">
@@ -621,8 +625,16 @@
     <!-- ══ Sub-view: Log ══════════════════════════════════════════ -->
     <div id="logSub_log" class="log-subview active">
 
+      <!-- Today's session hero: name, muscles, tonnage-target progress,
+           Start-session CTA (session-queue.js renderTrainHero()) -->
+      <div id="trainHeroCard" style="padding:6px 12px 0;"></div>
+
       <!-- Today's planned exercises, read from the active program (session-queue.js) -->
       <div id="sessionQueueCard" style="padding:0 12px;"></div>
+
+      <!-- Sleep/motivation/soreness/readiness strip, from today's daily
+           readiness check-in when filled in (session-queue.js) -->
+      <div id="trainReadinessStrip" class="train-strip" style="margin:0 12px 10px;"></div>
 
       <!-- Session context flags: alt-machine / alt-gym -->
       <div id="sessionContextBar" style="padding:0 12px;"></div>
@@ -4222,6 +4234,7 @@ function showTab(tabName) {
 
   switch (tabName) {
     case 'homeTab':
+      if (typeof renderHomeGreeting === 'function') renderHomeGreeting();
       renderHomeDashboard();
       if (typeof renderArchetypeProfileCard === 'function') renderArchetypeProfileCard();
       if (typeof window.initAiCoach === 'function' && currentUser) window.initAiCoach(currentUser);
@@ -4248,7 +4261,9 @@ function showTab(tabName) {
       }
       break;
     case 'logTab':
+      if (typeof window.renderTrainHero === 'function') window.renderTrainHero();
       if (typeof window.renderSessionQueue === 'function') window.renderSessionQueue();
+      if (typeof window.renderTrainReadinessStrip === 'function') window.renderTrainReadinessStrip();
       if (window.renderWorkouts) renderWorkouts();
       if (typeof window.renderGamificationUI === 'function' && currentUser) {
         window.renderGamificationUI(currentUser);
@@ -9347,54 +9362,58 @@ function renderHeroPhaseHeader(profile, username) {
     const gamification = getHomeGamificationSummary(profile, username);
     const streakCount  = gamification?.habitStreak || gamification?.currentStreak || 0;
     return `
-      <section class="home-dashboard-card home-hero-card">
-        <div class="home-card-header">
-          <p class="home-hero-topline">Habit Command Center</p>
+      <section class="pod pod--hero home-dashboard-card home-hero-card">
+        <div class="pod-row">
+          <span class="pod-kicker">Habit Command Center</span>
           <span class="home-status-pill ${statusPill}">${currentStatus}</span>
         </div>
-        <div class="home-split-grid">
-          <div>
-            <h2 class="home-hero-athlete">${athleteName}</h2>
-            <p class="home-hero-meta"><span class="ui-icon">${ICONS.calendar}</span> ${todayLabel}</p>
-            <p class="home-hero-meta"><span class="ui-icon">${ICONS.flame}</span> Habit Streak: <strong>${streakCount} day${streakCount !== 1 ? 's' : ''}</strong></p>
-            <p class="home-hero-meta"><span class="ui-icon">${ICONS.footprints}</span> Steps today: <strong>${stepsToday.toLocaleString()} / ${stepsGoal.toLocaleString()} (${stepsPct}%)</strong></p>
-          </div>
-          <div class="home-muted-panel">
-            <p class="home-stat-label">Daily Status</p>
-            <p class="home-stat-value" style="margin-bottom:8px;">${currentStatus}</p>
-            <p class="home-stat-label">Next Check-in</p>
-            <p class="home-stat-value">${nextReview}</p>
-          </div>
+        <div class="home-hero-num-row">
+          <span class="home-hero-num">${streakCount}</span>
+          <div><div class="home-hero-num-label">day streak</div><div class="home-hero-num-sub">${todayLabel}</div></div>
+        </div>
+        <div class="home-hero-statgrid">
+          <div><div class="home-hero-stat-lbl">Steps</div><div class="home-hero-stat-val">${stepsToday.toLocaleString()}</div></div>
+          <div><div class="home-hero-stat-lbl">Goal</div><div class="home-hero-stat-val">${stepsPct}%</div></div>
+          <div><div class="home-hero-stat-lbl">Status</div><div class="home-hero-stat-val">${currentStatus}</div></div>
+          <div><div class="home-hero-stat-lbl">Next check-in</div><div class="home-hero-stat-val">${nextReview}</div></div>
         </div>
       </section>
     `;
   }
 
+  const countdownNum = getCountdownDaysNumber(showDateLike);
   return `
-    <section class="home-dashboard-card home-hero-card">
-      <div class="home-card-header">
-        <p class="home-hero-topline">${heroToplineByArchetype[archetype] || 'Command Center'}</p>
+    <section class="pod pod--hero home-dashboard-card home-hero-card">
+      <div class="pod-row">
+        <span class="pod-kicker">${heroToplineByArchetype[archetype] || 'Command Center'}</span>
         <span class="home-status-pill ${statusPill}">${currentStatus}</span>
       </div>
-      <div class="home-split-grid">
-        <div>
-          <h2 class="home-hero-athlete">${athleteName}</h2>
-          <p class="home-hero-meta">Current Phase: ${phase}</p>
-          <p class="home-hero-meta">Phase Label: ${weekLabel}</p>
-          <p class="home-hero-meta">${weeksOut}</p>
-          <p class="home-hero-meta">Show Date: ${showDate}</p>
-          <p class="home-hero-meta">Days Until Show: ${showCountdown}</p>
-          <p class="home-hero-meta">Date: ${todayLabel}</p>
-        </div>
-        <div class="home-muted-panel">
-          <p class="home-stat-label">Current Status</p>
-          <p class="home-stat-value" style="margin-bottom:8px;">${currentStatus}</p>
-          <p class="home-stat-label">Next Review</p>
-          <p class="home-stat-value">${nextReview}</p>
-        </div>
+      ${countdownNum != null ? `
+      <div class="home-hero-num-row">
+        <span class="home-hero-num">${countdownNum}</span>
+        <div><div class="home-hero-num-label">days out</div><div class="home-hero-num-sub">${weeksOut}</div></div>
+      </div>` : `
+      <h2 class="home-hero-athlete">${athleteName}</h2>
+      <p class="home-hero-meta">${phase} &middot; ${weekLabel}</p>`}
+      <div class="home-hero-statgrid">
+        <div><div class="home-hero-stat-lbl">Phase</div><div class="home-hero-stat-val">${phase}</div></div>
+        <div><div class="home-hero-stat-lbl">Show date</div><div class="home-hero-stat-val">${showDate}</div></div>
+        <div><div class="home-hero-stat-lbl">Status</div><div class="home-hero-stat-val">${currentStatus}</div></div>
+        <div><div class="home-hero-stat-lbl">Next review</div><div class="home-hero-stat-val">${nextReview}</div></div>
       </div>
     </section>
   `;
+}
+
+/** Big-digit days-out for the hero card; null when there's no usable show date. */
+function getCountdownDaysNumber(dateLike) {
+  if (!dateLike) return null;
+  const showDate = new Date(dateLike);
+  if (Number.isNaN(showDate.getTime())) return null;
+  const now = new Date();
+  const ms = showDate.setHours(0, 0, 0, 0) - now.setHours(0, 0, 0, 0);
+  const days = Math.ceil(ms / (1000 * 60 * 60 * 24));
+  return days < 0 ? null : days;
 }
 
 function formatComplianceStatus(statusKey) {
@@ -10015,6 +10034,29 @@ function renderCompactProgressionSummary(profile, username) {
       <p class="home-mission-progress"><strong>Recent:</strong> ${recentProgressText}</p>
     </section>
   `;
+}
+
+function renderHomeGreeting() {
+  const el = document.getElementById('homeGreetingRow');
+  if (!el) return;
+  const { username, profile } = getHomeDashboardSourceData();
+  const displayName = getSafeDisplayValue(profile?.athleteName || username, 'there');
+  const hour = new Date().getHours();
+  const timeOfDay = hour < 12 ? 'Morning' : hour < 18 ? 'Afternoon' : 'Evening';
+  const dateStr = new Date().toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+  const gamification = getHomeGamificationSummary(profile, username);
+  const streakCount = gamification?.habitStreak || gamification?.currentStreak || 0;
+  const initials = (displayName || '?').split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
+
+  el.innerHTML = `
+    <div>
+      <div class="home-greeting-name">${timeOfDay}, ${displayName}</div>
+      <div class="home-greeting-meta">${dateStr}${streakCount ? ` &middot; day ${streakCount} of the streak` : ''}</div>
+    </div>
+    <div class="home-greeting-icons">
+      <button class="home-greeting-icon-btn" onclick="showTab('allTab')" aria-label="Search / everything"><span class="ui-icon" data-icon="search"></span></button>
+      <span class="home-greeting-avatar">${initials}</span>
+    </div>`;
 }
 
 function renderHomeDashboard() {

--- a/index.html
+++ b/index.html
@@ -684,7 +684,7 @@
         <div id="resistance-inputs" class="log-form-card">
 
           <div class="log-exercise-title" id="exerciseLiveTitle" hidden></div>
-          <input type="text" id="exercise" placeholder="Exercise name…" list="exerciseSuggestions" oninput="updateAddButtonState(); if(typeof renderInjuryWarning==='function') renderInjuryWarning(this.value); if(typeof renderExerciseVideoHint==='function') renderExerciseVideoHint(this.value); (function(v){var t=document.getElementById('exerciseLiveTitle'); if(!t) return; t.hidden=!v; t.textContent=v;})(this.value);" />
+          <input type="text" id="exercise" placeholder="Exercise name…" list="exerciseSuggestions" oninput="updateAddButtonState(); if(typeof renderInjuryWarning==='function') renderInjuryWarning(this.value); if(typeof renderExerciseVideoHint==='function') renderExerciseVideoHint(this.value); (function(v){var t=document.getElementById('exerciseLiveTitle'); if(!t) return; t.hidden=!v; t.textContent=v;})(this.value); if(typeof initQuickLog==='function') initQuickLog(this.value);" />
           <datalist id="exerciseSuggestions"></datalist>
 
           <!-- Progressive overload hint -->
@@ -693,87 +693,128 @@
           <!-- Coach technique video hint -->
           <div id="exerciseVideoHint" class="exercise-video-hint" style="display:none;"></div>
 
-          <!-- Sets + unit on one row -->
-          <div class="sets-unit-row">
-            <input type="number" id="sets" placeholder="Sets" oninput="generateSetInputs(this.value); updateAddButtonState();" />
-            <select id="weightUnit">
-              <option value="kg">kg</option>
-              <option value="lbs">lbs</option>
-            </select>
-          </div>
-
-          <!-- Machine at its weight ceiling — can't add more load next time -->
-          <label class="set-opt-pill maxed-out-pill" title="This machine/exercise is at its weight limit — progression suggestions will focus on reps instead of weight.">
-            <input type="checkbox" id="maxedOutToggle" />
-            <span>🔒 Maxed Out</span>
-          </label>
-
-          <!-- Dynamically generated set inputs -->
-          <div id="setInputsContainer"></div>
-
-          <!-- Template quick-load -->
-          <select id="resistanceTemplateSelect" class="log-template-select" onchange="loadSelectedResistanceTemplate()">
-            <option value="">Load a template…</option>
-          </select>
-          <div id="templateLoadMessage" style="margin-top:4px; color:#b00020; display:none;"></div>
-
-          <!-- Advanced options panel (modern custom toggle) -->
-          <div class="log-advanced" id="logAdvancedPanel">
-            <button class="log-adv-toggle" id="logAdvToggle" aria-expanded="false" type="button" onclick="toggleLogAdvanced()">
-              <span class="log-adv-left">
-                <svg class="log-adv-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-                  <line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/>
-                  <line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/>
-                  <line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/>
-                  <line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/>
-                  <line x1="17" y1="16" x2="23" y2="16"/>
-                </svg>
-                Advanced
-                <span class="log-adv-dot" id="logAdvDot"></span>
-              </span>
-              <svg class="log-adv-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
-                <polyline points="6 9 12 15 18 9"/>
-              </svg>
-            </button>
-            <div class="log-advanced-body" id="logAdvBody" hidden>
-              <div class="log-adv-grid">
-                <div class="log-adv-field">
-                  <label class="log-adv-label" for="goal">Target weight</label>
-                  <input type="number" id="goal" placeholder="e.g. 100" oninput="_updateLogAdvDot()" />
-                </div>
-                <div class="log-adv-field">
-                  <label class="log-adv-label" for="repGoal">Target reps</label>
-                  <input type="number" id="repGoal" placeholder="e.g. 8" oninput="_updateLogAdvDot()" />
-                </div>
-                <div class="log-adv-field">
-                  <label class="log-adv-label" for="targetRPE">
-                    RPE <span class="log-adv-hint">1–10</span>
-                  </label>
-                  <input type="number" id="targetRPE" placeholder="e.g. 8" min="1" max="10" step="0.5" inputmode="decimal" oninput="_updateLogAdvDot()" />
-                </div>
-                <div class="log-adv-field">
-                  <label class="log-adv-label" for="targetRIR">
-                    RIR <span class="log-adv-hint">0–5</span>
-                  </label>
-                  <input type="number" id="targetRIR" placeholder="e.g. 2" min="0" max="5" step="1" inputmode="numeric" oninput="_updateLogAdvDot()" />
+          <!-- Quick log: one-tap single-set logging. Drives the exact
+               same #sets/#reps_0/#weight_0 fields + addLogEntry() as the
+               manual form below — no separate save path, no new data
+               shape, just a faster front door onto it (session-queue.js). -->
+          <div class="ql-panel" id="quickLogPanel" hidden>
+            <div class="ql-row">
+              <div class="ql-field">
+                <div class="ql-label">Weight <span id="qlUnitLabel">kg</span></div>
+                <div class="ql-stepper">
+                  <button type="button" class="ql-step" onclick="quickLogStep('weight',-1)" aria-label="Decrease weight">−</button>
+                  <span class="ql-val" id="qlWeightVal">—</span>
+                  <button type="button" class="ql-step ql-step--plus" onclick="quickLogStep('weight',1)" aria-label="Increase weight">+</button>
                 </div>
               </div>
-              <div class="log-adv-rpe-row">
-                <span class="log-adv-rpe-scale">
-                  <span class="rpe-tick rpe-easy">6 Easy</span>
-                  <span class="rpe-bar"></span>
-                  <span class="rpe-tick rpe-hard">10 Max</span>
-                </span>
-                <span class="log-adv-rir-note">RPE + RIR ≈ 10</span>
-              </div>
-              <div class="log-adv-field log-adv-field--full">
-                <label class="log-adv-label" for="entryDate">Log date</label>
-                <input type="date" id="entryDate" oninput="_updateLogAdvDot()" />
+              <div class="ql-field">
+                <div class="ql-label">Reps</div>
+                <div class="ql-stepper">
+                  <button type="button" class="ql-step" onclick="quickLogStep('reps',-1)" aria-label="Decrease reps">−</button>
+                  <span class="ql-val" id="qlRepsVal">—</span>
+                  <button type="button" class="ql-step ql-step--plus" onclick="quickLogStep('reps',1)" aria-label="Increase reps">+</button>
+                </div>
               </div>
             </div>
+            <button type="button" class="cta-capsule ql-log-btn" id="qlLogBtn" onclick="quickLogSet()">
+              <span id="qlLogBtnLabel">Log set</span>
+              <span class="cta-capsule-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round"><path d="M5 13l4 4L19 7"/></svg></span>
+            </button>
           </div>
 
-          <button id="addLogBtn" onclick="addLogEntry()" disabled class="log-add-btn">+ Add to Log</button>
+          <!-- Manual / multi-set entry — everything the quick-log panel
+               above doesn't cover (custom set counts, per-set drop-sets/
+               rest-pause/unilateral, target RPE/RIR, template loading,
+               back-dating). Nothing here changed; just tucked behind a
+               disclosure so quick-log is the default one-tap path. -->
+          <details class="log-manual-entry" id="logManualEntry">
+            <summary class="log-manual-entry-toggle">Manual / multi-set entry</summary>
+            <div class="log-manual-entry-body">
+
+            <!-- Sets + unit on one row -->
+            <div class="sets-unit-row">
+              <input type="number" id="sets" placeholder="Sets" oninput="generateSetInputs(this.value); updateAddButtonState();" />
+              <select id="weightUnit" onchange="if(typeof syncQuickLogUnit==='function') syncQuickLogUnit(this.value);">
+                <option value="kg">kg</option>
+                <option value="lbs">lbs</option>
+              </select>
+            </div>
+
+            <!-- Machine at its weight ceiling — can't add more load next time -->
+            <label class="set-opt-pill maxed-out-pill" title="This machine/exercise is at its weight limit — progression suggestions will focus on reps instead of weight.">
+              <input type="checkbox" id="maxedOutToggle" />
+              <span>🔒 Maxed Out</span>
+            </label>
+
+            <!-- Dynamically generated set inputs -->
+            <div id="setInputsContainer"></div>
+
+            <!-- Template quick-load -->
+            <select id="resistanceTemplateSelect" class="log-template-select" onchange="loadSelectedResistanceTemplate()">
+              <option value="">Load a template…</option>
+            </select>
+            <div id="templateLoadMessage" style="margin-top:4px; color:#b00020; display:none;"></div>
+
+            <!-- Advanced options panel (modern custom toggle) -->
+            <div class="log-advanced" id="logAdvancedPanel">
+              <button class="log-adv-toggle" id="logAdvToggle" aria-expanded="false" type="button" onclick="toggleLogAdvanced()">
+                <span class="log-adv-left">
+                  <svg class="log-adv-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                    <line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/>
+                    <line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/>
+                    <line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/>
+                    <line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/>
+                    <line x1="17" y1="16" x2="23" y2="16"/>
+                  </svg>
+                  Advanced
+                  <span class="log-adv-dot" id="logAdvDot"></span>
+                </span>
+                <svg class="log-adv-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+                  <polyline points="6 9 12 15 18 9"/>
+                </svg>
+              </button>
+              <div class="log-advanced-body" id="logAdvBody" hidden>
+                <div class="log-adv-grid">
+                  <div class="log-adv-field">
+                    <label class="log-adv-label" for="goal">Target weight</label>
+                    <input type="number" id="goal" placeholder="e.g. 100" oninput="_updateLogAdvDot()" />
+                  </div>
+                  <div class="log-adv-field">
+                    <label class="log-adv-label" for="repGoal">Target reps</label>
+                    <input type="number" id="repGoal" placeholder="e.g. 8" oninput="_updateLogAdvDot()" />
+                  </div>
+                  <div class="log-adv-field">
+                    <label class="log-adv-label" for="targetRPE">
+                      RPE <span class="log-adv-hint">1–10</span>
+                    </label>
+                    <input type="number" id="targetRPE" placeholder="e.g. 8" min="1" max="10" step="0.5" inputmode="decimal" oninput="_updateLogAdvDot()" />
+                  </div>
+                  <div class="log-adv-field">
+                    <label class="log-adv-label" for="targetRIR">
+                      RIR <span class="log-adv-hint">0–5</span>
+                    </label>
+                    <input type="number" id="targetRIR" placeholder="e.g. 2" min="0" max="5" step="1" inputmode="numeric" oninput="_updateLogAdvDot()" />
+                  </div>
+                </div>
+                <div class="log-adv-rpe-row">
+                  <span class="log-adv-rpe-scale">
+                    <span class="rpe-tick rpe-easy">6 Easy</span>
+                    <span class="rpe-bar"></span>
+                    <span class="rpe-tick rpe-hard">10 Max</span>
+                  </span>
+                  <span class="log-adv-rir-note">RPE + RIR ≈ 10</span>
+                </div>
+                <div class="log-adv-field log-adv-field--full">
+                  <label class="log-adv-label" for="entryDate">Log date</label>
+                  <input type="date" id="entryDate" oninput="_updateLogAdvDot()" />
+                </div>
+              </div>
+            </div>
+
+            <button id="addLogBtn" onclick="addLogEntry()" disabled class="log-add-btn">+ Add to Log</button>
+
+            </div>
+          </details>
 
         </div><!-- /log-form-card -->
 

--- a/index.html
+++ b/index.html
@@ -913,8 +913,19 @@
 
       <!-- ── Header ── -->
       <div class="wt-header">
-        <h2 class="wt-title"><span class="ui-icon" data-icon="scale"></span> Bodyweight Tracker</h2>
+        <h2 class="wt-title pod-title" style="font-size:20px;">Body</h2>
         <div id="wtTrendBadge" class="wt-trend-badge" style="display:none;"></div>
+      </div>
+
+      <!-- ── Hero: big current-weight readout + sparkline (renderWeightHero) ── -->
+      <div class="pod pod--hero wt-hero" id="wtHero" style="display:none;">
+        <div class="pod-kicker">Bodyweight</div>
+        <div class="wt-hero-num-row">
+          <span class="home-hero-num" id="wtHeroValue">—</span>
+          <span class="wt-hero-unit" id="wtHeroUnit">kg</span>
+          <span class="wt-hero-avg" id="wtHeroAvg"></span>
+        </div>
+        <svg class="wt-hero-spark" id="wtHeroSparkline" viewBox="0 0 330 60" preserveAspectRatio="none"></svg>
       </div>
 
       <!-- ── Stat strip (populated by renderWeights) ── -->
@@ -12298,6 +12309,9 @@ function renderWeights() {
     if (chg) { chg.textContent = changeDisp; chg.className = 'wt-stat-val ' + (changeKg > 0 ? 'wt-up' : changeKg < 0 ? 'wt-down' : ''); }
     if (ent) ent.textContent = log.length;
 
+    // ── Hero readout + sparkline ──
+    renderWeightHero(log, lastKg, displayUnit);
+
     // ── Weekly averages & rate ──
     renderWeeklyBreakdown(log, displayUnit);
   } else {
@@ -12306,6 +12320,8 @@ function renderWeights() {
     if (logCount) logCount.textContent = '';
     const wkCard = document.getElementById('wtWeeklyCard');
     if (wkCard) wkCard.style.display = 'none';
+    const heroEl = document.getElementById('wtHero');
+    if (heroEl) heroEl.style.display = 'none';
   }
 
   log.slice().reverse().forEach((entry, revIdx) => {
@@ -12325,6 +12341,54 @@ function renderWeights() {
       showBodyweightProgress();
     } else {
       showWorkoutProgress();
+    }
+  }
+}
+
+/** Big Anton current-weight readout + a real sparkline over the last
+ * entries — all from the same log array/unit renderWeights() already
+ * computed, just given the mockup's hero visual treatment. */
+function renderWeightHero(log, lastKg, displayUnit) {
+  const heroEl = document.getElementById('wtHero');
+  if (!heroEl) return;
+  heroEl.style.display = '';
+
+  const valueEl = document.getElementById('wtHeroValue');
+  const unitEl = document.getElementById('wtHeroUnit');
+  const avgEl = document.getElementById('wtHeroAvg');
+  const sparkEl = document.getElementById('wtHeroSparkline');
+  const toDispNum = (kg) => kg != null ? convertWeightValue(kg, 'kg', displayUnit, 1) : null;
+
+  if (valueEl) valueEl.textContent = toDispNum(lastKg) ?? '—';
+  if (unitEl) unitEl.textContent = displayUnit;
+
+  const recent = log.slice(-7);
+  const recentVals = recent.map(e => getEntryWeightKg(e)).filter(v => v != null);
+  if (avgEl) {
+    if (recentVals.length) {
+      const avg = recentVals.reduce((a, b) => a + b, 0) / recentVals.length;
+      avgEl.textContent = '7d avg ' + toDispNum(avg).toFixed(1);
+      avgEl.style.display = '';
+    } else {
+      avgEl.style.display = 'none';
+    }
+  }
+
+  if (sparkEl) {
+    const points = log.slice(-14).map(e => getEntryWeightKg(e)).filter(v => v != null);
+    if (points.length >= 2) {
+      const min = Math.min(...points), max = Math.max(...points);
+      const range = max - min || 1;
+      const w = 330, h = 60, pad = 6;
+      const coords = points.map((v, i) => {
+        const x = (i / (points.length - 1)) * w;
+        const y = pad + (1 - (v - min) / range) * (h - pad * 2);
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      });
+      sparkEl.innerHTML = `<polyline points="${coords.join(' ')}" fill="none" stroke="#6fae8b" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>`;
+      sparkEl.style.display = '';
+    } else {
+      sparkEl.style.display = 'none';
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -683,7 +683,8 @@
       <div id="resistance-section">
         <div id="resistance-inputs" class="log-form-card">
 
-          <input type="text" id="exercise" placeholder="Exercise name…" list="exerciseSuggestions" oninput="updateAddButtonState(); if(typeof renderInjuryWarning==='function') renderInjuryWarning(this.value); if(typeof renderExerciseVideoHint==='function') renderExerciseVideoHint(this.value);" />
+          <div class="log-exercise-title" id="exerciseLiveTitle" hidden></div>
+          <input type="text" id="exercise" placeholder="Exercise name…" list="exerciseSuggestions" oninput="updateAddButtonState(); if(typeof renderInjuryWarning==='function') renderInjuryWarning(this.value); if(typeof renderExerciseVideoHint==='function') renderExerciseVideoHint(this.value); (function(v){var t=document.getElementById('exerciseLiveTitle'); if(!t) return; t.hidden=!v; t.textContent=v;})(this.value);" />
           <datalist id="exerciseSuggestions"></datalist>
 
           <!-- Progressive overload hint -->
@@ -775,6 +776,9 @@
           <button id="addLogBtn" onclick="addLogEntry()" disabled class="log-add-btn">+ Add to Log</button>
 
         </div><!-- /log-form-card -->
+
+        <!-- Exercises already logged today (session-queue.js renderSessionSoFar()) -->
+        <div id="sessionSoFarCard" style="margin-top:10px;"></div>
 
         <!-- Logs render here -->
         <div id="workoutsContainer" style="margin-top:16px;"></div>
@@ -4264,6 +4268,7 @@ function showTab(tabName) {
       if (typeof window.renderTrainHero === 'function') window.renderTrainHero();
       if (typeof window.renderSessionQueue === 'function') window.renderSessionQueue();
       if (typeof window.renderTrainReadinessStrip === 'function') window.renderTrainReadinessStrip();
+      if (typeof window.renderSessionSoFar === 'function') window.renderSessionSoFar();
       if (window.renderWorkouts) renderWorkouts();
       if (typeof window.renderGamificationUI === 'function' && currentUser) {
         window.renderGamificationUI(currentUser);
@@ -5056,6 +5061,7 @@ function addLogEntry() {
     syncLocalHistoryFromWorkouts();
   }
   renderWorkouts();
+  if (typeof window.renderSessionSoFar === 'function') window.renderSessionSoFar();
   updateTrainingCalendar();
 
   // ✅ Clear form inputs

--- a/src/js/libraries.js
+++ b/src/js/libraries.js
@@ -31,44 +31,119 @@
     return COARSE_GROUPS[fine] || 'Other';
   }
 
-  /** { name -> { lastDate, lastReps, lastWeight, muscle, logCount } } across
-   * both the live and archived history stores. */
-  function _buildExerciseHistory() {
+  /** Epley-style e1RM, matching the formula addLogEntry() already uses
+   * for its own estimated1RM field — keep this consistent app-wide. */
+  function _e1rm(weight, reps) {
+    if (weight == null || reps == null) return 0;
+    return Number(weight) * (1 + Number(reps) / 30);
+  }
+
+  /** name -> [{ date, reps:[], weights:[] }, ...] (one array entry per
+   * logged session of that exercise), sorted most-recent-first, across
+   * both the live (workouts_<user>) and archived (tl_workout_history_v1)
+   * stores. This is the single real data source every stat below is
+   * derived from — no exercise database, no fabricated numbers. */
+  function _buildExerciseSessions() {
     const u = _user();
     const map = new Map();
     if (!u || typeof localStorage === 'undefined') return map;
 
-    const record = (name, dateStr, reps, weight) => {
-      if (!name) return;
-      const existing = map.get(name);
-      if (!existing || (dateStr && dateStr > existing.lastDate)) {
-        map.set(name, { name, lastDate: dateStr || '', lastReps: reps, lastWeight: weight, muscle: _coarseGroup(name), logCount: (existing?.logCount || 0) + 1 });
-      } else {
-        existing.logCount += 1;
-      }
+    const record = (name, dateStr, reps, weights) => {
+      if (!name || !dateStr) return;
+      const list = map.get(name) || [];
+      list.push({ date: dateStr, reps: reps || [], weights: weights || [] });
+      map.set(name, list);
     };
 
     try {
       const workouts = JSON.parse(localStorage.getItem('workouts_' + u)) || [];
       workouts.forEach(w => (w.log || []).forEach(entry => {
-        const reps = Array.isArray(entry.repsArray) ? entry.repsArray : [];
-        const weights = Array.isArray(entry.weightsArray) ? entry.weightsArray : [];
-        record(entry.exercise, w.date, reps[reps.length - 1], weights[weights.length - 1]);
+        record(entry.exercise, w.date,
+          Array.isArray(entry.repsArray) ? entry.repsArray : [],
+          Array.isArray(entry.weightsArray) ? entry.weightsArray : []);
       }));
     } catch { /* ignore malformed storage */ }
 
     try {
       const archived = JSON.parse(localStorage.getItem('tl_workout_history_v1')) || [];
       archived.filter(w => !w.userId || w.userId === u).forEach(w => (w.exercises || []).forEach(ex => {
-        const reps = Array.isArray(ex.repsArray) ? ex.repsArray : [];
-        const weights = Array.isArray(ex.weightsArray) ? ex.weightsArray : [];
-        const dateStr = (w.date || '').slice(0, 10);
-        record(ex.name, dateStr, reps[reps.length - 1], weights[weights.length - 1]);
+        record(ex.name, (w.date || '').slice(0, 10),
+          Array.isArray(ex.repsArray) ? ex.repsArray : [],
+          Array.isArray(ex.weightsArray) ? ex.weightsArray : []);
       }));
     } catch { /* ignore malformed storage */ }
 
+    // Same exercise can appear as several single-set sessions on the same
+    // date (quick-log) — merge same-date sessions into one before sorting,
+    // so "last session" means "last day trained", not "last single set".
+    map.forEach((sessions, name) => {
+      const byDate = new Map();
+      sessions.forEach(s => {
+        const existing = byDate.get(s.date);
+        if (existing) { existing.reps.push(...s.reps); existing.weights.push(...s.weights); }
+        else byDate.set(s.date, { date: s.date, reps: s.reps.slice(), weights: s.weights.slice() });
+      });
+      map.set(name, Array.from(byDate.values()).sort((a, b) => b.date.localeCompare(a.date)));
+    });
+
     return map;
   }
+
+  /** { lastDate, lastReps, lastWeight, muscle, logCount } per exercise —
+   * the flat summary Libraries' list view needs. */
+  function _buildExerciseHistory() {
+    const sessions = _buildExerciseSessions();
+    const map = new Map();
+    sessions.forEach((list, name) => {
+      const last = list[0];
+      const lastReps = last ? last.reps[last.reps.length - 1] : null;
+      const lastWeight = last ? last.weights[last.weights.length - 1] : null;
+      const logCount = list.reduce((n, s) => n + s.reps.length, 0);
+      map.set(name, { name, lastDate: last ? last.date : '', lastReps, lastWeight, muscle: _coarseGroup(name), logCount });
+    });
+    return map;
+  }
+
+  /** Real per-exercise stats for the density the redesign spec calls
+   * for: best-ever e1RM, and a week-over-week delta comparing the most
+   * recent logged session's top set against the one before it. Returns
+   * null if the exercise has fewer than 1 logged session. */
+  function getExerciseStats(name) {
+    const sessions = _buildExerciseSessions().get(name);
+    if (!sessions || !sessions.length) return null;
+
+    let bestE1rm = 0;
+    sessions.forEach(s => s.reps.forEach((r, i) => {
+      bestE1rm = Math.max(bestE1rm, _e1rm(s.weights[i], r));
+    }));
+
+    const topSetOf = (session) => {
+      if (!session) return null;
+      let top = null, topE1rm = -1;
+      session.reps.forEach((r, i) => {
+        const e = _e1rm(session.weights[i], r);
+        if (e > topE1rm) { topE1rm = e; top = { reps: r, weight: session.weights[i], e1rm: e }; }
+      });
+      return top;
+    };
+
+    const last = topSetOf(sessions[0]);
+    const previous = topSetOf(sessions[1]);
+    const pctOf1rm = last && bestE1rm ? Math.round((last.weight / bestE1rm) * 100) : null;
+    const deltaWeight = last && previous ? _round1(last.weight - previous.weight) : null;
+
+    return {
+      bestE1rm: Math.round(bestE1rm * 10) / 10,
+      lastDate: sessions[0].date,
+      lastTopSet: last,
+      previousTopSet: previous,
+      pctOf1rm,
+      deltaWeight,
+      sessionCount: sessions.length,
+    };
+  }
+
+  function _round1(n) { return Math.round(n * 10) / 10; }
 
   function _formatDate(dateStr) {
     if (!dateStr) return '—';
@@ -99,17 +174,21 @@
 
     const filtered = _activeGroup === 'all' ? history : history.filter(e => e.muscle === _activeGroup);
 
-    const rows = filtered.slice(0, 40).map(e => `
+    const rows = filtered.slice(0, 40).map(e => {
+      const stats = getExerciseStats(e.name);
+      return `
       <div class="sq-row">
         <span class="sq-name">${e.name}</span>
         <span class="sq-summary">${_formatDate(e.lastDate)}${e.lastReps != null ? ' &middot; ' + e.lastReps + (e.lastWeight != null ? '×' + e.lastWeight : '') : ''}</span>
-      </div>`).join('');
+        <span class="sq-e1rm">${stats && stats.bestE1rm ? stats.bestE1rm + ' kg' : '—'}</span>
+      </div>`;
+    }).join('');
 
     el.innerHTML = `
       <div class="pod-row"><span class="pod-title" style="font-size:20px;">Libraries</span><span class="ws-header-sub">${history.length} exercises logged</span></div>
       <div class="pill-nav">${pillRow}</div>
       <div class="pod sq-card">
-        <div class="pod-row"><span class="pod-kicker">${_activeGroup === 'all' ? 'All exercises' : _activeGroup}</span><span class="sq-count">last used</span></div>
+        <div class="pod-row"><span class="pod-kicker">${_activeGroup === 'all' ? 'All exercises' : _activeGroup}</span><span class="sq-count">e1RM &middot; last used</span></div>
         ${rows || '<p class="ws-empty-note">Nothing logged in this group yet.</p>'}
       </div>
       <div class="pill-nav" style="margin-top:12px;">
@@ -122,7 +201,9 @@
 
   global.renderLibraries = renderLibraries;
   global.selectLibraryGroup = selectLibraryGroup;
+  global.getExerciseStats = getExerciseStats;
+  global.getCoarseMuscleGroup = _coarseGroup;
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { renderLibraries, selectLibraryGroup };
+    module.exports = { renderLibraries, selectLibraryGroup, getExerciseStats, getCoarseMuscleGroup: _coarseGroup };
   }
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/src/js/libraries.js
+++ b/src/js/libraries.js
@@ -1,0 +1,128 @@
+/**
+ * libraries.js
+ * The "Libraries" screen: a real per-exercise history list (last used +
+ * last set) grouped by muscle, built from the same two stores the rest
+ * of the app already writes to — no fabricated exercise database.
+ *   - workouts_<user>            current/recent days (addLogEntry.js)
+ *   - tl_workout_history_v1      archived days (archiveOldWorkouts.js)
+ * Functional/Flexibility/Posing have no structured plan/history data
+ * model in the app yet, so those pills route to the existing dedicated
+ * tabs (functionalTab/mobilityTab/posingTab) instead of showing
+ * fabricated content — same "launcher" pattern as the Body tab.
+ */
+(function (global) {
+  'use strict';
+
+  const COARSE_GROUPS = {
+    chest: 'Chest',
+    back: 'Back', traps: 'Back',
+    shoulders: 'Delts',
+    biceps: 'Arms', triceps: 'Arms', forearms: 'Arms',
+    legs: 'Legs', quads: 'Legs', hamstrings: 'Legs', glutes: 'Legs', calves: 'Legs', abductors: 'Legs', adductors: 'Legs',
+    abs: 'Core',
+  };
+
+  function _user() {
+    return global.currentUser || (typeof localStorage !== 'undefined' && localStorage.getItem('fitnessAppUser'));
+  }
+
+  function _coarseGroup(exerciseName) {
+    const fine = typeof global.getMuscleGroup === 'function' ? global.getMuscleGroup(exerciseName) : 'other';
+    return COARSE_GROUPS[fine] || 'Other';
+  }
+
+  /** { name -> { lastDate, lastReps, lastWeight, muscle, logCount } } across
+   * both the live and archived history stores. */
+  function _buildExerciseHistory() {
+    const u = _user();
+    const map = new Map();
+    if (!u || typeof localStorage === 'undefined') return map;
+
+    const record = (name, dateStr, reps, weight) => {
+      if (!name) return;
+      const existing = map.get(name);
+      if (!existing || (dateStr && dateStr > existing.lastDate)) {
+        map.set(name, { name, lastDate: dateStr || '', lastReps: reps, lastWeight: weight, muscle: _coarseGroup(name), logCount: (existing?.logCount || 0) + 1 });
+      } else {
+        existing.logCount += 1;
+      }
+    };
+
+    try {
+      const workouts = JSON.parse(localStorage.getItem('workouts_' + u)) || [];
+      workouts.forEach(w => (w.log || []).forEach(entry => {
+        const reps = Array.isArray(entry.repsArray) ? entry.repsArray : [];
+        const weights = Array.isArray(entry.weightsArray) ? entry.weightsArray : [];
+        record(entry.exercise, w.date, reps[reps.length - 1], weights[weights.length - 1]);
+      }));
+    } catch { /* ignore malformed storage */ }
+
+    try {
+      const archived = JSON.parse(localStorage.getItem('tl_workout_history_v1')) || [];
+      archived.filter(w => !w.userId || w.userId === u).forEach(w => (w.exercises || []).forEach(ex => {
+        const reps = Array.isArray(ex.repsArray) ? ex.repsArray : [];
+        const weights = Array.isArray(ex.weightsArray) ? ex.weightsArray : [];
+        const dateStr = (w.date || '').slice(0, 10);
+        record(ex.name, dateStr, reps[reps.length - 1], weights[weights.length - 1]);
+      }));
+    } catch { /* ignore malformed storage */ }
+
+    return map;
+  }
+
+  function _formatDate(dateStr) {
+    if (!dateStr) return '—';
+    const d = new Date(dateStr);
+    if (Number.isNaN(d.getTime())) return dateStr;
+    return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+  }
+
+  let _activeGroup = 'all';
+
+  function selectLibraryGroup(group) {
+    _activeGroup = group;
+    renderLibraries();
+  }
+
+  function renderLibraries() {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('librariesContent');
+    if (!el) return;
+
+    const history = Array.from(_buildExerciseHistory().values())
+      .sort((a, b) => (b.lastDate || '').localeCompare(a.lastDate || ''));
+
+    const groups = ['all', 'Chest', 'Back', 'Delts', 'Arms', 'Legs', 'Core'];
+    const pillRow = groups.map(g =>
+      `<span class="pill${g === _activeGroup ? ' active' : ''}" onclick="selectLibraryGroup('${g}')">${g === 'all' ? 'All' : g}</span>`
+    ).join('');
+
+    const filtered = _activeGroup === 'all' ? history : history.filter(e => e.muscle === _activeGroup);
+
+    const rows = filtered.slice(0, 40).map(e => `
+      <div class="sq-row">
+        <span class="sq-name">${e.name}</span>
+        <span class="sq-summary">${_formatDate(e.lastDate)}${e.lastReps != null ? ' &middot; ' + e.lastReps + (e.lastWeight != null ? '×' + e.lastWeight : '') : ''}</span>
+      </div>`).join('');
+
+    el.innerHTML = `
+      <div class="pod-row"><span class="pod-title" style="font-size:20px;">Libraries</span><span class="ws-header-sub">${history.length} exercises logged</span></div>
+      <div class="pill-nav">${pillRow}</div>
+      <div class="pod sq-card">
+        <div class="pod-row"><span class="pod-kicker">${_activeGroup === 'all' ? 'All exercises' : _activeGroup}</span><span class="sq-count">last used</span></div>
+        ${rows || '<p class="ws-empty-note">Nothing logged in this group yet.</p>'}
+      </div>
+      <div class="pill-nav" style="margin-top:12px;">
+        <span class="pill" onclick="showTab('functionalTab')">Functional</span>
+        <span class="pill" onclick="showTab('mobilityTab')">Flexibility</span>
+        <span class="pill" onclick="showTab('posingTab')">Posing</span>
+      </div>
+    `;
+  }
+
+  global.renderLibraries = renderLibraries;
+  global.selectLibraryGroup = selectLibraryGroup;
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderLibraries, selectLibraryGroup };
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/src/js/readiness-checkin.js
+++ b/src/js/readiness-checkin.js
@@ -210,5 +210,6 @@
 
   window.renderReadinessHomeCard = renderReadinessHomeCard;
   window.showReadinessIfNeeded = showReadinessIfNeeded;
+  window.getTodayReadinessEntry = getTodayEntry;
 
 })();

--- a/src/js/session-queue.js
+++ b/src/js/session-queue.js
@@ -205,13 +205,22 @@
       reps.forEach((r, i) => { totalVolumeKg += (Number(r) || 0) * (Number(weights[i]) || 0); });
     });
 
-    const rows = log.map(entry => {
+    // Group by exercise name — quick-log calls addLogEntry() once per
+    // single set, so the same exercise can appear as several separate
+    // log[] entries; show one row per exercise with the combined count.
+    const byExercise = new Map();
+    log.forEach(entry => {
       const reps = Array.isArray(entry.repsArray) ? entry.repsArray : [];
       const weights = Array.isArray(entry.weightsArray) ? entry.weightsArray : [];
-      const lastReps = reps[reps.length - 1];
-      const lastWeight = weights[weights.length - 1];
-      const summary = reps.length ? `${reps.length}×${lastReps ?? '?'}${lastWeight != null ? ' · ' + lastWeight + ' kg' : ''}` : '';
-      return `<div class="sq-row"><span class="sq-name">${entry.exercise}</span><span class="sq-summary">${summary}</span></div>`;
+      const existing = byExercise.get(entry.exercise) || { setCount: 0, lastReps: null, lastWeight: null };
+      existing.setCount += reps.length;
+      if (reps.length) { existing.lastReps = reps[reps.length - 1]; existing.lastWeight = weights[weights.length - 1]; }
+      byExercise.set(entry.exercise, existing);
+    });
+
+    const rows = Array.from(byExercise.entries()).map(([name, e]) => {
+      const summary = e.setCount ? `${e.setCount}×${e.lastReps ?? '?'}${e.lastWeight != null ? ' · ' + e.lastWeight + ' kg' : ''}` : '';
+      return `<div class="sq-row"><span class="sq-name">${name}</span><span class="sq-summary">${summary}</span></div>`;
     }).join('');
 
     el.innerHTML = `
@@ -233,12 +242,16 @@
     const exercises = day && Array.isArray(day.exercises) ? day.exercises : [];
     if (!day || !exercises.length) { el.innerHTML = ''; return; }
 
-    const rows = exercises.map((ex, i) => `
-      <div class="sq-row">
+    const _esc = (s) => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+    const rows = exercises.map((ex, i) => {
+      const first = (ex.sets && ex.sets[0]) || {};
+      return `
+      <div class="sq-row sq-row--tap" data-ex-name="${_esc(ex.name)}" data-ex-weight="${first.weight ?? ''}" data-ex-reps="${first.reps ?? ''}">
         <span class="sq-index">${i + 1}</span>
         <span class="sq-name">${ex.name}</span>
         <span class="sq-summary">${_setSummary(ex)}</span>
-      </div>`).join('');
+      </div>`;
+    }).join('');
 
     el.innerHTML = `
       <div class="pod sq-card">
@@ -248,9 +261,178 @@
         </div>
         ${rows}
       </div>`;
+
+    if (!el._tapWired) {
+      el._tapWired = true;
+      el.addEventListener('click', (e) => {
+        const row = e.target.closest('.sq-row--tap');
+        if (!row || typeof global.startQuickLogFor !== 'function') return;
+        global.startQuickLogFor(row.dataset.exName, {
+          weight: row.dataset.exWeight ? Number(row.dataset.exWeight) : null,
+          reps: row.dataset.exReps ? Number(row.dataset.exReps) : null,
+        });
+      });
+    }
   }
 
-  const api = { getTodaysPlannedDay, renderSessionQueue, renderTrainHero, renderTrainReadinessStrip, renderSessionSoFar };
+  // ── Quick log — one-tap single-set logging ──────────────────────
+  // Drives the existing #exercise/#sets/#reps_0/#weight_0 fields and
+  // calls the existing addLogEntry() — no parallel save path, no new
+  // data shape. This is purely a faster front door onto the same
+  // workouts_<user> store the manual form already writes to.
+
+  let _qlExerciseName = null;
+  let _qlWeight = null;
+  let _qlReps = null;
+
+  function _round1(n) { return Math.round(n * 10) / 10; }
+
+  function _syncQuickLogDisplay() {
+    if (typeof document === 'undefined') return;
+    const w = document.getElementById('qlWeightVal');
+    const r = document.getElementById('qlRepsVal');
+    if (w) w.textContent = _qlWeight != null ? _qlWeight : '—';
+    if (r) r.textContent = _qlReps != null ? _qlReps : '—';
+  }
+
+  function _writeQuickLogToForm() {
+    if (typeof document === 'undefined') return;
+    const weightEl = document.getElementById('weight_0');
+    const repsEl = document.getElementById('reps_0');
+    if (weightEl && _qlWeight != null) weightEl.value = _qlWeight;
+    if (repsEl && _qlReps != null) repsEl.value = _qlReps;
+    if (typeof global.updateAddButtonState === 'function') global.updateAddButtonState();
+  }
+
+  /** Sets already logged today for this exact exercise name — real count
+   * from the same store renderSessionSoFar() reads. */
+  function _todaysSetCount(name) {
+    const u = _user();
+    if (!u || typeof localStorage === 'undefined') return 0;
+    const todayStr = new Date().toISOString().slice(0, 10);
+    try {
+      const workouts = JSON.parse(localStorage.getItem('workouts_' + u)) || [];
+      const today = workouts.find(w => w.date === todayStr);
+      if (!today) return 0;
+      return (today.log || []).filter(e => e.exercise === name)
+        .reduce((n, e) => n + (Array.isArray(e.repsArray) ? e.repsArray.length : 0), 0);
+    } catch { return 0; }
+  }
+
+  function _updateQuickLogButtonLabel(name) {
+    if (typeof document === 'undefined') return;
+    const labelEl = document.getElementById('qlLogBtnLabel');
+    if (labelEl) labelEl.textContent = 'Log set ' + (_todaysSetCount(name) + 1);
+  }
+
+  function syncQuickLogUnit(unit) {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('qlUnitLabel');
+    if (el) el.textContent = unit || 'kg';
+  }
+
+  /** Called on every #exercise input. Shows the quick-log panel, ensures
+   * #reps_0/#weight_0 exist (via the app's own generateSetInputs(1), so
+   * its suggestion engine seeds sensible defaults), and keeps the last
+   * tapped weight/reps sticky across sets of the SAME exercise. */
+  function initQuickLog(exerciseName) {
+    if (typeof document === 'undefined') return;
+    const panel = document.getElementById('quickLogPanel');
+    if (!panel) return;
+    const name = (exerciseName || '').trim();
+    if (!name) { panel.hidden = true; return; }
+    panel.hidden = false;
+
+    const setsInput = document.getElementById('sets');
+    if (setsInput && setsInput.value !== '1') setsInput.value = '1';
+    if (typeof global.generateSetInputs === 'function') global.generateSetInputs(1);
+
+    const isNewExercise = name !== _qlExerciseName;
+    if (isNewExercise || _qlWeight == null || _qlReps == null) {
+      const weightEl = document.getElementById('weight_0');
+      const repsEl = document.getElementById('reps_0');
+      _qlWeight = weightEl && weightEl.value !== '' ? Number(weightEl.value) : (_qlWeight ?? 20);
+      _qlReps = repsEl && repsEl.value !== '' ? Number(repsEl.value) : (_qlReps ?? 8);
+      _qlExerciseName = name;
+    }
+    _syncQuickLogDisplay();
+    _writeQuickLogToForm();
+
+    const unitSel = document.getElementById('weightUnit');
+    if (unitSel) syncQuickLogUnit(unitSel.value);
+    _updateQuickLogButtonLabel(name);
+  }
+
+  /** Tapped a session-queue row: jump straight into quick-log for that
+   * exercise, pre-filled from the plan's first set (real planned values,
+   * falling back to the sticky-default logic above when absent). */
+  function startQuickLogFor(name, plannedFirstSet) {
+    if (typeof document === 'undefined' || !name) return;
+    const exerciseEl = document.getElementById('exercise');
+    if (!exerciseEl) return;
+    exerciseEl.value = name;
+    initQuickLog(name);
+    if (plannedFirstSet) {
+      if (plannedFirstSet.weight != null) _qlWeight = plannedFirstSet.weight;
+      if (plannedFirstSet.reps != null) _qlReps = plannedFirstSet.reps;
+      _syncQuickLogDisplay();
+      _writeQuickLogToForm();
+    }
+    document.getElementById('quickLogPanel')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+
+  function quickLogStep(field, delta) {
+    if (field === 'weight') {
+      const step = (_qlWeight || 0) >= 100 ? 5 : 2.5;
+      _qlWeight = Math.max(0, _round1((_qlWeight ?? 20) + delta * step));
+    } else {
+      _qlReps = Math.max(0, (_qlReps ?? 8) + delta);
+    }
+    _syncQuickLogDisplay();
+    _writeQuickLogToForm();
+  }
+
+  /** The one-tap action: log exactly one set for the current exercise/
+   * weight/reps via the existing addLogEntry() (same validation, same
+   * PR/streak/milestone side effects, same storage shape), then re-arms
+   * for the next set of the same exercise. */
+  function quickLogSet() {
+    if (typeof document === 'undefined') return;
+    const exerciseEl = document.getElementById('exercise');
+    const name = exerciseEl ? exerciseEl.value.trim() : '';
+    if (!name || _qlReps == null || _qlReps <= 0) return;
+
+    const setsInput = document.getElementById('sets');
+    if (setsInput) setsInput.value = '1';
+    if (typeof global.generateSetInputs === 'function') global.generateSetInputs(1);
+    _writeQuickLogToForm();
+
+    if (typeof global.addLogEntry !== 'function') return;
+    global.addLogEntry();
+
+    // addLogEntry() clears #exercise on success and leaves it untouched
+    // on a validation failure — used here as a success signal rather
+    // than duplicating its validation logic.
+    const succeeded = exerciseEl && exerciseEl.value === '';
+    if (succeeded) {
+      exerciseEl.value = name;
+      const liveTitle = document.getElementById('exerciseLiveTitle');
+      if (liveTitle) { liveTitle.hidden = false; liveTitle.textContent = name; }
+      const setsInput2 = document.getElementById('sets');
+      if (setsInput2) setsInput2.value = '1';
+      if (typeof global.generateSetInputs === 'function') global.generateSetInputs(1);
+      _writeQuickLogToForm(); // keep the same weight/reps for the next set
+      _updateQuickLogButtonLabel(name);
+    }
+  }
+
+  const api = { getTodaysPlannedDay, renderSessionQueue, renderTrainHero, renderTrainReadinessStrip, renderSessionSoFar,
+    initQuickLog, quickLogStep, quickLogSet, startQuickLogFor, syncQuickLogUnit };
+  global.initQuickLog = initQuickLog;
+  global.quickLogStep = quickLogStep;
+  global.quickLogSet = quickLogSet;
+  global.startQuickLogFor = startQuickLogFor;
+  global.syncQuickLogUnit = syncQuickLogUnit;
   global.getTodaysPlannedDay = getTodaysPlannedDay;
   global.renderSessionQueue = renderSessionQueue;
   global.renderTrainHero = renderTrainHero;

--- a/src/js/session-queue.js
+++ b/src/js/session-queue.js
@@ -233,6 +233,96 @@
       </div>`;
   }
 
+  // ── Weekly volume landmarks (MEV/MAV/MRV) ───────────────────────
+  // MEV/MAV/MRV are commonly-published weekly-set training guidelines
+  // (Renaissance-Periodization-style ballparks), not a per-user
+  // prescription this app computes — they're reference thresholds.
+  // What IS real: the actual weekly set count per muscle, tallied from
+  // the same workout history libraries.js already reads.
+  const VOLUME_LANDMARKS = {
+    Chest: { mev: 8, mav: 18, mrv: 22 },
+    Back: { mev: 10, mav: 20, mrv: 25 },
+    Delts: { mev: 8, mav: 20, mrv: 26 },
+    Arms: { mev: 8, mav: 18, mrv: 24 },
+    Legs: { mev: 10, mav: 20, mrv: 28 },
+    Core: { mev: 6, mav: 16, mrv: 20 },
+  };
+
+  /** Real weekly (last 7 days) set count per coarse muscle group, from
+   * the live + archived workout history. */
+  function _weeklySetsByMuscle() {
+    const u = _user();
+    const counts = {};
+    if (!u || typeof localStorage === 'undefined' || typeof global.getCoarseMuscleGroup !== 'function') return counts;
+
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - 7);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+
+    const tally = (name, dateStr, setCount) => {
+      if (!dateStr || dateStr < cutoffStr) return;
+      const group = global.getCoarseMuscleGroup(name);
+      counts[group] = (counts[group] || 0) + setCount;
+    };
+
+    try {
+      const workouts = JSON.parse(localStorage.getItem('workouts_' + u)) || [];
+      workouts.forEach(w => (w.log || []).forEach(entry => {
+        tally(entry.exercise, w.date, Array.isArray(entry.repsArray) ? entry.repsArray.length : 0);
+      }));
+    } catch { /* ignore */ }
+
+    try {
+      const archived = JSON.parse(localStorage.getItem('tl_workout_history_v1')) || [];
+      archived.filter(w => !w.userId || w.userId === u).forEach(w => (w.exercises || []).forEach(ex => {
+        tally(ex.name, (w.date || '').slice(0, 10), Array.isArray(ex.repsArray) ? ex.repsArray.length : 0);
+      }));
+    } catch { /* ignore */ }
+
+    return counts;
+  }
+
+  function renderVolumeLandmarks() {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('volumeLandmarksCard');
+    if (!el) return;
+
+    const weekly = _weeklySetsByMuscle();
+    const groups = Object.keys(VOLUME_LANDMARKS).filter(g => weekly[g] > 0);
+    if (!groups.length) { el.innerHTML = ''; return; }
+
+    const rows = groups.map(g => {
+      const { mev, mav, mrv } = VOLUME_LANDMARKS[g];
+      const actual = weekly[g] || 0;
+      const fillPct = Math.min(100, Math.round((actual / mrv) * 100));
+      const mevPct = Math.round((mev / mrv) * 100);
+      const mavPct = Math.round((mav / mrv) * 100);
+      const overMav = actual >= mav;
+      const fillColor = overMav
+        ? 'linear-gradient(90deg,#6d5124,#c79a54)'
+        : 'linear-gradient(90deg,#236b4e,#6fae8b)';
+      return `
+        <div class="vl-row">
+          <span class="vl-muscle">${g}</span>
+          <div class="vl-track">
+            <div class="vl-fill" style="width:${fillPct}%;background:${fillColor}"></div>
+            <div class="vl-tick" style="left:${mevPct}%"></div>
+            <div class="vl-tick vl-tick--mav" style="left:${mavPct}%"></div>
+          </div>
+          <span class="vl-count${overMav ? ' is-high' : ''}">${actual}/${mrv}</span>
+        </div>`;
+    }).join('');
+
+    el.innerHTML = `
+      <div class="pod vl-card">
+        <div class="pod-row">
+          <span class="pod-kicker">Weekly volume landmarks</span>
+          <span class="sq-count">sets &middot; MEV/MAV/MRV</span>
+        </div>
+        ${rows}
+      </div>`;
+  }
+
   function renderSessionQueue() {
     if (typeof document === 'undefined') return;
     const el = document.getElementById('sessionQueueCard');
@@ -243,13 +333,22 @@
     if (!day || !exercises.length) { el.innerHTML = ''; return; }
 
     const _esc = (s) => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+    const hasStats = typeof global.getExerciseStats === 'function';
     const rows = exercises.map((ex, i) => {
       const first = (ex.sets && ex.sets[0]) || {};
+      const stats = hasStats ? global.getExerciseStats(ex.name) : null;
+      const pctHTML = stats && stats.pctOf1rm != null
+        ? `<span class="sq-e1rm">${stats.pctOf1rm}%</span>` : '<span class="sq-e1rm">—</span>';
+      const deltaHTML = stats && stats.deltaWeight != null
+        ? `<span class="sq-delta ${stats.deltaWeight > 0 ? 'is-up' : stats.deltaWeight < 0 ? 'is-down' : 'is-flat'}">${stats.deltaWeight > 0 ? '+' : ''}${stats.deltaWeight}</span>`
+        : '<span class="sq-delta is-flat">=</span>';
       return `
       <div class="sq-row sq-row--tap" data-ex-name="${_esc(ex.name)}" data-ex-weight="${first.weight ?? ''}" data-ex-reps="${first.reps ?? ''}">
         <span class="sq-index">${i + 1}</span>
         <span class="sq-name">${ex.name}</span>
         <span class="sq-summary">${_setSummary(ex)}</span>
+        ${pctHTML}
+        ${deltaHTML}
       </div>`;
     }).join('');
 
@@ -257,7 +356,7 @@
       <div class="pod sq-card">
         <div class="pod-row">
           <span class="pod-kicker">Today's plan · ${day.name}</span>
-          <span class="sq-count">${exercises.length} exercise${exercises.length === 1 ? '' : 's'}</span>
+          <span class="sq-count">load &middot; %1RM &middot; &Delta; last</span>
         </div>
         ${rows}
       </div>`;
@@ -325,6 +424,22 @@
     if (labelEl) labelEl.textContent = 'Log set ' + (_todaysSetCount(name) + 1);
   }
 
+  /** "e1RM 122 kg · 78% of 1RM" meta line under the exercise title —
+   * real numbers from getExerciseStats() (libraries.js), hidden entirely
+   * when there's no logged history for the exercise yet rather than
+   * showing a zero/placeholder. */
+  function _updateExerciseStatsLine(name) {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('exerciseStatsLine');
+    if (!el) return;
+    const stats = typeof global.getExerciseStats === 'function' ? global.getExerciseStats(name) : null;
+    if (!stats || !stats.bestE1rm) { el.hidden = true; return; }
+    const parts = [`e1RM ${stats.bestE1rm} kg`];
+    if (stats.pctOf1rm != null) parts.push(`${stats.pctOf1rm}% of 1RM`);
+    el.hidden = false;
+    el.textContent = parts.join(' · ');
+  }
+
   function syncQuickLogUnit(unit) {
     if (typeof document === 'undefined') return;
     const el = document.getElementById('qlUnitLabel');
@@ -361,6 +476,7 @@
     const unitSel = document.getElementById('weightUnit');
     if (unitSel) syncQuickLogUnit(unitSel.value);
     _updateQuickLogButtonLabel(name);
+    _updateExerciseStatsLine(name);
   }
 
   /** Tapped a session-queue row: jump straight into quick-log for that
@@ -423,11 +539,14 @@
       if (typeof global.generateSetInputs === 'function') global.generateSetInputs(1);
       _writeQuickLogToForm(); // keep the same weight/reps for the next set
       _updateQuickLogButtonLabel(name);
+      _updateExerciseStatsLine(name);
+      if (typeof global.renderSessionQueue === 'function') global.renderSessionQueue(); // refresh %1RM/Δ vs the set just logged
     }
   }
 
   const api = { getTodaysPlannedDay, renderSessionQueue, renderTrainHero, renderTrainReadinessStrip, renderSessionSoFar,
-    initQuickLog, quickLogStep, quickLogSet, startQuickLogFor, syncQuickLogUnit };
+    initQuickLog, quickLogStep, quickLogSet, startQuickLogFor, syncQuickLogUnit, renderVolumeLandmarks };
+  global.renderVolumeLandmarks = renderVolumeLandmarks;
   global.initQuickLog = initQuickLog;
   global.quickLogStep = quickLogStep;
   global.quickLogSet = quickLogSet;

--- a/src/js/session-queue.js
+++ b/src/js/session-queue.js
@@ -90,6 +90,96 @@
     return weight ? `${sets.length}×${reps} · ${weight}` : `${sets.length}×${reps}`;
   }
 
+  /** Sum of reps*weight across every planned set, in kg. */
+  function _tonnageTarget(exercises) {
+    return exercises.reduce((sum, ex) => {
+      const sets = Array.isArray(ex.sets) ? ex.sets : [];
+      return sum + sets.reduce((s, set) => s + (Number(set.reps) || 0) * (Number(set.weight) || 0), 0);
+    }, 0);
+  }
+
+  function _totalSets(exercises) {
+    return exercises.reduce((n, ex) => n + (Array.isArray(ex.sets) ? ex.sets.length : 0), 0);
+  }
+
+  /** Average of any explicit per-set RPE targets in the plan, or null. */
+  function _avgTargetRpe(exercises) {
+    const rpes = [];
+    exercises.forEach(ex => (ex.sets || []).forEach(s => { if (s.rpe != null) rpes.push(Number(s.rpe)); }));
+    if (!rpes.length) return null;
+    return (rpes.reduce((a, b) => a + b, 0) / rpes.length).toFixed(1);
+  }
+
+  function _muscleSummary(exercises) {
+    if (typeof global.getMuscleGroup !== 'function') return '';
+    const groups = [];
+    exercises.forEach(ex => {
+      const g = global.getMuscleGroup(ex.name);
+      if (g && !groups.includes(g)) groups.push(g);
+    });
+    return groups.slice(0, 3).join(' · ');
+  }
+
+  /** Train tab hero pod: today's session name/muscles/set-target, tonnage-
+   * target progress bar, and a start-session CTA. Real data throughout —
+   * "vs last"/"fatigue"/"PR shots" have no computed source yet, so those
+   * three stat cells are left out rather than fabricated (see the plan's
+   * metrics decision — visual-only stats must be clearly non-real, and an
+   * unlabeled fake number is worse than a shorter, honest stat row).
+   */
+  function renderTrainHero() {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('trainHeroCard');
+    if (!el) return;
+
+    const day = getTodaysPlannedDay();
+    if (!day) {
+      el.innerHTML = `
+        <div class="pod pod--hero train-hero-card">
+          <div class="pod-kicker">No session planned today</div>
+          <p class="ws-empty-note" style="margin-top:8px;">Rest day, or no active program is assigned — log manually below whenever you're ready.</p>
+        </div>`;
+      return;
+    }
+
+    const exercises = Array.isArray(day.exercises) ? day.exercises : [];
+    const tonnageTargetKg = _tonnageTarget(exercises);
+    const totalSets = _totalSets(exercises);
+    const rpeTarget = _avgTargetRpe(exercises);
+    const muscles = _muscleSummary(exercises);
+
+    el.innerHTML = `
+      <div class="pod pod--hero train-hero-card">
+        <div class="train-hero-top">
+          <div>
+            <div class="train-hero-name">${day.name}</div>
+            <div class="train-hero-meta">${muscles ? muscles + ' &middot; ' : ''}${exercises.length} lift${exercises.length === 1 ? '' : 's'} &middot; ${totalSets} set${totalSets === 1 ? '' : 's'}</div>
+          </div>
+          ${rpeTarget ? `<div class="train-hero-rpe"><div class="home-hero-stat-lbl">Target RPE</div><div class="train-hero-rpe-val">${rpeTarget}</div></div>` : ''}
+        </div>
+        <div class="train-hero-tonnage-row">
+          <span>TONNAGE 0.0t / ${(tonnageTargetKg / 1000).toFixed(1)}t</span>
+          <span>0% &middot; 0 of ${totalSets} sets</span>
+        </div>
+        <div class="train-hero-tonnage-track"><div class="train-hero-tonnage-fill" style="width:0%"></div></div>
+        <button class="cta-capsule train-hero-cta" onclick="goToQuickLog()">Start session</button>
+      </div>`;
+  }
+
+  /** Sleep/Energy/Sore/Ready strip — all four values come straight from
+   * the daily readiness check-in (src/js/readiness-checkin.js) when the
+   * lifter has filled it in today; otherwise each cell shows "—". */
+  function renderTrainReadinessStrip() {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('trainReadinessStrip');
+    if (!el) return;
+    const entry = typeof global.getTodayReadinessEntry === 'function' ? global.getTodayReadinessEntry() : null;
+    const cell = (label, val) => `<div class="train-strip-cell"><div class="home-hero-stat-lbl">${label}</div><div class="train-strip-val">${val != null ? val : '—'}</div></div>`;
+    el.innerHTML = entry
+      ? cell('Sleep', entry.sleep + '/5') + cell('Motivation', entry.motivation + '/5') + cell('Soreness', entry.soreness + '/5') + cell('Ready', entry.score)
+      : cell('Sleep', null) + cell('Motivation', null) + cell('Soreness', null) + cell('Ready', null);
+  }
+
   function renderSessionQueue() {
     if (typeof document === 'undefined') return;
     const el = document.getElementById('sessionQueueCard');
@@ -116,9 +206,11 @@
       </div>`;
   }
 
-  const api = { getTodaysPlannedDay, renderSessionQueue };
+  const api = { getTodaysPlannedDay, renderSessionQueue, renderTrainHero, renderTrainReadinessStrip };
   global.getTodaysPlannedDay = getTodaysPlannedDay;
   global.renderSessionQueue = renderSessionQueue;
+  global.renderTrainHero = renderTrainHero;
+  global.renderTrainReadinessStrip = renderTrainReadinessStrip;
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = api;
   }

--- a/src/js/session-queue.js
+++ b/src/js/session-queue.js
@@ -180,6 +180,50 @@
       : cell('Sleep', null) + cell('Motivation', null) + cell('Soreness', null) + cell('Ready', null);
   }
 
+  /** "Session so far" pod: exercises already logged today, from the same
+   * workouts_<user> store renderWorkouts() reads (real data — every
+   * exercise/set count shown here is something the user actually logged). */
+  function renderSessionSoFar() {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('sessionSoFarCard');
+    if (!el) return;
+
+    const u = global.currentUser || (typeof localStorage !== 'undefined' && localStorage.getItem('fitnessAppUser'));
+    const todayStr = new Date().toISOString().slice(0, 10);
+    let workouts = [];
+    try { workouts = u ? JSON.parse(localStorage.getItem('workouts_' + u)) || [] : []; } catch { workouts = []; }
+    const today = workouts.find(w => w.date === todayStr);
+    const log = today && Array.isArray(today.log) ? today.log : [];
+
+    if (!log.length) { el.innerHTML = ''; return; }
+
+    let totalSets = 0, totalVolumeKg = 0;
+    log.forEach(entry => {
+      const reps = Array.isArray(entry.repsArray) ? entry.repsArray : [];
+      const weights = Array.isArray(entry.weightsArray) ? entry.weightsArray : [];
+      totalSets += entry.sets || reps.length;
+      reps.forEach((r, i) => { totalVolumeKg += (Number(r) || 0) * (Number(weights[i]) || 0); });
+    });
+
+    const rows = log.map(entry => {
+      const reps = Array.isArray(entry.repsArray) ? entry.repsArray : [];
+      const weights = Array.isArray(entry.weightsArray) ? entry.weightsArray : [];
+      const lastReps = reps[reps.length - 1];
+      const lastWeight = weights[weights.length - 1];
+      const summary = reps.length ? `${reps.length}×${lastReps ?? '?'}${lastWeight != null ? ' · ' + lastWeight + ' kg' : ''}` : '';
+      return `<div class="sq-row"><span class="sq-name">${entry.exercise}</span><span class="sq-summary">${summary}</span></div>`;
+    }).join('');
+
+    el.innerHTML = `
+      <div class="pod sq-card">
+        <div class="pod-row">
+          <span class="pod-kicker">Session so far</span>
+          <span class="sq-count">${totalSets} set${totalSets === 1 ? '' : 's'} &middot; ${(totalVolumeKg).toLocaleString()} kg</span>
+        </div>
+        ${rows}
+      </div>`;
+  }
+
   function renderSessionQueue() {
     if (typeof document === 'undefined') return;
     const el = document.getElementById('sessionQueueCard');
@@ -206,11 +250,12 @@
       </div>`;
   }
 
-  const api = { getTodaysPlannedDay, renderSessionQueue, renderTrainHero, renderTrainReadinessStrip };
+  const api = { getTodaysPlannedDay, renderSessionQueue, renderTrainHero, renderTrainReadinessStrip, renderSessionSoFar };
   global.getTodaysPlannedDay = getTodaysPlannedDay;
   global.renderSessionQueue = renderSessionQueue;
   global.renderTrainHero = renderTrainHero;
   global.renderTrainReadinessStrip = renderTrainReadinessStrip;
+  global.renderSessionSoFar = renderSessionSoFar;
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = api;
   }

--- a/src/js/settings-hero.js
+++ b/src/js/settings-hero.js
@@ -1,0 +1,69 @@
+/**
+ * settings-hero.js
+ * Mockup-style summary at the top of the Settings tab: profile pod +
+ * grouped preference rows. Reads the same prefs the real settings form
+ * (further down the same tab) already reads/writes — this is a summary
+ * view, not a second source of truth. Toggling vacation/sick mode here
+ * calls the exact same setVacationMode()/setSickMode() the rest of the
+ * app already uses, so it stays in sync with the real settings form.
+ */
+(function (global) {
+  'use strict';
+
+  function _user() {
+    return global.currentUser || (typeof localStorage !== 'undefined' && localStorage.getItem('fitnessAppUser'));
+  }
+
+  function _row(label, right, sub) {
+    return `<div class="sh-row"><span class="sh-row-label">${label}</span>` +
+      (sub ? `<span class="sh-row-sub">${sub}</span>` : '') +
+      `<span class="sh-row-val">${right}</span></div>`;
+  }
+
+  function _togglePill(on) {
+    return `<span class="sh-toggle ${on ? 'is-on' : ''}">${on ? 'ON' : 'OFF'}</span>`;
+  }
+
+  function renderSettingsHero() {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('settingsHero');
+    if (!el) return;
+
+    const u = _user();
+    const initials = (u || '?').slice(0, 2).toUpperCase();
+    const appMode = typeof global.getCurrentAppMode === 'function' ? global.getCurrentAppMode() : 'athlete';
+    const unit = typeof global.getBodyweightPreference === 'function' ? global.getBodyweightPreference().unit : 'kg';
+    const theme = (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) || 'system default';
+    const vacation = typeof global.getVacationMode === 'function' ? global.getVacationMode() : { active: false };
+    const sick = typeof global.getSickMode === 'function' ? global.getSickMode() : { active: false };
+
+    el.innerHTML = `
+      <div class="pod pod--hero sh-profile">
+        <div class="sh-profile-avatar">${initials}</div>
+        <div class="sh-profile-info">
+          <div class="sh-profile-name">${u || 'Athlete'}</div>
+          <div class="sh-profile-meta">${appMode === 'both' ? 'Coach + athlete' : appMode === 'coach' ? 'Coach' : 'Athlete'}</div>
+        </div>
+      </div>
+
+      <div class="pod sh-group">
+        <div class="pod-kicker" style="margin-bottom:6px;">Units &amp; display</div>
+        ${_row('Weight unit', unit)}
+        ${_row('Theme', theme)}
+      </div>
+
+      <div class="pod sh-group">
+        <div class="pod-kicker" style="margin-bottom:6px;">Modes</div>
+        <div class="sh-row"><span class="sh-row-label">Vacation mode</span><span class="sh-row-sub">pauses streak</span>${_togglePill(!!vacation.active)}</div>
+        <div class="sh-row"><span class="sh-row-label">Sick mode</span><span class="sh-row-sub">pauses progression</span>${_togglePill(!!sick.active)}</div>
+      </div>
+
+      <button class="sh-logout" onclick="if(typeof logout==='function') logout();">Log out</button>
+    `;
+  }
+
+  global.renderSettingsHero = renderSettingsHero;
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderSettingsHero };
+  }
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary

Follow-up to #327 — brings the modernist redesign in line with the definitive v3A/v4A mockup and the formal "Ironlog visual system" handoff spec (mobile v3A + desktop v4A), scoped strictly to visual/IA per the spec's "Rules of engagement" (no feature removal, no data-layer changes beyond the nav IA).

## What's in this PR

- **Fidelity fixes (1-3/4)**: rebuilt Home hero, added a Train session hero, fixed Log-live-set (live title + session-so-far), fixed Body/Weight hero readout + sparkline — matching the mockup's actual layout (big Anton hero numbers, specific stat rows/card order), not just its color tokens.
- **3 missing screens**: Libraries, Coach (mobile), Settings — discovered via a re-read of the live design artifact, built on real existing app data only.
- **Global interaction states + one-tap set logging**: hover/active/focus-visible/loading-skeleton/disabled/reduced-motion states; a quick-log stepper (`initQuickLog`/`quickLogSet`/`startQuickLogFor`) that drives the existing `addLogEntry()`/`generateSetInputs()` save path — no parallel data path.
- **Real computed metrics** (previously flagged as visual-only placeholders): e1RM, %1RM, last-session deltas, and MEV/MAV/MRV weekly volume landmarks per muscle group — all derived from actual logged workout history, not fabricated.
- **Desktop rail nav**: 8-item rail navigation (Queue/Clients/Programs/Templates/Messages/Check-ins/Analytics/Settings) added to the coach workspace, with live counts.
- **Hex-literal + accessibility audit**: tokenized the last raw-hex colors in redesign-authored CSS; expanded `.pill` tap targets to ~44px via an invisible hit-area (visual size unchanged, matches mockup); spot-checked contrast (all status-text tokens clear 4.5:1 against pod surfaces).

## Verification

- `npx jest` — 28 suites / 96 tests passing throughout.
- Manual browser verification of each rebuilt screen and the quick-log flow against seeded data.
- One flagged (unresolved) conflict: a few uppercase kicker/eyebrow labels sit at 9.5-10.5px, under the spec's "mobile text ≥11px" line, but match the mockup's own micro-label typography — left as-is rather than deviating from the approved design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
